### PR TITLE
Remove unnecessary requirements

### DIFF
--- a/tools/blast_rbh/blast_rbh.xml
+++ b/tools/blast_rbh/blast_rbh.xml
@@ -2,10 +2,6 @@
     <description>from two FASTA files</description>
     <requirements>
         <requirement type="package" version="1.64">biopython</requirement>
-        <requirement type="python-module">Bio</requirement>
-        <requirement type="binary">makeblastdb</requirement>
-        <requirement type="binary">blastp</requirement>
-        <requirement type="binary">blastn</requirement>
         <requirement type="package" version="2.2.31">blast+</requirement>
     </requirements>
     <stdio>

--- a/tools/ncbi_blast_plus/ncbi_macros.xml
+++ b/tools/ncbi_blast_plus/ncbi_macros.xml
@@ -6,7 +6,6 @@
     </xml>
     <xml name="preamble">
         <requirements>
-            <requirement type="binary">@BINARY@</requirement>
             <requirement type="package" version="2.5.0">blast</requirement>
         </requirements>
         <stdio>


### PR DESCRIPTION
Galaxy never made any use of `binary` and `python-module` requirements. When using the (now default) Conda dependency resolver, they prevent the use of a "mulled" environment and require the use of a cached dependency manager to skip the creation of a temporary environment at every tool run.