### PR TITLE
import and use macros

### DIFF
--- a/tools/ncbi_blast_plus/blastxml_to_tabular.py
+++ b/tools/ncbi_blast_plus/blastxml_to_tabular.py
@@ -65,7 +65,7 @@ import re
 import os
 from optparse import OptionParser
 
-if "-v" in sys.argv or "--version" in sys.argv:
+if "-v" in sys.argv or "--version" in sys.argv or "-version" in sys.argv:
     print "v0.1.04"
     sys.exit(0)
 

--- a/tools/ncbi_blast_plus/blastxml_to_tabular.xml
+++ b/tools/ncbi_blast_plus/blastxml_to_tabular.xml
@@ -1,11 +1,10 @@
 <tool id="blastxml_to_tabular" name="BLAST XML to tabular" version="@WRAPPER_VERSION@">
     <description>Convert BLAST XML output to tabular</description>
-    <stdio>
-        <!-- Anything other than zero is an error -->
-        <exit_code range="1:" />
-        <exit_code range=":-1" />
-    </stdio>
-    <version_command interpreter="python">blastxml_to_tabular.py --version</version_command>
+    <macros>
+        <token name="@BINARY@">blastxml_to_tabular.py</token>
+        <import>ncbi_macros.xml</import>
+    </macros>
+    <expand macro="preamble" />
     <command interpreter="python">
 blastxml_to_tabular.py -o "$tabular_file"
 #if $output.out_format == "cols":


### PR DESCRIPTION
`@WRAPPER_VERSION@` were used before but no macro files was imported.
We are now using a little bit more macros with the disadvantage  that we are requiring blast+ as dependency but it is not needed.