### PR TITLE
Remove sed hacking of datatypes/registry.py from travis setup.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -127,7 +127,6 @@ install:
  - ln -s ${TRAVIS_BUILD_DIR}/tools/blast2go/ tools/blast2go
  - ln -s ${TRAVIS_BUILD_DIR}/datatypes/blast_datatypes/blast.py lib/galaxy/datatypes/blast.py
  - ln -s ${TRAVIS_BUILD_DIR}/.travis.datatypes_conf.xml datatypes_conf.xml
- - sed -i '6 i import blast' lib/galaxy/datatypes/registry.py
  - cp ${TRAVIS_BUILD_DIR}/test-data/* test-data/
  - cp ${TRAVIS_BUILD_DIR}/tool-data/* tool-data/
  - ./run.sh --stop-daemon || true


### PR DESCRIPTION
Should not be needed following this bugfix upstream (https://bitbucket.org/galaxy/galaxy-central/commits/1422966f1ca88472b8685015f5a8cdd3dd0f1db9).
