### PR TITLE
package_blast_plus_2_5_0 named to match BioConda

### DIFF
--- a/packages/package_blast_plus_2_5_0/.shed.yml
+++ b/packages/package_blast_plus_2_5_0/.shed.yml
@@ -1,0 +1,15 @@
+name: package_blast_plus_2_5_0
+owner: iuc
+homepage_url: https://blast.ncbi.nlm.nih.gov/
+remote_repository_url: https://github.com/peterjc/galaxy_blast/tree/master/packages/package_blast_plus_2_5_0/
+description: NCBI BLAST+ 2.5.0 (binaries only)
+long_description: |
+  This Tool Shed package is intended to be used as a dependency
+  of the Galaxy wrappers for NCBI BLAST+ and any other tools which
+  call the BLAST+ binaries internally.
+  Note that for compatibility with BioConda, interally this is now
+  called "blast" rather than "blast+" as in the older Galaxy BLAST+
+  packages.
+categories:
+- Tool Dependency Packages
+type: tool_dependency_definition

--- a/packages/package_blast_plus_2_5_0/tool_dependencies.xml
+++ b/packages/package_blast_plus_2_5_0/tool_dependencies.xml
@@ -1,0 +1,61 @@
+<?xml version='1.0' encoding='utf-8'?>
+<tool_dependency>
+    <package name="blast" version="2.5.0">
+        <install version="1.0">
+            <actions_group>
+                <!-- Download the binaries for BLAST+ compatible with 64-bit OSX. -->
+                <actions os="darwin" architecture="x86_64">
+                    <!-- Original URL ftp://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/2.5.0/ncbi-blast-2.5.0+-universal-macosx.tar.gz -->
+                    <action type="download_by_url" sha256sum="a446a18eec900cfd821a754bd984f6fe7076341801ece5ca40cbcddde7d0ca72" target_filename="ncbi-blast-2.5.0+-universal-macosx.tar.gz">https://depot.galaxyproject.org/software/blast_plus/blast_plus_2.5.0_darwin_all.tar.gz</action>
+                    <action type="move_directory_files">
+                         <source_directory>bin</source_directory>
+                         <destination_directory>$INSTALL_DIR</destination_directory>
+                     </action>
+                </actions>
+                <!-- Download the binaries for BLAST+ compatible with 32-bit OSX. -->
+                <actions os="darwin" architecture="i386">
+                    <!-- Original URL ftp://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/2.5.0/ncbi-blast-2.5.0+-universal-macosx.tar.gz -->
+                    <action type="download_by_url" sha256sum="a446a18eec900cfd821a754bd984f6fe7076341801ece5ca40cbcddde7d0ca72" target_filename="ncbi-blast-2.5.0+-universal-macosx.tar.gz">https://depot.galaxyproject.org/software/blast_plus/blast_plus_2.5.0_darwin_all.tar.gz</action>
+                    <action type="move_directory_files">
+                        <source_directory>bin</source_directory>
+                        <destination_directory>$INSTALL_DIR</destination_directory>
+                    </action>
+                </actions>
+                <!-- Download the binaries for BLAST+ compatible with 64-bit Linux. -->
+                <actions os="linux" architecture="x86_64">
+                    <!-- Original URL ftp://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/2.5.0/ncbi-blast-2.5.0+-x64-linux.tar.gz -->
+                    <action type="download_by_url" sha256sum="d7006968b527fc151db9d6e58c3ad3235f0b04d9769dcb1a49f3eeb9303b84ac" target_filename="ncbi-blast-2.5.0+-x64-linux.tar.gz">https://depot.galaxyproject.org/software/blast_plus/blast_plus_2.5.0_linux_x64.tar.gz</action>
+                    <action type="move_directory_files">
+                        <source_directory>bin</source_directory>
+                        <destination_directory>$INSTALL_DIR</destination_directory>
+                    </action>
+                </actions>
+                <actions>
+                    <action type="shell_command">echo "ERROR: Automated installation on your operating system and CPU architecture combination is not yet supported."</action>
+                    <action type="shell_command">echo "Your machine details (the output from 'uname' and 'arch'):"</action>
+                    <action type="shell_command">uname</action>
+                    <action type="shell_command">arch</action>
+                    <action type="shell_command">echo "Please report this via https://github.com/peterjc/galaxy_blast/issues - thank you!"</action>
+                    <action type="shell_command">false</action>
+                    <!-- The 'false' command will return an error, so Galaxy should treat this as a failed install -->
+                </actions>
+                <!-- The $PATH environment variable is only set if one of the above <actions> tags resulted in a successful installation. -->
+                <action type="set_environment">
+                    <environment_variable name="PATH" action="prepend_to">$INSTALL_DIR</environment_variable>
+                    <environment_variable name="BLAST_ROOT_DIR" action="set_to">$INSTALL_DIR</environment_variable>
+                </action>
+            </actions_group>
+        </install>
+        <readme>
+Downloads the precompiled 64 bit Linux, or Mac OS X BLAST+ binaries from the NCBI,
+which is faster than performing a local compilation, avoids any issues with build
+dependencies, and is more reproducible between installations as there is no
+variability from the compiler or library versions.
+
+Note that NCBI do not provide 32 bit Linux binaries anymore.
+
+For more details, see:
+http://blast.ncbi.nlm.nih.gov/Blast.cgi?CMD=Web&amp;PAGE_TYPE=BlastDocs&amp;DOC_TYPE=Download
+        </readme>
+    </package>
+</tool_dependency>


### PR DESCRIPTION
Different packaging eco-systems have dealt with the NCBI BLAST vs BLAST+ naming differently. BioConda has ``legacy-blast`` and ``blast``, see https://github.com/bioconda/bioconda-recipes/tree/master/recipes/blast 

I've already made ``tool_dependencies.xml`` packages for BLAST+ 2.3.0 and 2.4.0 under the name ``blast+``, but propose from 2.5.0 onwards to use ``blast`` to match BioConda.

While both existed in parallel from version 2.2.16 (August 2008) to 2.2.26 (October 2011), as of v2.2.27 onwards only BLAST+ exists so the ambiguity is not a problem nowadays.

This is a pragmatic way forward for #88 since we don't yet have a clear way to resolve different naming per package resolving back end - see https://github.com/galaxyproject/galaxy/issues/1927

@bgruening what do you think?