### PR TITLE
Add tool citations.

### DIFF
--- a/tools/blast2go/blast2go.xml
+++ b/tools/blast2go/blast2go.xml
@@ -115,4 +115,10 @@ This wrapper is available to install into other Galaxy Instances via the Galaxy
 Tool Shed at http://toolshed.g2.bx.psu.edu/view/peterjc/blast2go
 
     </help>
+    <citations>
+        <citation type="doi">10.7717/peerj.167</citation>
+        <citation type="doi">10.1093/nar/gkn176</citation>
+        <citation type="doi">10.1155/2008/619832</citation>
+        <citation type="doi">10.1093/bioinformatics/bti610</citation>
+    </citations>
 </tool>

--- a/tools/blast_rbh/blast_rbh.xml
+++ b/tools/blast_rbh/blast_rbh.xml
@@ -232,4 +232,7 @@ http://dx.doi.org/10.1186/1471-2105-10-421
 This wrapper is available to install into other Galaxy Instances via the Galaxy
 Tool Shed at http://toolshed.g2.bx.psu.edu/view/peterjc/blast_rbh
     </help>
+    <citations>
+        <citation type="doi">10.1186/1471-2105-10-421</citation>
+    </citations>
 </tool>

--- a/tools/blastxml_to_top_descr/blastxml_to_top_descr.xml
+++ b/tools/blastxml_to_top_descr/blastxml_to_top_descr.xml
@@ -108,4 +108,7 @@ This wrapper is available to install into other Galaxy Instances via the Galaxy
 Tool Shed at http://toolshed.g2.bx.psu.edu/view/peterjc/blastxml_to_top_descr
 
     </help>
+    <citations>
+        <citation type="doi">10.7717/peerj.167</citation>
+    </citations>
 </tool>

--- a/tools/ncbi_blast_plus/blastxml_to_tabular.xml
+++ b/tools/ncbi_blast_plus/blastxml_to_tabular.xml
@@ -209,4 +209,7 @@ http://dx.doi.org/10.7717/peerj.167
 This wrapper is available to install into other Galaxy Instances via the Galaxy
 Tool Shed at http://toolshed.g2.bx.psu.edu/view/devteam/ncbi_blast_plus
     </help>
+    <citations>
+      <citation type="doi">10.7717/peerj.167</citation>
+    </citations>
 </tool>

--- a/tools/ncbi_blast_plus/ncbi_blastdbcmd_info.xml
+++ b/tools/ncbi_blast_plus/ncbi_blastdbcmd_info.xml
@@ -32,4 +32,5 @@ cite the following papers:
 
 @REFERENCES@
     </help>
+    <expand macro="blast_citations" />
 </tool>

--- a/tools/ncbi_blast_plus/ncbi_blastdbcmd_wrapper.xml
+++ b/tools/ncbi_blast_plus/ncbi_blastdbcmd_wrapper.xml
@@ -104,4 +104,5 @@ cite the following papers:
 
 @REFERENCES@
     </help>
+    <expand macro="blast_citations" />    
 </tool>

--- a/tools/ncbi_blast_plus/ncbi_blastn_wrapper.xml
+++ b/tools/ncbi_blast_plus/ncbi_blastn_wrapper.xml
@@ -128,4 +128,5 @@ cite the following papers:
 
 @REFERENCES@
     </help>
+    <expand macro="blast_citations" />
 </tool>

--- a/tools/ncbi_blast_plus/ncbi_blastp_wrapper.xml
+++ b/tools/ncbi_blast_plus/ncbi_blastp_wrapper.xml
@@ -144,4 +144,5 @@ cite the following papers:
 
 @REFERENCES@
     </help>
+    <expand macro="blast_citations" />    
 </tool>

--- a/tools/ncbi_blast_plus/ncbi_blastx_wrapper.xml
+++ b/tools/ncbi_blast_plus/ncbi_blastx_wrapper.xml
@@ -123,4 +123,5 @@ cite the following papers:
 
 @REFERENCES@
     </help>
+    <expand macro="blast_citations" />
 </tool>

--- a/tools/ncbi_blast_plus/ncbi_convert2blastmask_wrapper.xml
+++ b/tools/ncbi_blast_plus/ncbi_convert2blastmask_wrapper.xml
@@ -84,4 +84,5 @@ cite the following papers (a more specific paper covering this wrapper is planne
 
 @REFERENCES@
     </help>
+    <expand macro="blast_citations" />
 </tool>

--- a/tools/ncbi_blast_plus/ncbi_deltablast_wrapper.xml
+++ b/tools/ncbi_blast_plus/ncbi_deltablast_wrapper.xml
@@ -141,4 +141,5 @@ cite the following papers (a more specific paper covering this wrapper is planne
 
 @REFERENCES@
     </help>
+    <expand macro="blast_citations" />
 </tool>

--- a/tools/ncbi_blast_plus/ncbi_dustmasker_wrapper.xml
+++ b/tools/ncbi_blast_plus/ncbi_dustmasker_wrapper.xml
@@ -96,4 +96,5 @@ cite the following papers (a more specific paper covering this wrapper is planne
 
 @REFERENCES@
     </help>
+    <expand macro="blast_citations" />
 </tool>

--- a/tools/ncbi_blast_plus/ncbi_macros.xml
+++ b/tools/ncbi_blast_plus/ncbi_macros.xml
@@ -380,6 +380,19 @@ http://dx.doi.org/10.1186/1471-2105-10-421
 This wrapper is available to install into other Galaxy Instances via the Galaxy
 Tool Shed at http://toolshed.g2.bx.psu.edu/view/devteam/ncbi_blast_plus
     </token>
+    <xml name="blast_citations">
+        <citations>
+            <citation type="doi">10.1186/1471-2105-10-421</citation>
+            <citation type="doi">10.7717/peerj.167</citation>
+            <!-- TODO: @peterjc please modify the following in preparation
+                       BibTeX entry as you see fit or eliminate. -->
+            <citation type="bibtex">@article{"galaxy_blast"
+    author = "Cock, Peter J.A. et al.",
+    journal = "*in preparation*", 
+    year = "2014",
+}</citation>
+        </citations>
+    </xml>
     <token name="@OUTPUT_FORMAT@">**Output format**
 
 Because Galaxy focuses on processing tabular data, the default output of this

--- a/tools/ncbi_blast_plus/ncbi_makeblastdb.xml
+++ b/tools/ncbi_blast_plus/ncbi_makeblastdb.xml
@@ -180,4 +180,5 @@ cite the following papers:
 
 @REFERENCES@
     </help>
+    <expand macro="blast_citations" />
 </tool>

--- a/tools/ncbi_blast_plus/ncbi_makeprofiledb.xml
+++ b/tools/ncbi_blast_plus/ncbi_makeprofiledb.xml
@@ -124,4 +124,5 @@ cite the following papers:
 
 @REFERENCES@
     </help>
+    <expand macro="blast_citations" />
 </tool>

--- a/tools/ncbi_blast_plus/ncbi_psiblast_wrapper.xml
+++ b/tools/ncbi_blast_plus/ncbi_psiblast_wrapper.xml
@@ -152,4 +152,5 @@ cite the following papers (a more specific paper covering this wrapper is planne
 
 @REFERENCES@
     </help>
+    <expand macro="blast_citations" />
 </tool>

--- a/tools/ncbi_blast_plus/ncbi_rpsblast_wrapper.xml
+++ b/tools/ncbi_blast_plus/ncbi_rpsblast_wrapper.xml
@@ -104,4 +104,5 @@ cite the following papers:
 
 @REFERENCES@
     </help>
+    <expand macro="blast_citations" />
 </tool>

--- a/tools/ncbi_blast_plus/ncbi_rpstblastn_wrapper.xml
+++ b/tools/ncbi_blast_plus/ncbi_rpstblastn_wrapper.xml
@@ -102,4 +102,5 @@ cite the following papers:
 
 @REFERENCES@
     </help>
+    <expand macro="blast_citations" />
 </tool>

--- a/tools/ncbi_blast_plus/ncbi_segmasker_wrapper.xml
+++ b/tools/ncbi_blast_plus/ncbi_segmasker_wrapper.xml
@@ -98,4 +98,5 @@ cite the following papers (a more specific paper covering this wrapper is planne
 
 @REFERENCES@
     </help>
+    <expand macro="blast_citations" />
 </tool>

--- a/tools/ncbi_blast_plus/ncbi_tblastn_wrapper.xml
+++ b/tools/ncbi_blast_plus/ncbi_tblastn_wrapper.xml
@@ -158,4 +158,5 @@ cite the following papers:
 
 @REFERENCES@
     </help>
+    <expand macro="blast_citations" />
 </tool>

--- a/tools/ncbi_blast_plus/ncbi_tblastx_wrapper.xml
+++ b/tools/ncbi_blast_plus/ncbi_tblastx_wrapper.xml
@@ -92,4 +92,5 @@ cite the following papers:
 
 @REFERENCES@
     </help>
+    <expand macro="blast_citations" />
 </tool>

--- a/tools/reciprocal_best_hits/reciprocal_best_hits.xml
+++ b/tools/reciprocal_best_hits/reciprocal_best_hits.xml
@@ -123,4 +123,7 @@ Note for BLASTX or TBLASTN, those expressions may need adjustment for
 converting from nucleotide coordinates to amino acids (factor of 3).
 
     </help>
+    <citations>
+        <!-- TODO -->
+    </citations>
 </tool>


### PR DESCRIPTION
New feature included in Galaxy with commit https://bitbucket.org/galaxy/galaxy-central/commits/8536414e03580828831dbd68ba6fd8a888630cd9. This will be included in the Galaxy's August 2014 release. For more information see Galaxy Pull Request #440 (https://bitbucket.org/galaxy/galaxy-central/pull-request/440/initial-bibtex-doi-citation-support-in/diff).

Because Galaxy's XML tool parsing is very relaxed, these extra tags will not break older Galaxy instances but such instances will not render these citations.
