### PR TITLE
Prepopulate sqlite database during @travisci tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -105,6 +105,7 @@ before_install:
 #
 
 install:
+ - export GALAXY_TEST_DB_TEMPLATE=https://github.com/jmchilton/galaxy-downloads/raw/master/db_gx_rev_0117.sqlite
  - ln -s ${TRAVIS_BUILD_DIR}/.travis.tool_conf.xml tool_conf.xml
  - rm tool_conf.xml.sample
  - ln -s ${TRAVIS_BUILD_DIR}/.travis.tool_conf.xml tool_conf.xml.sample


### PR DESCRIPTION
This version is slightly less brittle than @peterjc's initial attempts because when used this way the database should auto-upgrade from version 117 on startup as new revisions are committed.
