### PR TITLE
Seems can't use lines_diff on binary files now

### DIFF
--- a/tools/ncbi_blast_plus/ncbi_makeblastdb.xml
+++ b/tools/ncbi_blast_plus/ncbi_makeblastdb.xml
@@ -110,7 +110,7 @@ $hash_index
             <param name="hash_index" value="true" />
             <output name="outfile" compare="contains" file="four_human_proteins.fasta.log.txt" ftype="blastdbp">
                 <extra_files type="file" value="four_human_proteins.fasta.phr" name="blastdb.phr" />
-                <extra_files type="file" value="four_human_proteins.fasta.pin" name="blastdb.pin" lines_diff="2" />
+                <extra_files type="file" value="four_human_proteins.fasta.pin" name="blastdb.pin" compare="sim_size" delta="0" />
                 <extra_files type="file" value="four_human_proteins.fasta.psq" name="blastdb.psq" />
                 <extra_files type="file" value="four_human_proteins.fasta.pog" name="blastdb.pog" />
                 <extra_files type="file" value="four_human_proteins.fasta.phd" name="blastdb.phd" />
@@ -129,7 +129,7 @@ $hash_index
             <param name="taxid" value="9606" />
             <output name="outfile" compare="contains" file="four_human_proteins_taxid.fasta.log.txt" ftype="blastdbp">
                 <extra_files type="file" value="four_human_proteins_taxid.fasta.phr" name="blastdb.phr" />
-                <extra_files type="file" value="four_human_proteins_taxid.fasta.pin" name="blastdb.pin" lines_diff="2" />
+                <extra_files type="file" value="four_human_proteins_taxid.fasta.pin" name="blastdb.pin" compare="sim_size" delta="0" />
                 <extra_files type="file" value="four_human_proteins_taxid.fasta.psq" name="blastdb.psq" />
                 <extra_files type="file" value="four_human_proteins_taxid.fasta.pog" name="blastdb.pog" />
                 <extra_files type="file" value="four_human_proteins_taxid.fasta.phd" name="blastdb.phd" />
@@ -147,7 +147,7 @@ $hash_index
             <param name="mask_data_file" value="segmasker_four_human.maskinfo-asn1" ftype="maskinfo-asn1" />
             <output name="outfile" compare="contains" file="four_human_proteins.fasta.log.txt" ftype="blastdbp">
                 <extra_files type="file" value="four_human_proteins.fasta.phr" name="blastdb.phr" />
-                <extra_files type="file" value="four_human_proteins.fasta.pin" name="blastdb.pin" lines_diff="2" />
+                <extra_files type="file" value="four_human_proteins.fasta.pin" name="blastdb.pin" compare="sim_size" delta="0" />
                 <extra_files type="file" value="four_human_proteins.fasta.psq" name="blastdb.psq" />
                 <extra_files type="file" value="four_human_proteins.fasta.pog" name="blastdb.pog" />
                 <extra_files type="file" value="four_human_proteins.fasta.phd" name="blastdb.phd" />
@@ -166,7 +166,7 @@ $hash_index
             <param name="taxid" value="9606" />
             <output name="outfile" compare="contains" file="three_human_mRNA.fasta.log.txt" ftype="blastdbn">
                 <extra_files type="file" value="three_human_mRNA.fasta.nhr" name="blastdb.nhr" />
-                <extra_files type="file" value="three_human_mRNA.fasta.nin" name="blastdb.nin" lines_diff="2" />
+                <extra_files type="file" value="three_human_mRNA.fasta.nin" name="blastdb.nin" compare="sim_size" delta="0" />
                 <extra_files type="file" value="three_human_mRNA.fasta.nsq" name="blastdb.nsq" />
                 <extra_files type="file" value="three_human_mRNA.fasta.nog" name="blastdb.nog" />
                 <extra_files type="file" value="three_human_mRNA.fasta.nhd" name="blastdb.nhd" />

--- a/tools/ncbi_blast_plus/ncbi_makeblastdb.xml
+++ b/tools/ncbi_blast_plus/ncbi_makeblastdb.xml
@@ -166,7 +166,7 @@ $hash_index
             <param name="taxid" value="9606" />
             <output name="outfile" compare="contains" file="three_human_mRNA.fasta.log.txt" ftype="blastdbn">
                 <extra_files type="file" value="three_human_mRNA.fasta.nhr" name="blastdb.nhr" />
-                <extra_files type="file" value="three_human_mRNA.fasta.nin" name="blastdb.nin" compare="sim_size" delta="0" />
+                <extra_files type="file" value="three_human_mRNA.fasta.nin" name="blastdb.nin" compare="sim_size" delta="8" />
                 <extra_files type="file" value="three_human_mRNA.fasta.nsq" name="blastdb.nsq" />
                 <extra_files type="file" value="three_human_mRNA.fasta.nog" name="blastdb.nog" />
                 <extra_files type="file" value="three_human_mRNA.fasta.nhd" name="blastdb.nhd" />


### PR DESCRIPTION
e.g. https://travis-ci.org/peterjc/galaxy_blast/jobs/381587821

```
======================================================================
FAIL: ( ncbi_makeblastdb ) > Test-1
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/travis/build/peterjc/galaxy_blast/galaxy-dev/test/functional/test_toolbox.py", line 88, in test_tool
    self.do_it(tool_version=tool_version, test_index=test_index)
  File "/home/travis/build/peterjc/galaxy_blast/galaxy-dev/test/functional/test_toolbox.py", line 41, in do_it
    verify_tool(tool_id, self.galaxy_interactor, resource_parameters=resource_parameters, test_index=test_index, tool_version=tool_version, register_job_data=register_job_data)
  File "/home/travis/build/peterjc/galaxy_blast/galaxy-dev/lib/galaxy/tools/verify/interactor.py", line 679, in verify_tool
    raise e
JobOutputsError: History item  different than expected, difference (using contains):
( /home/travis/build/peterjc/galaxy_blast/test-data/four_human_proteins.fasta.log.txt v. /tmp/tmpaeReg4four_human_proteins.fasta.log.txt )
Composite file (blastdb.pin) of History item fc5c2ad70cbb4f9f different than expected, difference:
History item fc5c2ad70cbb4f9f different than expected, difference (using diff):
( /home/travis/build/peterjc/galaxy_blast/test-data/four_human_proteins.fasta.pin v. /tmp/tmpIm63RHfour_human_proteins.fasta.pin )

```

Instead trying test ``*.nin`` and ``*.pin`` files with ``sim_size``.