### PR TITLE
Update blast_rbh.py

### DIFF
--- a/tools/blast_rbh/blast_rbh.py
+++ b/tools/blast_rbh/blast_rbh.py
@@ -210,7 +210,7 @@ def best_hits(blast_tabular, ignore_self=False):
             elif score < best_score:
                 # print("No improvement for %s, %s < %s" % (a, score, best_score))
                 continue
-            elif score > best_score:
+            elif score >= best_score:
                 # This is better, discard old best
                 best = dict()
                 # Now append this hit...


### PR DESCRIPTION
I was looking into the code for reciprocal best blast with a similar code that I already have and I noticed that some best hits were missing with this code. score > best_score doesn't allow for the maximum score to be the first find. 
so I needed to add the equals >= and now it works, those hits didn't have any ties.