### PR TITLE
Merge BLAST XML tool

### DIFF
--- a/tools/merge_blastxml/merge_blastxml.py
+++ b/tools/merge_blastxml/merge_blastxml.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python
+
+# This file is derived from code in the Galaxy project that, but due to historical
+# reasons reflecting time developed outside of the Galaxy Project, this file is under
+# the MIT license.
+#
+# The MIT License (MIT)
+# Copyright (c) 2012,2013,2014,2015,2016 Peter Cock
+# Copyright (c) 2012 Edward Kirton
+# Copyright (c) 2013 Nicola Soranzo
+# Copyright (c) 2014 Bjoern Gruening
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE
+
+import re
+import shutil
+import sys
+xmlfiles = sys.argv[2:]
+xmlout = sys.argv[1]
+
+
+def merge(split_files, output_file):
+    iter_num_re = re.compile(' *<Iteration_iter-num>\d+</Iteration_iter-num>')
+    query_ID_re = re.compile(' *<Iteration_query-ID>Query_\d+</Iteration_query-ID>')
+    if len(split_files) == 1:
+        shutil.copy(split_files[0], output_file)
+        # TODO return merge(split_files, output_file)
+    out = open(output_file, "w")
+    h = None
+    iter_num = 2  # we only start using this from the 2nd file onwards
+    for f in split_files:
+        h = open(f)
+        # body = False
+        first_line = False
+        header = h.readline()
+        if not header:
+            out.close()
+            h.close()
+            raise ValueError("BLAST XML file %s was empty" % f)
+        if header.strip() != '<?xml version="1.0"?>':
+            out.write(header)  # for diagnosis
+            out.close()
+            h.close()
+            raise ValueError("%s is not an XML file!" % f)
+        line = h.readline()
+        header += line
+        # check that for BLAST doctype
+        if line.strip() not in [
+                '<!DOCTYPE BlastOutput PUBLIC "-//NCBI//NCBI BlastOutput/EN" "http://www.ncbi.nlm.nih.gov/dtd/NCBI_BlastOutput.dtd">',
+                '<!DOCTYPE BlastOutput PUBLIC "-//NCBI//NCBI BlastOutput/EN" "NCBI_BlastOutput.dtd">']:
+            out.write(header)  # for diagnosis
+            out.close()
+            h.close()
+            raise ValueError("%s is not a BLAST XML file!" % f)
+        # read in header (part before the first <Iteration>)
+        while True:
+            line = h.readline()
+            if not line:
+                out.write(header)  # for diagnosis
+                out.close()
+                h.close()
+                raise ValueError("BLAST XML file %s ended prematurely" % f)
+            header += line
+            if "<Iteration>" in line:
+                break
+            if len(header) > 10000:
+                # Something has gone wrong, don't load too much into memory!
+                # Write what we have to the merged file for diagnostics
+                out.write(header)
+                out.close()
+                h.close()
+                raise ValueError("BLAST XML file %s has too long a header!" % f)
+        if "<BlastOutput>" not in header:
+            out.close()
+            h.close()
+            raise ValueError("%s is not a BLAST XML file:\n%s\n..." % (f, header))
+        if f == split_files[0]:
+            out.write(header)
+            old_header = header
+        elif old_header[:300] != header[:300]:
+            # Enough to check <BlastOutput_program> and <BlastOutput_version> match
+            out.close()
+            h.close()
+            raise ValueError("BLAST XML headers don't match for %s and %s - have:\n%s\n...\n\nAnd:\n%s\n...\n" %
+                             (split_files[0], f, old_header[:300], header[:300]))
+        else:
+            first_line = True
+        for line in h:
+            if first_line or "<Iteration>" in line:
+                if "<Iteration>" in line:
+                    line = next(h)
+                out.write("<Iteration>\n")
+                first_line = False
+                iter_num_match = iter_num_re.match(line)
+                if iter_num_match is not None:
+                    out.write('  <Iteration_iter-num>{}</Iteration_iter-num>\n'.format(iter_num))
+                else:
+                    out.write(line)
+                line = next(h)
+                query_ID_match = query_ID_re.match(line)
+                if query_ID_match is not None:
+                    out.write('  <Iteration_query-ID>Query_{}</Iteration_query-ID>\n'.format(iter_num))
+                else:
+                    out.write(line)
+                iter_num += 1
+                continue
+
+            if "</BlastOutput_iterations>" in line:
+                break
+            out.write(line)
+        h.close()
+    out.write("  </BlastOutput_iterations>\n")
+    out.write("</BlastOutput>\n")
+    out.close()
+
+
+merge(xmlfiles, xmlout)

--- a/tools/merge_blastxml/merge_blastxml.xml
+++ b/tools/merge_blastxml/merge_blastxml.xml
@@ -1,0 +1,42 @@
+<tool id="merge_blastxml" name="Merge BLAST XML" version="0.0.1" profile="16.04">
+  <description>Merge multiple BLAST XML files into a single BLAST XML file</description>
+
+  <command detect_errors="exit_code"><![CDATA[
+    python '$__tool_directory__/merge_blastxml.py' '$output_xml'
+    #for $element in $input_xmls:
+      '${element}'
+    #end for
+    ]]>
+  </command>
+
+  <inputs>
+    <param name="input_xmls" type="data" format="blastxml" multiple="true" label="BLAST XML datasets" />
+  </inputs>
+
+  <outputs>
+    <data name="output_xml" format="blastxml" label="Merge BLAST XML on ${on_string}" />
+  </outputs>
+
+  <tests>
+    <test>
+      <param name="input_xmls" value="q1.blastxml,q2.blastxml" ftype="blastxml" />
+      <output name="output_xml" file="output.blastxml" />
+    </test>
+  </tests>
+
+  <help><![CDATA[
+This tool takes BLAST XML format output of multiple XML runs and combines them into a single BLAST XML file. It does not
+do any deep inspection of the XML, it simply concatenates their hit descriptions into a single file. The code is largely
+based on that written by Peter Cock and included in the Galaxy code_. As such it should be considered as being under a
+MIT license, as explained inside the merge_blastxml.py script.
+
+.. _code: https://github.com/galaxyproject/galaxy/blob/dev/lib/galaxy/datatypes/blast.py
+    ]]>
+  </help>
+
+<citations>
+  <citation type="doi">
+    10.1186/s13742-015-0080-7
+  </citation>
+</citations>
+</tool>

--- a/tools/merge_blastxml/test-data/output.blastxml
+++ b/tools/merge_blastxml/test-data/output.blastxml
@@ -1,0 +1,3931 @@
+<?xml version="1.0"?>
+<!DOCTYPE BlastOutput PUBLIC "-//NCBI//NCBI BlastOutput/EN" "http://www.ncbi.nlm.nih.gov/dtd/NCBI_BlastOutput.dtd">
+<BlastOutput>
+  <BlastOutput_program>blastn</BlastOutput_program>
+  <BlastOutput_version>BLASTN 2.5.0+</BlastOutput_version>
+  <BlastOutput_reference>Zheng Zhang, Scott Schwartz, Lukas Wagner, and Webb Miller (2000), &quot;A greedy algorithm for aligning DNA sequences&quot;, J Comput Biol 2000; 7(1-2):203-14.</BlastOutput_reference>
+  <BlastOutput_db>/usr/people/galaxyuser/galaxy/galaxysrv/galaxy/database/files/000/dataset_421_files/blastdb</BlastOutput_db>
+  <BlastOutput_query-ID>Query_1</BlastOutput_query-ID>
+  <BlastOutput_query-def>AB462261.1 Culicoides brevitarsis genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Naha17_1</BlastOutput_query-def>
+  <BlastOutput_query-len>796</BlastOutput_query-len>
+  <BlastOutput_param>
+    <Parameters>
+      <Parameters_expect>0.001</Parameters_expect>
+      <Parameters_sc-match>1</Parameters_sc-match>
+      <Parameters_sc-mismatch>-2</Parameters_sc-mismatch>
+      <Parameters_gap-open>0</Parameters_gap-open>
+      <Parameters_gap-extend>0</Parameters_gap-extend>
+      <Parameters_filter>L;m;</Parameters_filter>
+    </Parameters>
+  </BlastOutput_param>
+<BlastOutput_iterations>
+<Iteration>
+  <Iteration_iter-num>1</Iteration_iter-num>
+  <Iteration_query-ID>Query_1</Iteration_query-ID>
+  <Iteration_query-def>AB462261.1 Culicoides brevitarsis genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Naha17_1</Iteration_query-def>
+  <Iteration_query-len>796</Iteration_query-len>
+<Iteration_hits>
+<Hit>
+  <Hit_num>1</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|1</Hit_id>
+  <Hit_def>AB462264.1 Culicoides wadai genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Isg18_1</Hit_def>
+  <Hit_accession>1</Hit_accession>
+  <Hit_len>834</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>684.381</Hsp_bit-score>
+      <Hsp_score>370</Hsp_score>
+      <Hsp_evalue>0</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>728</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>762</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>660</Hsp_identity>
+      <Hsp_positive>660</Hsp_positive>
+      <Hsp_gaps>80</Hsp_gaps>
+      <Hsp_align-len>785</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAAATATAATGATGTATTCTTTATAAG-GTATGGTTG-T-TAT-CGTTGTTA-T-TA-CAG-T-G--G-------CTTCGGCAAGCTCGTTATAAAGATGTAGTTTATTATGTCTTAAGCGAGTGCTGTAATACAACAAAACTAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCC--GTAAAACTAGTGA-CTTCGTGTCGCTAGTATGCATATT---G--------CT-TT---A----CGC---GATATGCATTGATATTTTTATCAAGATACTTTGGAGTGAGTAC-TTTGTAC-GTAAAATAAAATAAAAAAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCATGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGCGTCGTTTGCTTCCTCGGAGGCTGCGCGCATAAGTGCTTGATGTGATCATATGAATTGCTTCAGATTCATATATCATTAATAAAGTA-A-TATGAGTGGTTG-CTT---TGC-AGATA-CG--TGCATTTGACCATTACTTTTATTTAATTAAATA--AAATATTGGTATAAAATCAAA</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTA-ATCTAAAACATTCAATGATGTATTCT-CACAAGTGTATGGTTGTTGTTTCCGTTGTTATTGTAGCAGCTCGTCGTAATTATCGTCGGGCAGCTTGCTATAAAGATGTAGTTTATTATGTCTTAAGCGAGTGCTGCAATACAACAATACAAAATTTCTTAGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCTAAGGCCCCCAGTAAAACTAGTGATCTTTGTGTCACTAGTATGCATATTAATGCATAACATCTCTTCGGAGGTGCGCTTTGATATGCATTG--ATTTATATCAAGATACTTTGGAGTGAGTACATTCGTACAATAAAA-CAAA-CAAAAAAAGATC-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTT-TGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGACTCGTTTGAA-CGTC------T-----CATAAGTGCATGATGTGATCATATGGATTTCG-C-GATTCATATATCATTAATAAAGGAGAATATG-GTTGTTAACGTGCGTGTTACATTGCGTTTGCATTTGACCATTATTTTTATTTAATAAAATAATAAATTTTGGTATAAAATCAAA</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||| ||  |||| ||  |||||||||||||  | ||| ||||||||| | | | |||||||| | || ||| | |  |       | ||||  |||| | |||||||||||||||||||||||||||||||||||||| |||||||||| || ||||||||| ||||||||||||||||||||||||||||||||||||| ||||||||  ||||||||||||| ||| ||||| ||||||||||||||   |        || ||   |    |||   |||||||||||  |||| ||||||||||||||||||||||||| || ||||  |||||  |||  ||||||||||| |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  |||||||   | ||      |     ||||||||| ||||||||||||||| ||| |  | |||||||||||||||||||||| | | |||| || |||  | |   ||  | ||  ||  ||||||||||||||| ||||||||||| |||||  |||| ||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>54.6731</Hsp_bit-score>
+      <Hsp_score>29</Hsp_score>
+      <Hsp_evalue>4.97388e-10</Hsp_evalue>
+      <Hsp_query-from>768</Hsp_query-from>
+      <Hsp_query-to>796</Hsp_query-to>
+      <Hsp_hit-from>806</Hsp_hit-from>
+      <Hsp_hit-to>834</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>29</Hsp_identity>
+      <Hsp_positive>29</Hsp_positive>
+      <Hsp_gaps>0</Hsp_gaps>
+      <Hsp_align-len>29</Hsp_align-len>
+      <Hsp_qseq>ACTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>ACTATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>2</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|0</Hit_id>
+  <Hit_def>AB462263.1 Culicoides maculatus genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Kag12_1</Hit_def>
+  <Hit_accession>0</Hit_accession>
+  <Hit_len>764</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>682.534</Hsp_bit-score>
+      <Hsp_score>369</Hsp_score>
+      <Hsp_evalue>0</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>727</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>701</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>623</Hsp_identity>
+      <Hsp_positive>623</Hsp_positive>
+      <Hsp_gaps>48</Hsp_gaps>
+      <Hsp_align-len>738</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAAATATAATGATGTATTCTTTATAAGGTATGGTTGTTATCGTTGTTATTACAG-TGGCT-T--CGGCAAGCTCGTTATAAAGATGTAGTTTATTATGTCTTAAGCGAGTGCTGTAATACAACAAAACTAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGC-CCCGTAAAACTAGTGA-CTTCGTGTCGCTAGTATGCATATT-GCTTTACGCGATATGCATTGATATTTTTATCAAGATACTTTGGAGTGAGTACTTTGTACGTA-AAATAAAATAAAAAAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCATGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGCGTCGTTTGCTTCCTCGGAGGCTGCGCGCATAAGTGCTTGATGTGATCATATGAATTGCTTCAGATTCATATATCATTAATAAAGTAATATGAGTGGTTGCTTTGCAGATACGTGCAT--TTGACCATTACTTTTATTTAATTAAATAAA-ATATTGGTATAAAATCAA</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTA-ACT--AAACATTCAATGATGTATTCTTTA--AGGTATGGTTG---TCGTTGTTATTGCAGCAGCCTCTCGCGGGCAGCTTGCTATAAAGATGTAGTTTATTATGTCTTAAGCAAGTGTTGTGGTTCAACAAA---AAATTACTTGGGTAGCTTTATTTAAGAGCTTTAAAGACTTGTTTGCCCAAGGCTCCCGTAAAACTAGTGATCTT-GTTTCATTAGTATGCA-ATTATATTTA-TATATTTGCATTGAT-TTTATATCAAGATACTTTGGTGTGAGTAC---GTATGTACATATAAAA-CAAAAAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTTCGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATG--TA-TT-G-T-C-TGAAAAGATAAATG--TAAGTGCATGATGTGATCATATGGATTWACT----TTCATATATCATTAATGGAGGA-TATG-GTTATCGCT--GCT-ATGTTTGCACACTTGGCCATTATTTTTATTTAGTTAAAAATATATATTGGTATAAAATCAA</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||| | |  ||| ||  ||||||||||||||||  |||||||||||   ||||||||||| |||  | || |  |||  |||| | |||||||||||||||||||||||||||||| |||| |||  | |||||||   ||||| |||||||||||||||  |||||||||||||||||||||||||||||| |||||||||||||||| ||| || ||  ||||||||| |||   ||||    || ||||||||| ||| |||||||||||||||| ||||||||   ||| ||| | ||||||  |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||   |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  |  || | | | |   | | |    |  ||||||| ||||||||||||||| |||   |    ||||||||||||||||  || | |||| ||  | |||  ||  ||   ||||   ||| |||||| ||||||||| ||||| | | ||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>52.8265</Hsp_bit-score>
+      <Hsp_score>28</Hsp_score>
+      <Hsp_evalue>1.78893e-09</Hsp_evalue>
+      <Hsp_query-from>766</Hsp_query-from>
+      <Hsp_query-to>796</Hsp_query-to>
+      <Hsp_hit-from>734</Hsp_hit-from>
+      <Hsp_hit-to>764</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>30</Hsp_identity>
+      <Hsp_positive>30</Hsp_positive>
+      <Hsp_gaps>0</Hsp_gaps>
+      <Hsp_align-len>31</Hsp_align-len>
+      <Hsp_qseq>TAACTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>TATCTATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>|| ||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>3</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|17</Hit_id>
+  <Hit_def>AB462280.1 Culicoides kibunensis genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: AM05_6</Hit_def>
+  <Hit_accession>17</Hit_accession>
+  <Hit_len>817</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>621.595</Hsp_bit-score>
+      <Hsp_score>336</Hsp_score>
+      <Hsp_evalue>1.08727e-180</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>796</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>817</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>678</Hsp_identity>
+      <Hsp_positive>678</Hsp_positive>
+      <Hsp_gaps>59</Hsp_gaps>
+      <Hsp_align-len>836</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAAATATAATGATGTATTCTTTATAAGGTATGGTTGTTATCGT-TGTTATTA-C-AGTGGCTTCGGCAAGCTCGTTA-T-AAAGATGTAGTTTATTATGTCTTAAGCGAGTGCTGTAATACAA-CA---AAACT-AAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGAC---TT-CG-TGTCGCTAGTATGCATATTGC--TTTACGCG-ATATGCATTGATATTTTTATCAAGATACTTTGGAGTGAGTA----CTT--T-GTACGTA-AAATA-AAATAAAAAAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCA-TGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGCGTCGTTTGCTTCCTCGGAGGCTGC-GC-GCATAAGTGCTTGATGTGATCATATGAATTGCTTCAGATT-C--ATATATCATTAATAAAGTAATATGAGTGGTTGCTT-TGCAGATACGTGCATTTGACCATTACTTTTATTTAAT-TAAATA-A-AATATTGGTATAAAATCAA-AGGCACTTGCAAAT-GTAGACCGTTATATGTA-AAAACTTTAACTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAAATATAATGATGTA-TCATTCTAAGGTATGGTTGTT-TTGTCTCTCAACAGCTATTAACTT-GGC-AG--C-TTACTCAAAGATGTAGCTTATTATGTTTTAAGTAAGTGTTGTTAGACAATCAGGTATGGTGAAATTWCTTAGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCTAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGCATATACAAGTAAAATTGTATATGCATTGATATTTT--TCATGATACTTTGGTGTGAGTATAAAATTAATAATTTGTACAWAAACAAACAAAAAAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTCAAACTATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTGT--TTTGTTGTCTAACAA-CAGCAGAAGCATAAGTGCATGATGTGATCATAT-AA--GCTTTTAATYGCYTATATATCATTAATAAAGGTATAAGTATGGTAACAAGTGCTTTTGCACATATTTAACCATAATTTTTATTTAATATAAATATATAATTTTGGTATAAAATGAATATGTG-TTGYACGTTGTA-AGC-T-ATACAAAGAAAACTTTAAAATTGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| || || ||||||||||||||| | || | | |  | | | |  ||| ||| ||  | ||| | |||||||||| ||||||||| |||||  |||| ||| | |||| ||   |   | ||||| ||| ||||||||||||||||||||||||||||||||||||| ||||||||||||||||||| ||   || ||  || ||||||||||||||     |  |   | |||||||||||||||||  ||| |||||||||| |||||||     ||  |  |  ||| | | | ||| |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  |   |||||||||  ||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||  |||| |  ||   |  | || |  |||||||||| |||||||||||||| ||  ||||   ||  |  |||||||||||||||||  ||| |  ||||  |   |||   | |    |||| ||||| | ||||||||||| |||||| | ||| |||||||||||| || | |   ||| |  | ||| | | | |||   | ||||||||||   |||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>4</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|12</Hit_id>
+  <Hit_def>AB462275.1 Culicoides punctatus genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Kag13_1</Hit_def>
+  <Hit_accession>12</Hit_accession>
+  <Hit_len>787</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>590.202</Hsp_bit-score>
+      <Hsp_score>319</Hsp_score>
+      <Hsp_evalue>3.06608e-171</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>561</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>575</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>503</Hsp_identity>
+      <Hsp_positive>503</Hsp_positive>
+      <Hsp_gaps>36</Hsp_gaps>
+      <Hsp_align-len>586</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAAATATAATGATGTATTCTT-TATAAGGTATGGTTGTTATCGTTGTTA-T-T-ACAGT-GGCT--TCGGCAAGCTCGTTATAAAGATGTAGTTTATTATGTCTTAAGCGAGT-GC-TGTAATACAACAAAACTAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGAC---TT-CG-TGTCGCTAGTATGCATATTGCTTTACGCGATATGCATTGATATTTTTATC-AAGATACTTTGGAGTGAGTACT-TTGT-ACGTAA----A-AT-AA-AATA-AAAAAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCATGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATG</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTAT-TATAAAACATATAATGATGT-TCATTCTAT-AGGTATGGTTGTTGT-GTTGTCATTGTAAGAGTCATTTAGTTGGC-AGCTCTCTATAAAGACATAGTTTATTATGTTTTAAGGGAGTACCTTGCAGTGCGACAAAA--AAATTACTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGCATAT-ACTTAATTGTATATGCATTGAT-TTATT-TCAAAGATACATTGGAGAGAGTATAATTGTAATGAAATTGTACATAAACAAAACAAAAAAAG-TAAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTTCGATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATG</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||| |  |||| |||||||||||| |  || ||| ||||||||||||| | ||||| | | | | |||    |  | ||| |||||  ||||||||  ||||||||||||| ||||| ||||  | || | | | ||||||  ||||| ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||   || ||  || ||||||||||||||  ||| |    |||||||||||| || || || ||||||| |||||| |||||   |||| | | ||    | || || || | |||||||| | ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||   ||||||||||  |||||||||||||||||||||||||||||||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>5</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|18</Hit_id>
+  <Hit_def>AB462281.1 Culicoides verbosus genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: OKYN05_18</Hit_def>
+  <Hit_accession>18</Hit_accession>
+  <Hit_len>805</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>586.508</Hsp_bit-score>
+      <Hsp_score>317</Hsp_score>
+      <Hsp_evalue>3.96623e-170</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>796</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>805</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>681</Hsp_identity>
+      <Hsp_positive>681</Hsp_positive>
+      <Hsp_gaps>83</Hsp_gaps>
+      <Hsp_align-len>842</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAAATATAATGATGT--ATTCTTTATAAGGTAT---GGTTGTTATCGTTGTTATTAC-AGTGGCTTCGGCAAGCTCGTTATAAAGATGTAGTTTATTATGTCTTAAGCGAGTGCTGTAATACAACAA---------AACTAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGAC---TT-CG-TGTCGCTAGTATGCATATTGCTTTACGCGATATGCATTGATATTTTTATCAAGATACTTTGGAGTG--AG--------T--ACTTTGTACGTAAAATAAAATAAAAAAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCATGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGCGTCGTTTGCTTCCTCGGAGGCTGCGCGCATAAGTGCTTGATGTGATCATATGAATTGCTTCAGATT-C--ATATATCATTAATAAAG-TA-ATATGAGTGGTTGCT-TTGCAGATACGTGCATTTGACCATTACTTTTATTTAAT-TAAATAAAATA---TTGGTATAAAATCAA-AGG-CACTT-GCAAATGT-AGACCGTTATATGTAAAAACTTTAACTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAAATATAATGATGTTCATTC-ATAAAAGGTATAACGGTTGTTGTC-TTTCAATGGCTATTCACTT-AGCAAGCTTGCTATAAAAATGTAGTTTATTATGTTTTAAGCAAGTGTTGTTAGACAA-AAGGTTGGTTGTTCAAAATTACTTAGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCTAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGTATAT-ACTTAATTGTATATGCATTGATATTTT--TCATGATACTTTGGAGTGTGAGTATAAAATTAAAATTTGTAC-AAAAACAAAA-ACAAAAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATAAACTAATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATG--TCTTTAAAAT--T-G-AGA-T------ATAAGTGCATGATGTGATCATAT-AA--GCTT-A-ATTGCCTATATATCATTAATAAAGGTGGAGGT-A-TGGT-GCTATTGT-G-TACAT--ATTTAACCATCATTTTTATTTAATATAAATAATATAATTTTGGTATAAAATGAATATGTCATATAGCACATATCATACAGCAAAA---AAAAACTTTAAAATTGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  ||||  || |||||||   ||||||| || ||   ||  | | |  |||  ||||||| | |||||| |||||||||||||||| |||||| |||| ||| | |||| ||           | ||||| ||| ||||||||||||||||||||||||||||||||||||| ||||||||||||||||||| ||   || ||  || ||||||||| ||||  ||| |    |||||||||||||||||  ||| ||||||||||||||  ||        |  | |||||||  |||| |||| | ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||    | |||||||||  |||||||||||||||||||||||||||||||||||||||||||||||||||||||||  || ||    |  | | ||  |      |||||||| |||||||||||||| ||  |||| | ||| |  ||||||||||||||||| |  |  | | |||| ||| |||  | ||| |  |||| ||||| | ||||||||||| ||||||| |||   |||||||||||| || | | ||  | ||| || | | || |  | |   |||||||||||   |||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>6</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|5</Hit_id>
+  <Hit_def>AB462268.1 Culicoides cylindratus genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Kag08, short type</Hit_def>
+  <Hit_accession>5</Hit_accession>
+  <Hit_len>748</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>582.815</Hsp_bit-score>
+      <Hsp_score>315</Hsp_score>
+      <Hsp_evalue>5.13064e-169</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>561</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>547</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>490</Hsp_identity>
+      <Hsp_positive>490</Hsp_positive>
+      <Hsp_gaps>36</Hsp_gaps>
+      <Hsp_align-len>572</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAAATATAATGATGTATTCTT-TATAAGGTATGGTTGTTATCGTTGTTATTAC-AGTGGCTTCGGCAAGCTCGTTATAAAGATGTAGTTTATTATGTCTTAAGCGAGTGCTGTAATACAACAAAACTAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGACTTCGTGTCGCTAGTATGCATATTGCTTTACGCGATATGCATTGATATTTTTATCAAGATACTTTGGAGTGAGTA-----C----TTTGTACGTAAAATAAAATAAAAAAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCATGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATG</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTAT----AAAATATATAATGATGT-TCATTCAATAAGGT-TGGTGGTTGT-ATTGTAACAGCTATTTACTT-AGC-AGCTTGCTATAAAGATGTRGTTTATYATGTCTTAAGYAAGTGTTGYGATACARCAAA---AAATTTCTTAGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCTAAGGCCCCGTAAAACTAGTAAC-CCAT-T-GCGAGGTGGC-TA--G---TATGC-ATATGCATTGATATTTT--TCATGATACTTTGGAGTGAGTATAATACAAAAATTGTACATAAAACAAAAYAAAAAAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTATAATATTTT-TGATATTCATAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATAYATTAAACTATCTTATG</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||    |||| |||||||||||| |  ||  ||||||| |||| ||| |  |||| |   | | |  |||  || |||| | ||||||||||| |||||| ||||||||||  |||| ||  ||||| ||||   ||||||||| ||||||||||||||||||||||||||||||||||||| ||||||||||||||||||| ||  | | | || ||   || ||  |   || || |||||||||||||||||  ||| ||||||||||||||||||     |     |||||| ||||| |||| ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||||||||  ||||||||| |  |||||||||||||||||||||||||||||||||||||||| ||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>7</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|21</Hit_id>
+  <Hit_def>AB462284.1 Culicoides paraflavescens genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: OKYN05_13</Hit_def>
+  <Hit_accession>21</Hit_accession>
+  <Hit_len>842</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>564.348</Hsp_bit-score>
+      <Hsp_score>305</Hsp_score>
+      <Hsp_evalue>1.85841e-163</Hsp_evalue>
+      <Hsp_query-from>170</Hsp_query-from>
+      <Hsp_query-to>724</Hsp_query-to>
+      <Hsp_hit-from>249</Hsp_hit-from>
+      <Hsp_hit-to>783</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>484</Hsp_identity>
+      <Hsp_positive>484</Hsp_positive>
+      <Hsp_gaps>38</Hsp_gaps>
+      <Hsp_align-len>564</Hsp_align-len>
+      <Hsp_qseq>AAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGAC---TT-CG-TGTCGCTAGTATGCATATTGCTTTACGCGATATGCATTGATATTTTTATCAAGATACTTTGGAGTGAGTACT--TTGTACGTAAAATAAAATAAAAAAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCATGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGCGTCGTTTGCTTCCTCGGAGGCTGCGCGCATAAGTGCTTGATGTGATCATATGAATTGCTTCAGATTCATATATCATTAATAAAGTAATATGAGTGGTTGCTTTGCAGATACGTGCATTTGACCATTACTTTTATTTAATTAAATA--AAATATTGGTATAAAAT</Hsp_qseq>
+      <Hsp_hseq>AAATTTCTTGGGTAGCTTTATTGAAGAGCTTTAAAGACTTATTTGCCCAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGCATA-CCCTTTATTGGGTATGCATTGATATTTT--TCATGATACTTTGGTGTGAGTACTTATTGTACATATGAT-AAATAAAAAAACGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTTTGATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGCGTCTCTAGCGA--TAGAAG-C-GCT----TAAGTGCATGATGTGATTATAT-AA--G-TAAA-ATT-ATATATCATTAATAAAGGAATAAAA-TGGTA--T--G-A-AT-CAT--ATTTAACCATTATTTTTATTTAAA-AAATAACAAATTTTGGTATAAAAT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||| |||||||||||||||||| |||||||||||||||||||||||||| ||   || ||  || |||||||||||||   |||||   | ||||||||||||||||  ||| |||||||||| |||||||||  |||||| ||  || ||||||||||| ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  |||||||||||  |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  | ||    | | || | ||     ||||||| ||||||||| |||| ||  | |  | ||| ||||||||||||||||| ||||  | ||||   |  | | || | |  |||| ||||||| ||||||||||  |||||  |||| ||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>145.159</Hsp_bit-score>
+      <Hsp_score>78</Hsp_score>
+      <Hsp_evalue>2.8691e-37</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>145</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>143</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>126</Hsp_identity>
+      <Hsp_positive>126</Hsp_positive>
+      <Hsp_gaps>8</Hsp_gaps>
+      <Hsp_align-len>148</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAAATATAATGATGTATTCTTTATAAGGTATGGTTGTT-ATCGTTGTTATTA-C-AGTGGCTTCGGCAAGCTCGTTATAAAGATGTAGTTTATTATGTCTTAAG</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATT-AAAACATATAATGATGT-TTC-TT-TAAGGTATGGTGTTTGATATTTGTTGATAGCTATTTGATT-AGCAAGCTTACTATAAAGATGTAGTTTATTATGTCTTAAG</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||||| |||| |||||||||||| ||| || |||||||||||  || ||  |||||  || | | | | ||  |||||||   |||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>8</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|20</Hit_id>
+  <Hit_def>AB462283.1 Culicoides matsuzawai genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: IS05_6</Hit_def>
+  <Hit_accession>20</Hit_accession>
+  <Hit_len>908</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>545.882</Hsp_bit-score>
+      <Hsp_score>295</Hsp_score>
+      <Hsp_evalue>6.73148e-158</Hsp_evalue>
+      <Hsp_query-from>170</Hsp_query-from>
+      <Hsp_query-to>565</Hsp_query-to>
+      <Hsp_hit-from>300</Hsp_hit-from>
+      <Hsp_hit-to>698</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>372</Hsp_identity>
+      <Hsp_positive>372</Hsp_positive>
+      <Hsp_gaps>17</Hsp_gaps>
+      <Hsp_align-len>406</Hsp_align-len>
+      <Hsp_qseq>AAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGAC---TT-CG-TGTCGCTAGTATGCATATTGCTTTACGCGA-TATGCATTGATATTTTTATCAAGATACTTTGGAGTGA-GTAC-T-TTGTACGTAAAATAAAATAAAAAAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCAT-GATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGCGTC</Hsp_qseq>
+      <Hsp_hseq>AAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGCATA-CAC-TTARTTGAGTATGCATTGATATTTT--TCATGATACTTTGGTGTGAAGTACATATTGTACCG-ATAT-AAACAAAAAAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTT-ATCGATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTGTC</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||   || ||  || |||||||||||||   | |||   || ||||||||||||||||  ||| |||||||||| |||| |||| | ||||||   | || ||| |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| || ||||||||||  ||||||||||||||||||||||||||||||||||||||||||||||||||||||||| |||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>148.852</Hsp_bit-score>
+      <Hsp_score>80</Hsp_score>
+      <Hsp_evalue>2.21795e-38</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>145</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>154</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>134</Hsp_identity>
+      <Hsp_positive>134</Hsp_positive>
+      <Hsp_gaps>15</Hsp_gaps>
+      <Hsp_align-len>157</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAAATATAATGATGTATTCTTTATA-A-GGTAT--GGTTGTTATCGTTGTTAT-T-A-CAG-TG---GCTTCGGCAAGCTCGTTATAAAGATGTAGTTTATTAT-GTCTTAAG</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAAATATAATGATGT-TTCTTTATATAAGGTATATGGTTGTTAT-GTTGTCTTGTCAACAGCTATTTGATTA-GCAAGCTTGCTATAAAGATGTAGTTTATTACGGTCTTAAG</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||||||||| | |||||  ||||||||| |||||  | | | ||| |    | ||  ||||||| | ||||||||||||||||||||  ||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>9</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|19</Hit_id>
+  <Hit_def>AB462282.1 Culicoides humeralis genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Kag15_1</Hit_def>
+  <Hit_accession>19</Hit_accession>
+  <Hit_len>912</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>532.955</Hsp_bit-score>
+      <Hsp_score>288</Hsp_score>
+      <Hsp_evalue>5.2407e-154</Hsp_evalue>
+      <Hsp_query-from>170</Hsp_query-from>
+      <Hsp_query-to>796</Hsp_query-to>
+      <Hsp_hit-from>297</Hsp_hit-from>
+      <Hsp_hit-to>912</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>535</Hsp_identity>
+      <Hsp_positive>535</Hsp_positive>
+      <Hsp_gaps>49</Hsp_gaps>
+      <Hsp_align-len>646</Hsp_align-len>
+      <Hsp_qseq>AAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGAC---TT-CG-TGTCGCTAGTATGCATATTGCTTTACGCGA-TATGCATTGATATTTTTATCAAGATACTTTGGAGTGAGTA--CTTTGTA-CGTAAAATAA-AA-TAAAAAAAA-GATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCAT-GATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGCGTCGTTTGCTTCCTCGGAGGCTGCGCGCATAAGTGCTTGATGTGATCATATGAATTGCTTCAGATTCATATATCATTAATAAAG--TAATATGAGTGGTTGCTTTGCAGATACGTGCAT--TTGACCATTACTTTTATTTAATTAAATAAAATATTGGTATAAAATCAA-AGGCACTT-GCAAATGTAGACCGTTATATGTAAAAACTTTAACTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>AAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGCATA-CAC-TTAATTGAGTATGCATTGATATTTT--TCATGATACTTTGGTGTGAGTATAATTTGTATTGTACATAAACAAGAAAAAAAAACGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTT-ATCGATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTGT-GT---CTTGAAAA-AGACAT----CATAAGTGCATGATGTGATTATAT-AA--GCGCAAGCTT-ATATATCATTAATAAAGGATAATATG-GACGTATC---GCT-AT-CTTGCATACTTAACCATAATTTTTATTTGATTATAAATAATTTTGGTATAAAATGAGTATGT-CTAAGCTC-T-TAG-CTTTCGCCTCTAAAA-CTTTAT-TATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||   || ||  || |||||||||||||   | |||   || ||||||||||||||||  ||| |||||||||| |||||||   ||||||  ||| |  || ||  |||||||| |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| || ||||||||||  ||||||||||||||||||||||||||||||||||||||||||||||||||||||||| || ||   |||      || |      ||||||||| ||||||||| |||| ||  ||   || || |||||||||||||||||  ||||||| |  ||  |   ||  || | |||||  || ||||| | |||||||| |||| | | ||| |||||||||||| |  | |  ||  ||   | ||| |  |    | ||||| |||||  |||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>145.159</Hsp_bit-score>
+      <Hsp_score>78</Hsp_score>
+      <Hsp_evalue>2.8691e-37</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>145</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>152</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>131</Hsp_identity>
+      <Hsp_positive>131</Hsp_positive>
+      <Hsp_gaps>13</Hsp_gaps>
+      <Hsp_align-len>155</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAAATATAATGATGTATTCTTTATA-A---GGTAT--GGTT--GTTATCGTTGTTATTA-C-AGTGGCTTCGGCAAGCTCGTTATAAAGATGTAGTTTATTATGTCTTAAG</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAAATATAATGATGT-TTCTTTATATATAAGGTATATGGTTATGTTGTC-TTGTCAAYRGCTATTYGATTA-GCAAGCTTGCTATAAAGATGTAGTTTATTATGTCTTAAG</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||||||||| |   |||||  ||||  ||| || |||| |    | | | | ||  ||||||| | |||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>10</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|13</Hit_id>
+  <Hit_def>AB462276.1 Culicoides sumatrae genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: ONYK05_17</Hit_def>
+  <Hit_accession>13</Hit_accession>
+  <Hit_len>784</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>525.569</Hsp_bit-score>
+      <Hsp_score>284</Hsp_score>
+      <Hsp_evalue>8.76954e-152</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>561</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>583</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>499</Hsp_identity>
+      <Hsp_positive>499</Hsp_positive>
+      <Hsp_gaps>46</Hsp_gaps>
+      <Hsp_align-len>595</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTAT-ATT-AAAAAAATATAATGATGTATTCTTTATAAGGTATGGTTGTTA-TC-GTTGTTATTACAGTGGCTTCGGCAAGC-T----CGTTATAAAGATGTAGTTTATTATGTCTTAAGCGAGTGCTGTA-ATACAACAAAACTAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGAC---TT-CG-TGTCGCTAGTATGCATATTGCTTTACGCGATATGCATTGATATTTTTATCAAGATACTTTGGAGTGA---------GT--A-CTTTGTACGTAAAATA-AAATA--AAAAAAAGA-T-CA-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATT-TCATGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATG</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATTATTAAAAAAAATATAATGATGT-TTCATT-CAAGGTATGGTTGTTAATCTATTGCAATGGCTATTAATTTAGC-AGCTTACACCGCTATAAAGATGTGGTTTATCATATCTTAAGC-A-TTC-GTAGGTGTTGTGATAGAAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGTATAT-ACTTAATTGTATATGCATTGATATTTT--TCATGATACTTTGGTGTGATAATAAAAAGTAAATCTTTATA-TTTATATAGAGATAGGAAAAAAAAAGTAAAGAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTATC--GATATTCACGAAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATG</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||| ||| |||||||||||||||||| ||| ||  ||||||||||||||| ||  |||  ||  |  |   ||  || ||| |    || ||||||||||| |||||| || |||||||| | | | |||  |      | |  ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||   || ||  || ||||||||| ||||  ||| |    |||||||||||||||||  ||| |||||||||| ||||         ||  | |||| ||  | | ||| | |||  ||||||| | |  | |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||  |||||||||  ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>11</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|9</Hit_id>
+  <Hit_def>AB462272.1 Culicoides nipponensis genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Isg22</Hit_def>
+  <Hit_accession>9</Hit_accession>
+  <Hit_len>794</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>518.182</Hsp_bit-score>
+      <Hsp_score>280</Hsp_score>
+      <Hsp_evalue>1.46745e-149</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>558</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>567</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>491</Hsp_identity>
+      <Hsp_positive>491</Hsp_positive>
+      <Hsp_gaps>45</Hsp_gaps>
+      <Hsp_align-len>585</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAAATATAATGATGTATTCTT-TATAAG-GT-ATGGTTGTTATCGTTGTT---ATTACAGTGGCTTCGGCAAGC-TCGTTATAAAGATGTAGTTTATTATGTC-T-TA--AGCGAG--TGCTGTAATACAACAA-A----ACTAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGAC---TT-CG-TGTCGCTAGTATGCATATTGCTTTACGCGATATGCATTGATATTTTTATCAAGATACTTTGGAGTGAGTACTTTGTACGTAAAATAAAATAAAAAAAAG-ATCA-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATAT-TTCATGATATTCACA-GAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTAT-TATAAAAAATATAATGATGT-TCATTCTATTAGTGTAATGG-TGTTATTATTATTACAATTGCAATATATTTTGCA-GCTTACACA-AAAGATGTAGTTTATTATATCATATATGTGCAAGTATATTGTAATAATAAAAGAGTTGGTTAAATTTCTTGGGTAGCTTTATTGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGTATAT--ATTCA-TTTATATACATTGATATTTT--TCATGATACTTTGGATTGA-TA---TG-A--TAAAACAAACAAAAAAAAAGTGTAAGAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATATTTTTGATATTCACAAGA-TCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTT</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||| |  ||||||||||||||||| |  || ||| || || |||| ||||||  || ||   ||| || |   ||  ||| || |    | |||||||||||||||||| || | ||   || ||  |  |||||||  | || |      |||||||||||||||||||||| ||||||||||||||||||||||||||||||||||||||||||||| ||   || ||  || ||||||||| ||||   || |    |||| ||||||||||||  ||| ||||||||||| ||| ||   || |  ||||| |||  |||||||||  | | ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||  ||||||||||| || |||||||||||||||||||||||||||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>12</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|15</Hit_id>
+  <Hit_def>AB462278.1 Culicoides erairai genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: IS05_2</Hit_def>
+  <Hit_accession>15</Hit_accession>
+  <Hit_len>931</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>516.336</Hsp_bit-score>
+      <Hsp_score>279</Hsp_score>
+      <Hsp_evalue>5.2779e-149</Hsp_evalue>
+      <Hsp_query-from>170</Hsp_query-from>
+      <Hsp_query-to>796</Hsp_query-to>
+      <Hsp_hit-from>310</Hsp_hit-from>
+      <Hsp_hit-to>931</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>533</Hsp_identity>
+      <Hsp_positive>533</Hsp_positive>
+      <Hsp_gaps>47</Hsp_gaps>
+      <Hsp_align-len>648</Hsp_align-len>
+      <Hsp_qseq>AAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGAC---TT-CG-TGTCGCTAGTATGCATATTGCTTTA-CGCGATATGCATTGATATTTTTATCAAGATACTTTGGAGTGAGTACTTTG--TACGTA-AAA--T-AAAA--TAAAAAAA-AGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCATGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGCGTCGTTTGCTTCCTCGGAGGCTGC-GCGCATAAGTGCTTGATGTGATCATATGAATTGCTTCAGATTCATATATCATTAATAAAGTAATATGAG-TGGTTGCTTTGCAGATACGT-GCAT-TTG-ACCATTACTTTTATTTAATTAAATAAAATATTGGTATAAAATCAA-AGGCACTTGCAAATGTAGACCGTTATATGTAAAAACTTTAACTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>AAATTTCTTAGGTAGCTTTATTGAAGAGCTTTAAAGACTTGTATGCCTAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGCATATATTTTAATCGGTGTATGCATTGATATTTT--TCATGATACTTTGGTGTGA-TATTTTGTATATTTACAAATGTAAAAATGTAAAAAAAGAGATC-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTACT--TATTCACAAAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTGTGATT--TTT-CTGG-T-GAAA-CAGAAGCTTACAAGTGCATGATGTGATCATATAGATGATTTCTGTCT-ATATATCATTAATAAAGTGGTATGATATGTGTACTAA--AGTTGTGTTGCATATTTAACCATAATTTTTATTTAATAATATTAATT-TTGGTATAAAATAAATAAGCACA--CAC-T-TAG----TTGTATC-AAAAACTTTAAAT-TGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>||||||||| ||||||||||| |||||||||||||||||||| |||| ||||||||||||||||||| ||   || ||  || ||||||||||||||   || | ||   ||||||||||||||||  ||| |||||||||| |||| || ||||  ||  || |||  | ||||  |||||||| ||||| |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  |  |||||||| ||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||  |  ||| ||   | | |  | |  ||  | |||||| ||||||||||||||  ||   ||| |  | ||||||||||||||||||  |||||  ||  | ||    || |  || |||| ||  ||||| | ||||||||||| | || || | |||||||||||| || | ||||   ||  | |||    || |||  ||||||||||| | |||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>135.926</Hsp_bit-score>
+      <Hsp_score>73</Hsp_score>
+      <Hsp_evalue>1.72675e-34</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>167</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>172</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>143</Hsp_identity>
+      <Hsp_positive>143</Hsp_positive>
+      <Hsp_gaps>11</Hsp_gaps>
+      <Hsp_align-len>175</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTA-AAAAAATATAATGATGTATTCTT-TATAAG-GTATGGTTGTTATCGTT--GTTAT-TACAGTGG-CTTCGGCAAGCTCGTTATAAAGATGTAGTTTATTATGTCTTAAGCGAGTGCTGTA-ATACAACAAAA</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTATAAAAAATATAATGATGTATCATTCTATAAGTGTATGGTGGTTGTTGTTTCGACAGCTAAAGTTTACTTTAGCAGCCTAC-TATAAAGATGTAGTTTATTATGTCTTAAGT-A-TGGTGTTGATTCAACAAAA</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||||||| |||||||||||||||||||  || |||||| ||||||| ||| | |||  |  |  || |||   |||  |||  ||   |||||||||||||||||||||||||||||  | || |||  || ||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>13</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|8</Hit_id>
+  <Hit_def>AB462271.1 Culicoides lungchiensis genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: AM05_8</Hit_def>
+  <Hit_accession>8</Hit_accession>
+  <Hit_len>776</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>510.796</Hsp_bit-score>
+      <Hsp_score>276</Hsp_score>
+      <Hsp_evalue>2.45557e-147</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>561</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>585</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>496</Hsp_identity>
+      <Hsp_positive>496</Hsp_positive>
+      <Hsp_gaps>44</Hsp_gaps>
+      <Hsp_align-len>595</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTA-TATTAAAAAAATATAATGATGTATTCT-TTATAAG-G-TATGGTTGTTAT-CGTTGTTATTAC-AGTGGCTTCGGCAAGCTCGTTATAAAGATGTAGTTTATTA--TGTC-T-TAAGCGAGTGCTGTAATACA--ACAA----AACTAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGAC---TT-CG-TGTCGCTAGTATGCATATTGCTTTACGCG-ATATGCATTGATATTTTTATCAAGATACTTTGG-----AG------TGAGTAC-TTTGTACGTAAAATAAAATAAAAAAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCATGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATG</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATTAAAAAAAAAATATAATGATGT--TCTATCATAAGTGTTATGG-TGTTATATATTACAATAACTATTTAATT-AGTAAGCTTATTATAAAGATGTGGTTTATCACTTATCTTATAAATAAGTATTGTAATATATTTTAAGTGTATGGAAATTACTTGGGTAGCTTTATTGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGTATATACATTTATTTGTATATACATTGATATTTTT-TCATGATACTTTGGTATAAAGAAAAAAAAAGTACAATTTT--GT-ACATATAA-AAAAAAAAGATCTAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTT-TGATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATG</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||| ||  ||||||||||||||||||  ||| | ||||| | ||||| ||||||   ||   || || | |   ||  | |||||  |||||||||||| |||||| |  | || | |||   |||  ||||||| |    ||    |   ||||| ||||||||||||||| ||||||||||||||||||||||||||||||||||||||||||||| ||   || ||  || ||||||||| ||||   ||||   | |||| ||||||||||||| ||| ||||||||||     ||        |||||  || |  || | ||| || |||||||||||| |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  |||||||||||  |||||||||||||||||||||||||||||||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>14</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|3</Hit_id>
+  <Hit_def>AB462266.1 Culicoides japonicus genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Ngs24_1</Hit_def>
+  <Hit_accession>3</Hit_accession>
+  <Hit_len>925</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>508.949</Hsp_bit-score>
+      <Hsp_score>275</Hsp_score>
+      <Hsp_evalue>8.8318e-147</Hsp_evalue>
+      <Hsp_query-from>170</Hsp_query-from>
+      <Hsp_query-to>561</Hsp_query-to>
+      <Hsp_hit-from>317</Hsp_hit-from>
+      <Hsp_hit-to>714</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>366</Hsp_identity>
+      <Hsp_positive>366</Hsp_positive>
+      <Hsp_gaps>22</Hsp_gaps>
+      <Hsp_align-len>406</Hsp_align-len>
+      <Hsp_qseq>AAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGAC---TT-CG-TGTCGCTAGTATGCATATTGCTTTACGCG-ATATGCATTGATATTTTTATCAAGATACTTTGGAGTGAGTACTTTGT---AC---GTAAAATAAAATAAAAAAA-AGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATAT-TTCATGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATG</Hsp_qseq>
+      <Hsp_hseq>AAATTACTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGTATAT-AC-TTAGTTGTATATGCATTGATATTTT--TCATGATACTTTGGTGTGA-T-TTTTGTAAAACAAAATATAATAAAATAAAAAAATTGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATATTACT--TATTCACAAAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATG</Hsp_hseq>
+      <Hsp_midline>||||| ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||   || ||  || ||||||||| ||||  | |||   | |||||||||||||||||  ||| |||||||||| |||| |  |||||   ||    || |||||||||||||||  |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||  |  |||||||| ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>130.386</Hsp_bit-score>
+      <Hsp_score>70</Hsp_score>
+      <Hsp_evalue>8.0338e-33</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>91</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>97</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>89</Hsp_identity>
+      <Hsp_positive>89</Hsp_positive>
+      <Hsp_gaps>6</Hsp_gaps>
+      <Hsp_align-len>97</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAAATATAATGATGTATT-CTT-TAT-AAGGTAT-GGTTGTT-ATCGT-TGTT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAAATATAATGATGTATCACTTATATTAAGGTATTGGTTGTTTATTGTGTGTT</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  ||| ||| ||||||| ||||||| || || ||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>15</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|11</Hit_id>
+  <Hit_def>AB462274.1 Culicoides peregrinus genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Yng26</Hit_def>
+  <Hit_accession>11</Hit_accession>
+  <Hit_len>794</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>499.716</Hsp_bit-score>
+      <Hsp_score>270</Hsp_score>
+      <Hsp_evalue>5.31537e-144</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>560</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>596</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>498</Hsp_identity>
+      <Hsp_positive>498</Hsp_positive>
+      <Hsp_gaps>46</Hsp_gaps>
+      <Hsp_align-len>601</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATAT-TAAAAAAATATAATGATGT-AT-TC-TTTATAAG-G-TATGGTTGTTATCGTTGTT---ATTAC-AGTGGCTTCGGCAAGCTCGTTATAAAGATGTAGTTTATTAT-GTC-T-TAAGCGAGTGCTGTAATACAA--CA------AAACTAAATTTCTTGGGTAGCTTTA--TAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGAC---TT-CG-TGTCGCTAGTATGCATATTGCTTTACGCGATATGCATTGATATTTTTATCAAGATACTTTGGAGTGA-GT--ACTT-T--GTAC------GTA-AAATAAAATAAAAAAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCATGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTAT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATATAAAAAAATATAATGATGTTCTCTCATTAAAAAGTGTTATGG-TGTTATATATATTACAATAACTATTAAATT-AGTAAGCTTATTATAAAGATGTGGTTTATCATTATCTTATAAATAAGTATTGTAATATAAGGTATTGGTGGTGTTTAATTTCTTGGGTAGCTTTAATTTTAAGAGCTTTAAAGACTTTTTTGCCCAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGTATAT-ACTTAATTGTATATACATTGATATTATTTTCATGATACTTTGGTGTGAAATAAAGTTATAAGTACTATTTTGTACATATAAAA-AAAAAAAAGATCTAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCMTGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTT-TGATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTAT</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||||| |||||||||||||||||||  | || || | ||| | ||||| ||||||   | ||   || || | |   ||  | |||||  |||||||||||| |||||| ||  || | |||   |||  ||||||| ||   |          | |||||||||||||||||||  |  ||||||||||||||||| |||||||||||||||||||||||||| ||   || ||  || ||||||||| ||||  ||| |    |||| |||||||||| || ||| |||||||||| ||||  |  | || |  ||||      ||| | |||||| |||||||||||| |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  |||||||||||  ||||||||||||||||||||||||||||||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>16</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|16</Hit_id>
+  <Hit_def>AB462279.1 Culicoides oxystoma genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Naha16_1</Hit_def>
+  <Hit_accession>16</Hit_accession>
+  <Hit_len>796</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>494.176</Hsp_bit-score>
+      <Hsp_score>267</Hsp_score>
+      <Hsp_evalue>2.473e-142</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>557</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>572</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>492</Hsp_identity>
+      <Hsp_positive>492</Hsp_positive>
+      <Hsp_gaps>53</Hsp_gaps>
+      <Hsp_align-len>591</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATT-AAAAAA-ATATAATGATGTATTCTTTATAAGGTAT-G-GTTG-T--TATCGTTGT-TATTACAGTGGCTTCGGCAAGCTCGTTATAAAGATGTAGTTTATTATGTCTTAAGCGAGTGCTGTAATA-CA-A-CAAAACTAAAT-TTCTTGGGTAGCTTT-ATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGAC---TT-CG-TGTCGCTAGTATGCATAT--TGCTTTACGCG-A---TATGCATTGATATTTTTATCAAGATACTTTGGAGTGA-GTACTTTGTACGTAA-AA-TAA-AATAAAAAAA-AGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTG-T-AATATT-TCA-TGAT-ATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTA-ATTAAAAAAACATATAATGATGT-TTC---ATAAGGTATGGTGTTGTTAATATGGTAGTGTCGT-C-TTGTC-ACGAC-AGCTTGTTATAAAGATGTAGTTTATTATGTCTTAAACAAGT-C---AATATCATATTAACGCAAAATAATCTTAGGTAGCTTTTATGTAAGAGCTTTAAAGACTTTTTTGCCTAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGTATATAATACCTT--GCGTATTGTATGCATTG--A-TTTT-TCATGATATTAATGTGTGATGTTGTTTATGCAAAACAATTAATAATAAAAAAATTGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCTAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATACGATTAGATTTTGATTAATAATCTCAATGATAATTGACAAAATCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||| ||| |||||| |||||||||||| |||   ||||||||| | |||| |  ||| || || |  | |  || |  || | |||| |||||||||||||||||||||||||||||| | ||| |   |||| || |  ||  | ||||  |||| ||||||||| ||  ||||||||||||||||| |||||| ||||||||||||||||||| ||   || ||  || ||||||||| ||||  | | ||  ||| |   |||||||||  | |||| ||| |||| |   | |||| ||  ||| | |  || || ||| ||||||||||  |||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||||||||||||| | |||| | ||| |||| ||| ||| | ||||||||||||||||||||||||||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>17</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|4</Hit_id>
+  <Hit_def>AB462267.1 Culicoides aterinervis genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: AM05_5</Hit_def>
+  <Hit_accession>4</Hit_accession>
+  <Hit_len>891</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>492.329</Hsp_bit-score>
+      <Hsp_score>266</Hsp_score>
+      <Hsp_evalue>8.8945e-142</Hsp_evalue>
+      <Hsp_query-from>170</Hsp_query-from>
+      <Hsp_query-to>561</Hsp_query-to>
+      <Hsp_hit-from>277</Hsp_hit-from>
+      <Hsp_hit-to>680</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>366</Hsp_identity>
+      <Hsp_positive>366</Hsp_positive>
+      <Hsp_gaps>24</Hsp_gaps>
+      <Hsp_align-len>410</Hsp_align-len>
+      <Hsp_qseq>AAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGAC---TT-CG-TGTCGCTAGTATGCATATTGCTTTACGCG-ATATGCATTGATATTTTTATCAAGATACTTTGGAGTGAGTA-----C----TTTGTACGTAAAATAA-AAT--AAAAAAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCATGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATG</Hsp_qseq>
+      <Hsp_hseq>AAATTTCTTAGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCTAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGCATA-CAC-TTAGTTGTGTATGCATTGATATTTT--TCATGATACTTTGGAGTGAGTATAATACAAAAATTGTACAT-AAATAATAATAAAAAAAAAAGATGAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTATAATATTTT-TGATATTCATAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATG</Hsp_hseq>
+      <Hsp_midline>||||||||| ||||||||||||||||||||||||||||||||||||| ||||||||||||||||||| ||   || ||  || |||||||||||||   | |||   |  ||||||||||||||||  ||| ||||||||||||||||||     |     |||||| | |||||| |||  ||||||||||| ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||||||||  ||||||||| |  |||||||||||||||||||||||||||||||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>119.306</Hsp_bit-score>
+      <Hsp_score>64</Hsp_score>
+      <Hsp_evalue>1.73901e-29</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>161</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>160</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>136</Hsp_identity>
+      <Hsp_positive>136</Hsp_positive>
+      <Hsp_gaps>15</Hsp_gaps>
+      <Hsp_align-len>168</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAAATATAATGATGTATTCTTTATAAGGTA-TGGTTGTTATCGTTGTTATT--A-CAGTGGCTTCG---GCAAGCTCGTTATAAAGATGTAGTTTATTATGTCTTAAGCGAGTGCTGTAATACA</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATA--AAAATA-TATAATGATG--TTCATTCTAAGGTTGTGGATGT-AT-GTTGTTATTGTAACAGCTATTTAGTTAGC-AGCTTGCTATAAAGATGTAGTTTATTATGTCTTAAGTAAGTGTTATGATACA</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||||  |||| | ||||||||||  ||| || ||||||  ||| ||| || |||||||||  | |||    || |   || |||| | |||||||||||||||||||||||||||||  |||| | | |||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>18</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|2</Hit_id>
+  <Hit_def>AB462265.1 Culicoides arakawae genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Kag02</Hit_def>
+  <Hit_accession>2</Hit_accession>
+  <Hit_len>907</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>475.709</Hsp_bit-score>
+      <Hsp_score>257</Hsp_score>
+      <Hsp_evalue>8.95765e-137</Hsp_evalue>
+      <Hsp_query-from>170</Hsp_query-from>
+      <Hsp_query-to>560</Hsp_query-to>
+      <Hsp_hit-from>304</Hsp_hit-from>
+      <Hsp_hit-to>702</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>357</Hsp_identity>
+      <Hsp_positive>357</Hsp_positive>
+      <Hsp_gaps>16</Hsp_gaps>
+      <Hsp_align-len>403</Hsp_align-len>
+      <Hsp_qseq>AAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGAC---TT-CG-TGTCGCTAGTATGCATATTGCTTTACGCGATATGCATTGATATTTTTATCAAGATACTTTGGAGTGA-GTACT----TTGTAC-GTAAAATA-AAATAAAAAAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCATGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTAT</Hsp_qseq>
+      <Hsp_hseq>AAATTACTTAGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCTAAGGCCCTGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGTATAT-ACTTAATTGTATATGCATTGATATTTT--TCATGATACTTTGGTGTGATATAATAAAAATGTACAATTTTGTACTAATAAAAAAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATAA-ATAATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTAT</Hsp_hseq>
+      <Hsp_midline>||||| ||| ||||||||||||||||||||||||||||||||||||| ||||||| ||||||||||| ||   || ||  || ||||||||| ||||  ||| |    |||||||||||||||||  ||| |||||||||| ||||  || |     |||||  |    ||  |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||   || |||||||||  ||||||||||||||||||||||||||||||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>128.539</Hsp_bit-score>
+      <Hsp_score>69</Hsp_score>
+      <Hsp_evalue>2.88947e-32</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>82</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>81</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>78</Hsp_identity>
+      <Hsp_positive>78</Hsp_positive>
+      <Hsp_gaps>1</Hsp_gaps>
+      <Hsp_align-len>82</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAAATATAATGATGTATTCTTTATAAGGTATGGTTGTT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAAATATAATGATGT-TCATTCATAAGGTATGGTTGTT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| |  || ||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>19</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|6</Hit_id>
+  <Hit_def>AB462269.1 Culicoides cylindratus genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Kag08, long type</Hit_def>
+  <Hit_accession>6</Hit_accession>
+  <Hit_len>820</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>473.863</Hsp_bit-score>
+      <Hsp_score>256</Hsp_score>
+      <Hsp_evalue>3.22174e-136</Hsp_evalue>
+      <Hsp_query-from>170</Hsp_query-from>
+      <Hsp_query-to>561</Hsp_query-to>
+      <Hsp_hit-from>235</Hsp_hit-from>
+      <Hsp_hit-to>619</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>357</Hsp_identity>
+      <Hsp_positive>357</Hsp_positive>
+      <Hsp_gaps>25</Hsp_gaps>
+      <Hsp_align-len>401</Hsp_align-len>
+      <Hsp_qseq>AAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGACTTCGTGTCGCTAGTATGCATATTGCTTTACGCGATATGCATTGATATTTTTATCAAGATACTTTGGAGTGAGTA-----C----TTTGTACGTAAAATAAAATAAAAAAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCATGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATG</Hsp_qseq>
+      <Hsp_hseq>AAATTTCTTAGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCTAAGGCCCCGTAAAACTAGTAAC-CCAT-T-GCGAGGTGGC-TA--G---TATGC-ATATGCATTGATATTTT--TCATGATACTTTGGAGTGAGTATAATACAAAAATTGTACATAAAA-CAAAT--AAAAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTATAATATTTT-TGATATTCATAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATG</Hsp_hseq>
+      <Hsp_midline>||||||||| ||||||||||||||||||||||||||||||||||||| ||||||||||||||||||| ||  | | | || ||   || ||  |   || || |||||||||||||||||  ||| ||||||||||||||||||     |     |||||| |||||  ||||  ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||||||||  ||||||||| |  |||||||||||||||||||||||||||||||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>102.686</Hsp_bit-score>
+      <Hsp_score>55</Hsp_score>
+      <Hsp_evalue>1.75136e-24</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>59</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>58</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>58</Hsp_identity>
+      <Hsp_positive>58</Hsp_positive>
+      <Hsp_gaps>1</Hsp_gaps>
+      <Hsp_align-len>59</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAAATATAATGATGT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAA-TATAATGATGT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||||||||||| |||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>20</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|10</Hit_id>
+  <Hit_def>AB462273.1 Culicoides ohmorii genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Kag05</Hit_def>
+  <Hit_accession>10</Hit_accession>
+  <Hit_len>825</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>451.703</Hsp_bit-score>
+      <Hsp_score>244</Hsp_score>
+      <Hsp_evalue>1.50957e-129</Hsp_evalue>
+      <Hsp_query-from>169</Hsp_query-from>
+      <Hsp_query-to>561</Hsp_query-to>
+      <Hsp_hit-from>201</Hsp_hit-from>
+      <Hsp_hit-to>614</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>365</Hsp_identity>
+      <Hsp_positive>365</Hsp_positive>
+      <Hsp_gaps>29</Hsp_gaps>
+      <Hsp_align-len>418</Hsp_align-len>
+      <Hsp_qseq>TAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGAC---TT-CG-TGTCGCTAGTATGCATATTGCTTTACGCGATATGCATTGATATTTTTATCAAGATACTTT-G-GAGTG---A-GT---------A-CTTTGTACGTA-A-A-ATA-AAATAAAAAAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCATGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATG</Hsp_qseq>
+      <Hsp_hseq>TAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGTATAT-ACTTAATTGTATATGCATTGATATTTTT--CATGATACTTTGGTGTGTGATAATATAAAAAAAAAATCTTTATATTTATATAGAGAGAAAAAAAAAAAATAAGAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTT-TGATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATG</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||   || ||  || ||||||||| ||||  ||| |    ||||||||||||||||||  || |||||||| | | |||   |  |         | |||| ||  || | | | | ||| |||||||| |  ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  |||||||||||  |||||||||||||||||||||||||||||||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>87.9128</Hsp_bit-score>
+      <Hsp_score>47</Hsp_score>
+      <Hsp_evalue>4.904e-20</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>59</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>60</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>57</Hsp_identity>
+      <Hsp_positive>57</Hsp_positive>
+      <Hsp_gaps>3</Hsp_gaps>
+      <Hsp_align-len>61</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTA-A-AAAAATATAATGATGT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTAT-TAACATAAAAATATAATGATGT</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||| | | | ||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>21</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|14</Hit_id>
+  <Hit_def>AB462277.1 Culicoides charadraeus genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: KC05_14</Hit_def>
+  <Hit_accession>14</Hit_accession>
+  <Hit_len>913</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>422.156</Hsp_bit-score>
+      <Hsp_score>228</Hsp_score>
+      <Hsp_evalue>1.1836e-120</Hsp_evalue>
+      <Hsp_query-from>169</Hsp_query-from>
+      <Hsp_query-to>560</Hsp_query-to>
+      <Hsp_hit-from>295</Hsp_hit-from>
+      <Hsp_hit-to>664</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>349</Hsp_identity>
+      <Hsp_positive>349</Hsp_positive>
+      <Hsp_gaps>38</Hsp_gaps>
+      <Hsp_align-len>400</Hsp_align-len>
+      <Hsp_qseq>TAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGAC---TT-CG-TGTCGCTAGTATGCATATTGCTTTACGCGATATGCATTGATATTTTTATCAAGATACTTTGGAGTGAGTACTTTGTACGTAAAATAAAATAAAA-AAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAAT--ATTTCATGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTAT</Hsp_qseq>
+      <Hsp_hseq>TAAATTTCTTAGGTAGCTTTATCGAAGAGCTTTAAAGACTTGTTTGCCTAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGCAT------TT----G---TGCATTGATA-TTTT-TCATGATACTTTGG--T--GT-GTTTGT--GT--AATAAAAAAAAATAAAAAATC-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATTGATATT-TGTTAT--A-A-AGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTAT</Hsp_hseq>
+      <Hsp_midline>|||||||||| ||||||||||| ||||||||||||||||||||||||| ||||||||||||||||||| ||   || ||  || ||||||||||||      ||    |   |||||||||| |||| ||| ||||||||||  |  ||  |||||  ||  ||||||| |||| |||| ||| |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  || |  || |||  | | |||||||||||||||||||||||||||||||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>97.1461</Hsp_bit-score>
+      <Hsp_score>52</Hsp_score>
+      <Hsp_evalue>8.14828e-23</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>82</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>83</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>76</Hsp_identity>
+      <Hsp_positive>76</Hsp_positive>
+      <Hsp_gaps>7</Hsp_gaps>
+      <Hsp_align-len>86</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTA-TATTAAA-AAAA--TATAATGATGTATTCTTTATAAGGTATGGTTGTT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTAATATAAAACAAAAATTATAATGATGTATTCTC-ATT-GGT-TGGTTGTT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||| ||| ||| ||||  ||||||||||||||||  ||  ||| ||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>22</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|7</Hit_id>
+  <Hit_def>AB462270.1 Culicoides dubius genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Isg23</Hit_def>
+  <Hit_accession>7</Hit_accession>
+  <Hit_len>1096</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>388.917</Hsp_bit-score>
+      <Hsp_score>210</Hsp_score>
+      <Hsp_evalue>1.20047e-110</Hsp_evalue>
+      <Hsp_query-from>170</Hsp_query-from>
+      <Hsp_query-to>560</Hsp_query-to>
+      <Hsp_hit-from>395</Hsp_hit-from>
+      <Hsp_hit-to>831</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>369</Hsp_identity>
+      <Hsp_positive>369</Hsp_positive>
+      <Hsp_gaps>46</Hsp_gaps>
+      <Hsp_align-len>437</Hsp_align-len>
+      <Hsp_qseq>AAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGAC---T-TCGT--G---TCGCTAGTA-TGCATAT---T-GCT-TTA-C-G-CGATATGCATT-GATATT--T-T-TAT-CAAGAT-AC-T-T---TG-GAGT-G--AGTACTT-TGTA-C-GT-AA-AATAAAA-TAAAAAAAAGA-TCA---AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCA--TGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTAT</Hsp_qseq>
+      <Hsp_hseq>AAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTAACCCATATAATATGAGGTAGCTAGTAATGCATATAAATAGTTGTTAACTGTCTTTATGCATTTGATATACATATATATTCATGATTATATATGAGTGTGTGTTGTCATTAGTTATTTAACTGGCAACAACAAAAATAAAAAAAAAAATTAAATAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATCTTAGTTGTTATTCACAGAATCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTAT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||   | |  |  |   | ||||||| |||||||   | | | ||| | | |  |||||||| |||||   | | ||| || ||| |  | |   || | || |  | || || | || | |  || || |||| ||||||||| | | |   ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| | |  || |||||||||| |||||||||||||||||||||||||||||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>73.1396</Hsp_bit-score>
+      <Hsp_score>39</Hsp_score>
+      <Hsp_evalue>1.37318e-15</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>52</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>51</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>48</Hsp_identity>
+      <Hsp_positive>48</Hsp_positive>
+      <Hsp_gaps>1</Hsp_gaps>
+      <Hsp_align-len>52</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAAATATA</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATA-AAAATATATATA</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||||  ||| | |||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+</Iteration_hits>
+  <Iteration_stat>
+    <Statistics>
+      <Statistics_db-num>22</Statistics_db-num>
+      <Statistics_db-len>18669</Statistics_db-len>
+      <Statistics_hsp-len>16</Statistics_hsp-len>
+      <Statistics_eff-space>14287260</Statistics_eff-space>
+      <Statistics_kappa>0.46</Statistics_kappa>
+      <Statistics_lambda>1.28</Statistics_lambda>
+      <Statistics_entropy>0.85</Statistics_entropy>
+    </Statistics>
+  </Iteration_stat>
+</Iteration>
+<Iteration>
+  <Iteration_iter-num>2</Iteration_iter-num>
+  <Iteration_query-ID>Query_2</Iteration_query-ID>
+  <Iteration_query-def>AB462262.1 Culicoides jacobsoni genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Kag14_1</Iteration_query-def>
+  <Iteration_query-len>774</Iteration_query-len>
+<Iteration_hits>
+<Hit>
+  <Hit_num>1</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|0</Hit_id>
+  <Hit_def>AB462263.1 Culicoides maculatus genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Kag12_1</Hit_def>
+  <Hit_accession>0</Hit_accession>
+  <Hit_len>764</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>780.406</Hsp_bit-score>
+      <Hsp_score>422</Hsp_score>
+      <Hsp_evalue>0</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>774</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>764</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>683</Hsp_identity>
+      <Hsp_positive>683</Hsp_positive>
+      <Hsp_gaps>60</Hsp_gaps>
+      <Hsp_align-len>799</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATACTAAAAAAATATAATGATGTATTCTTATATAAGGTTGGAGTGTTTGGTGGGTTGTTATTGCAGCGGCTTTGCCTTAACCGGCTTAGCAGCTCGCTATAAAGATGTAGTTTATTATGTCTTAAGCGAGTGCTGTGATACAACAAAAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGC-CCCGTAAAACTAGTGGCTCTTTTGACATTAGTATGCA--TATACTTTTGTATATGCATTGATTTT-TATCAAGATACTTTGGAGTGAGTACGAATGTACATA-AAAATAAAAAAAGATCTAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTT-GATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTGTGCCATCTCCTAACGGTGATGTGTCTCAAGTGCATGATGTGATCATATGGATGTAACAGTTCATATATCATTAATAAAGAGATATGGTTGTTGACGTGC-ATGTTTG-A-------CCATTATTTTTATCTAATAAATAAATA-ATTTTGGTATAAAATCAAGCG-TGTA-CTGTTTGACACAAAA---AT-CT-TTA-A-CTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTA-ACT--AAACATTCAATGATGTATTCTT---TAAGG-T--A-TGGTT-GT-CGTTGTTATTGCAGCAGC-CT--C-T---C-GC-GGGCAGCTTGCTATAAAGATGTAGTTTATTATGTCTTAAGCAAGTGTTGTGGTTCAACAAAAAATTACTTGGGTAGCTTTATTTAAGAGCTTTAAAGACTTGTTTGCCCAAGGCTCCCGTAAAACTAGTG-ATCTTGTTTCATTAGTATGCAATTATATTTATATATTTGCATTGATTTTATATCAAGATACTTTGGTGTGAGTACGTATGTACATATAAAACAAAAAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTTCGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTATTGTCTGAAAAGATAAATGT---AAGTGCATGATGTGATCATATGGAT-TWACT-TTCATATATCATTAATGGAG-GATATGGTTATCG-C-TGCTATGTTTGCACACTTGGCCATTATTTTTATTTAGTTAA-AAATATATATTGGTATAAAATCAAGTGGTGTAGCTG---G-CGCTAAAGCGATTCTATTCTATCTATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||| |||  ||| ||  ||||||||||||||   ||||| |  | || || ||  |||||||||||||| ||  |  | |   | ||   |||||| |||||||||||||||||||||||||||||||| |||| |||| | |||||||||||| |||||||||||||||  |||||||||||||||||||||||||||||| |||||||||||||||  |||| |  ||||||||||||  |||| || | ||| |||||||||||| |||||||||||||||| ||||||||| ||||||||| |||| ||||||||||| ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||   | ||  ||  |  |  |||   ||||||||||||||||||||||||| | ||  ||||||||||||||||  || ||||||||| | | | ||| ||||||| |       ||||||||||||| || | || ||||| || |||||||||||||||| | |||| |||   | | | |||   || || ||  | ||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>2</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|1</Hit_id>
+  <Hit_def>AB462264.1 Culicoides wadai genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Isg18_1</Hit_def>
+  <Hit_accession>1</Hit_accession>
+  <Hit_len>834</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>667.761</Hsp_bit-score>
+      <Hsp_score>361</Hsp_score>
+      <Hsp_evalue>0</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>668</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>696</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>605</Hsp_identity>
+      <Hsp_positive>605</Hsp_positive>
+      <Hsp_gaps>60</Hsp_gaps>
+      <Hsp_align-len>712</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATACTAAAAAAATATAATGATGTATTCTTATATAAG-GT-TGGAGTGTTTGGTGGGTTGTTATTGCAGCGGCTTTGCCT--TAACCGGCTTAGCAGCTCGCTATAAAGATGTAGTTTATTATGTCTTAAGCGAGTGCTGTGATACAACAA---AAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCC--GTAAAACTAGTGGCTCTTT-TG--AC----AT---TAGT-ATGCAT-ATA-CT-TT------T--G---T-ATATGCATTGATTTTTATCAAGATACTTTGGAGTGAGTACGAAT-GTAC-AT--AA-AAATAAAAAAAGATCTAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTTGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTGTGCCATCTCCTAACGGTGATGTGTCTC--AAGTGCATGATGTGATCATATGGATGTAACAGTTCATATATCATTAATAAAG-AG-ATATGGTTGTTGACGTGCATGTT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTAATCT-AAAACATTCAATGATGTATTCT--CACAAGTGTATGG-TTGTTGTTTCCGTTGTTATTGTAGCAGCTCGTCGTAATTATCGTC-GGGCAGCTTGCTATAAAGATGTAGTTTATTATGTCTTAAGCGAGTGCTGCAATACAACAATACAAAATTTCTTAGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCTAAGGCCCCCAGTAAAACTAGT-GATCTTTGTGTCACTAGTATGCATATTAATGCATAACATCTCTTCGGAGGTGCGCTTTGATATGCATTGATTTATATCAAGATACTTTGGAGTGAGTAC-ATTCGTACAATAAAACAAACAAAAAAAGATC-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTTGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATG--A-CTCGTT----TGAAC-GTCTCATAAGTGCATGATGTGATCATATGGATTTCGCGATTCATATATCATTAATAAAGGAGAATATGGTTGTTAACGTGCGTGTT</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||  || |||| ||  |||||||||||||   | ||| || |||  ||||   |  |||||||||| ||| |||   | |  | | || |   |||||| ||||||||||||||||||||||||||||||||||||||||  |||||||||   |||||||||| ||||||||||||||||||||||||||||||||||||| ||||||||  ||||||||||| | ||||| ||  ||    ||   || | |||||| | | || ||      |  |   | |||||||||||||| ||||||||||||||||||||||||| | | |||| ||  || ||| ||||||||||| ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||  | ||| |     |||   |||||  ||||||||||||||||||||||||| |  |  |||||||||||||||||||| || ||||||||||| |||||| ||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>71.293</Hsp_bit-score>
+      <Hsp_score>38</Hsp_score>
+      <Hsp_evalue>4.79952e-15</Hsp_evalue>
+      <Hsp_query-from>667</Hsp_query-from>
+      <Hsp_query-to>716</Hsp_query-to>
+      <Hsp_hit-from>711</Hsp_hit-from>
+      <Hsp_hit-to>761</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>47</Hsp_identity>
+      <Hsp_positive>47</Hsp_positive>
+      <Hsp_gaps>1</Hsp_gaps>
+      <Hsp_align-len>51</Hsp_align-len>
+      <Hsp_qseq>TTTGACCATTATTTTTATCTAATAAATAAAT-AATTTTGGTATAAAATCAA</Hsp_qseq>
+      <Hsp_hseq>TTTGACCATTATTTTTATTTAATAAAATAATAAATTTTGGTATAAAATCAA</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||| |||||||  ||| |||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>3</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|21</Hit_id>
+  <Hit_def>AB462284.1 Culicoides paraflavescens genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: OKYN05_13</Hit_def>
+  <Hit_accession>21</Hit_accession>
+  <Hit_len>842</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>641.908</Hsp_bit-score>
+      <Hsp_score>347</Hsp_score>
+      <Hsp_evalue>0</Hsp_evalue>
+      <Hsp_query-from>183</Hsp_query-from>
+      <Hsp_query-to>774</Hsp_query-to>
+      <Hsp_hit-from>248</Hsp_hit-from>
+      <Hsp_hit-to>842</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>526</Hsp_identity>
+      <Hsp_positive>526</Hsp_positive>
+      <Hsp_gaps>29</Hsp_gaps>
+      <Hsp_align-len>608</Hsp_align-len>
+      <Hsp_qseq>AAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGGCTC-TTTTGACAT---TAGTATGCATATACTT--TTGTATATGCATTGATTTTTATCAAGATACTTTGGAGTGAGTAC-GAATGTACATA--A-AAATAAAAAAA-GATCTAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTT-GATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTGTGCCATCTCCTAACGGT-GATGTGTCTCAAGTGCATGATGTGATCATATGGATGTAACAGTTCATATATCATTAATAAAGAGATATGGTTGT-TGACGTGCATGTTTGACCATTATTTTTATCTAATAAATAAATAATTTTGGTATAAAATCAAGCGTGTACTGTTTGACAC-AAAAAT-CTTTAACTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>AAAATTTCTTGGGTAGCTTTATTGAAGAGCTTTAAAGACTTATTTGCCCAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGCATACCCTTTATTGGGTATGCATTGATATTTTTCATGATACTTTGGTGTGAGTACTTATTGTACATATGATAAATAAAAAAACGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTTTGATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGCG-TCTC-TAGCGATAGAAGCG-CTTAAGTGCATGATGTGATTATATA-A-GTAAAA-TT-ATATATCATTAATAAAGGAATAAAATGGTATGAA-T-CATATTTAACCATTATTTTTATTTAAAAAATAACAAATTTTGGTATAAAATAGATA-TGTA-TGATT-ACCTTAAAAATTCTTTAT-TATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||| |||||||||||||||||| ||||||||||||||||||||||||||  | | ||  ||  |   |||||||||||  |||  |||  ||||||||||| ||| ||| |||||||||| ||||||||  | ||||||||  | ||||||||||| |||| ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||||||||||  |||||||||||||||||||||||||||||||||||||||||||||||||||||| |||  |||| || || | || | | || |||||||||||||||| ||||  | |||| | || |||||||||||||||||  |||   | || |||  | ||| ||| |||||||||||||| ||| ||||||  ||||||||||||||||  |   |||| || || ||   |||||| |||||  |||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>98.9927</Hsp_bit-score>
+      <Hsp_score>53</Hsp_score>
+      <Hsp_evalue>2.20163e-23</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>162</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>143</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>130</Hsp_identity>
+      <Hsp_positive>130</Hsp_positive>
+      <Hsp_gaps>21</Hsp_gaps>
+      <Hsp_align-len>163</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATACTAAAAAAATATAATGATGTATTCTTATATAAGGT-TGGAGTGTTTGGTGGGTTGTTATTGCAGCGGCTTTGCCTTAACCGGCTTAGCAGCTCGCTATAAAGATGTAGTTTATTATGTCTTAAG</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAACA-TATAATGATGT-TTCTT-TA-A-GGTATGG--TGTTTGATAT-TTGTTGAT--AGCTA-TTTGA-TTA---G-C--A--AGCTTACTATAAAGATGTAGTTTATTATGTCTTAAG</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||| ||||| | ||||||||||| ||||| || | ||| |||  |||||| |   |||||  |  |||   ||||  |||   | |  |  ||||  ||||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>4</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|12</Hit_id>
+  <Hit_def>AB462275.1 Culicoides punctatus genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Kag13_1</Hit_def>
+  <Hit_accession>12</Hit_accession>
+  <Hit_len>787</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>638.214</Hsp_bit-score>
+      <Hsp_score>345</Hsp_score>
+      <Hsp_evalue>0</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>774</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>787</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>668</Hsp_identity>
+      <Hsp_positive>668</Hsp_positive>
+      <Hsp_gaps>65</Hsp_gaps>
+      <Hsp_align-len>813</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATACTAAAAAAATATAATGATGTATTCTTATATAAGGTTGGAGTGTTTGGTGGGTTGTTATTGCAGCGGCTTTGCCTTAACCGGCTTAGCAGCTCGCTATAAAGATGTAGTTTATTATGTCTTAAGCGAGTGCTGTG-A-TACAAC-AAAAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGGCTC-TTTTGACAT---TAGTATGCATATACTT--TTGTATATGCATTGATTTTTATC-AAGATAC-TT--TG-GAG--TGA--GT-ACG-AA-TGTACAT--A-AAAATAAAAAAAGATCTAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTT-GATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTGTGCCATCTCCTAACGGTGATGTGTCTCAAGTGCATGATGTGATCATATGGATG-TAACAGTTCATATATCATTAATAAAGAGATATGGTTG----TTGACGT---GC-ATGTTTGACCATTATTTTTATCTAATAAATAAATAATTTTGGTATAAAATCAAGCGT-GTACT-GTTTG--ACACAAAA-ATCTTTAACTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATTAT-AAAACATATAATGATGT-TCATTCTAT-AGG-T--A-TGGTTGTTGTGTTGTCATTGTAAGAG---T-CATTTA---G-TTGGCAGCTCTCTATAAAGACATAGTTTATTATGTTTTAAGGGAGTACCTTGCAGTGCGACAAAAAAATTACTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGCATATACTTAATTGTATATGCATTGATTTATTTCAAAGATACATTGGAGAGAGTATAATTGTAATGAAATTGTACATAAACAAAACAAAAAAAG-TAAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTTCGATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTCTT-TC--A-C--TGAAA-GCAT-AAGTGCATGATGTGATTATATAGGTGATATCAACTTATATATCATTAATAAAGTGTGGTGGTAACAAATATACTTTAAGCTATGTTTGACCATTATTTTTATCTAAAAAATAATAAATTTTGGTATAAAATCAAATGTAGTGTTTGTTTGTTACTCATAACATCCATT--TATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||  | |||| |||||||||||| |  || ||| ||| |  | || ||| || ||||| |||| |   |   | | || |   | || ||||||| |||||||||  ||||||||||||| ||||| |||| |  || | | | || |||||||| |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  | | ||  ||  |   ||||||||||||||||  |||||||||||||||||| | || ||||||| ||   | |||  | |  || | | || |||||||  | |||| |||||||| |  ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||||||||||  |||||||||||||||||||||||||||||||||||||||||||||||||||||| || | | ||  | |  |||   |  | |||||||||||||||| |||| | || || ||  | ||||||||||||||||| |   ||||      |  || |   || ||||||||||||||||||||||||| ||||||  |||||||||||||||||||  || ||  | |||||  || || || |||  |   |||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>5</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|18</Hit_id>
+  <Hit_def>AB462281.1 Culicoides verbosus genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: OKYN05_18</Hit_def>
+  <Hit_accession>18</Hit_accession>
+  <Hit_len>805</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>564.348</Hsp_bit-score>
+      <Hsp_score>305</Hsp_score>
+      <Hsp_evalue>1.80599e-163</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>713</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>732</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>619</Hsp_identity>
+      <Hsp_positive>619</Hsp_positive>
+      <Hsp_gaps>71</Hsp_gaps>
+      <Hsp_align-len>758</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATACTAAAAAAATATAATGATGTATTCTT-ATATAAGGTTGGAGTGTTTGGTGGGTTGTTATTGCAGCGGCTTTGCCTTAACCGGCTTAGC-AGCTCGCTATAAAGATGTAGTTTATTATGTCTTAAGCGAGTGCTGTGATACAACAA------------AAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGGCTC-TTTTGACAT---TAGTATGCATATACTT--TTGTATATGCATTGATTTTTATCAAGATACTTTGGAGTG--AG--T---A--CGAA--TGTAC-ATAA-AAATA-AAAAAAGATCTAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTT-TGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTGTGCCATCTCCTAACGGTGATGTGTCTCAAGTGCATGATGTGATCATATG-GATGTAACAGTTCATATATCATTAATAAAGA-G-A--TATGGT--TGTTGACGTGCATGTTTGACCATTATTTTTATCTAATA-AA-TAA-ATAATTTTGGTATAAAAT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAAATATAATGATGT-TCATTCATAAAAGG-T--A-T-AACGGT-TGTTG-TCTTTCAATGGCT----ATT---C-ACTTAGCAAGCTTGCTATAAAAATGTAGTTTATTATGTTTTAAGCAAGTGTTGTTAGACAA-AAGGTTGGTTGTTCAAAATTACTTAGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCTAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGTATATACTTAATTGTATATGCATTGATATTTTTCATGATACTTTGGAGTGTGAGTATAAAATTAAAATTTGTACAAAAACAAAAACAAAAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATAAACTAATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTC-T-T--TAAAATTGA-GA-TAT-AAGTGCATGATGTGATCATATAAGCT-TAATTGCCTATATATCATTAATAAAGGTGGAGGTATGGTGCTATTGT-GTACATATTTAACCATCATTTTTATTTAATATAAATAATATAATTTTGGTATAAAAT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||| ||||||||||||||||||| |  || ||| |||| |  | |    |||  |||| | || ||  ||||     ||   |  |||||| |||| |||||||| |||||||||||||||| |||||| |||| ||| | |||| ||            |||||| ||| ||||||||||||||||||||||||||||||||||||| |||||||||||||||||||  | | ||  ||  |   ||||||| ||||||||  |||||||||||||||| ||| ||| ||||||||||||||  ||  |   |    ||  ||||| | || ||| | |||||||||| |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||    | |||||||||  |||||||||||||||||||||||||||||||||||||||||||||||||||||| || | | |  |||   ||| |  | | |||||||||||||||||||||  | | |||  |   |||||||||||||||||  | |  ||||||  | |||  || ||| ||| ||||| |||||||| ||||| || ||| ||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>6</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|5</Hit_id>
+  <Hit_def>AB462268.1 Culicoides cylindratus genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Kag08, short type</Hit_def>
+  <Hit_accession>5</Hit_accession>
+  <Hit_len>748</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>562.502</Hsp_bit-score>
+      <Hsp_score>304</Hsp_score>
+      <Hsp_evalue>6.4955e-163</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>563</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>544</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>491</Hsp_identity>
+      <Hsp_positive>491</Hsp_positive>
+      <Hsp_gaps>45</Hsp_gaps>
+      <Hsp_align-len>576</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATACTAAAAAAATATAATGATGTATTCTTATATAAGGTTGGAGTGTTTGGTGGGTTGTTATTGCAGCGGCTTTGCCTTAACCGGCTTAGCAGCTCGCTATAAAGATGTAGTTTATTATGTCTTAAGCGAGTGCTGTGATACAACAAAAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGGCTCTTTTGACATTAGTATGCATATACTTTTGTATATGCATTGATTTTTATCAAGATACTTTGGAGTGAGTA-----C--GAA-TGTACAT---A-AAAA-TAAAAAAAGATCTAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTTGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTAT----AAAATATATAATGATGT--TC--ATTCAA---T-AAG-G-TTGGT-GGTTG-TATTGTAACAGCTAT---TT-A----CTTAGCAGCTTGCTATAAAGATGTRGTTTATYATGTCTTAAGYAAGTGTTGYGATACARCAAAAAATTTCTTAGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCTAAGGCCCCGTAAAACTAGTAAC-CCATTG-C-GAGGT-GGC---TA-GTATGCATATGCATTGATATTTTTCATGATACTTTGGAGTGAGTATAATACAAAAATTGTACATAAAACAAAAYAAAAAAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTATAATATTTTTGATATTCATAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATAYATTAAACTATCTT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||    |||| ||||||||||||  ||  ||  ||   |  || | ||||| ||||| ||||| | | ||| |   || |    |||||||||| ||||||||||||| |||||| ||||||||||  |||| || |||||| ||||||||||||| ||||||||||||||||||||||||||||||||||||| |||||||||||||||||||  | |  ||| |    ||  ||   ||  | || |||||||||||| ||| ||| ||||||||||||||||||     |   || |||||||   | ||||  ||||||||||| |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| |||||||||||||||||| |  |||||||||||||||||||||||||||||||||||||||| |||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>7</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|19</Hit_id>
+  <Hit_def>AB462282.1 Culicoides humeralis genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Kag15_1</Hit_def>
+  <Hit_accession>19</Hit_accession>
+  <Hit_len>912</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>540.342</Hsp_bit-score>
+      <Hsp_score>292</Hsp_score>
+      <Hsp_evalue>3.04352e-156</Hsp_evalue>
+      <Hsp_query-from>183</Hsp_query-from>
+      <Hsp_query-to>774</Hsp_query-to>
+      <Hsp_hit-from>296</Hsp_hit-from>
+      <Hsp_hit-to>912</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>522</Hsp_identity>
+      <Hsp_positive>522</Hsp_positive>
+      <Hsp_gaps>43</Hsp_gaps>
+      <Hsp_align-len>626</Hsp_align-len>
+      <Hsp_qseq>AAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGGCTC-TTTTGACAT---TAGTATGCATATACTT--TTGTATATGCATTGATTTTTATCAAGATACTTTGGAGTGAGTA-----CG-AATGTACAT-AA-AA-ATAAAAAAA-GATCTAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTT-GATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTGTGCCATCTCCTAACGGTGATGTGTCTCAAGTGCATGATGTGATCATATGGATGTAACAGTTCATATATCATTAATAAAG-AGA-TATGGTTGT-T-G--A-CGTGCATGTTTGACCATTATTTTTATCTAATAAATAAATAATTTTGGTATAAAATCAAGCGTGT--A--CT----G-TTT-GACACAAAAATCTTTAACTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>AAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGCATACACTTAATTGAGTATGCATTGATATTTTTCATGATACTTTGGTGTGAGTATAATTTGTATTGTACATAAACAAGAAAAAAAAACGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTATCGATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTG-TGTCTTGAAAAAGACATCA-T-AAGTGCATGATGTGATTATATAAGCGCAAGC-TT-ATATATCATTAATAAAGGATAATATGGACGTATCGCTATCTTGCATACTTAACCATAATTTTTATTTGATT-ATAAATAATTTTGGTATAAAATGA-GTATGTCTAAGCTCTTAGCTTTCGCCTCTAAAA-CTTTAT-TATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  | | ||  ||  |   ||||||||||| ||||  |||  ||||||||||| ||| ||| |||||||||| |||||||      | | ||||||| || || | ||||||| |||| ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| | ||||||||||  |||||||||||||||||||||||||||||||||||||||||||||||||||||| ||   | || | |    ||  |   | |||||||||||||||| ||||    | ||   || ||||||||||||||||| | | |||||  || | |  | | |||||  || ||||| |||||||| | ||  |||||||||||||||||||||| | |  |||  |  ||    | ||| | | | |||| |||||  |||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>113.766</Hsp_bit-score>
+      <Hsp_score>61</Hsp_score>
+      <Hsp_evalue>7.86264e-28</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>70</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>70</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>68</Hsp_identity>
+      <Hsp_positive>68</Hsp_positive>
+      <Hsp_gaps>2</Hsp_gaps>
+      <Hsp_align-len>71</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATACTAAAAAAATATAATGATGTATTCTT-ATATA</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAAATATAATGATGT-TTCTTTATATA</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||| ||||||||||||||||||| ||||| |||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>3</Hsp_num>
+      <Hsp_bit-score>65.753</Hsp_bit-score>
+      <Hsp_score>35</Hsp_score>
+      <Hsp_evalue>2.233e-13</Hsp_evalue>
+      <Hsp_query-from>122</Hsp_query-from>
+      <Hsp_query-to>162</Hsp_query-to>
+      <Hsp_hit-from>111</Hsp_hit-from>
+      <Hsp_hit-to>152</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>40</Hsp_identity>
+      <Hsp_positive>40</Hsp_positive>
+      <Hsp_gaps>1</Hsp_gaps>
+      <Hsp_align-len>42</Hsp_align-len>
+      <Hsp_qseq>TTAGC-AGCTCGCTATAAAGATGTAGTTTATTATGTCTTAAG</Hsp_qseq>
+      <Hsp_hseq>TTAGCAAGCTTGCTATAAAGATGTAGTTTATTATGTCTTAAG</Hsp_hseq>
+      <Hsp_midline>||||| |||| |||||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>8</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|13</Hit_id>
+  <Hit_def>AB462276.1 Culicoides sumatrae genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: ONYK05_17</Hit_def>
+  <Hit_accession>13</Hit_accession>
+  <Hit_len>784</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>531.109</Hsp_bit-score>
+      <Hsp_score>287</Hsp_score>
+      <Hsp_evalue>1.83173e-153</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>774</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>784</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>653</Hsp_identity>
+      <Hsp_positive>653</Hsp_positive>
+      <Hsp_gaps>76</Hsp_gaps>
+      <Hsp_align-len>817</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTAT-ACT-AAAAAAATATAATGATGTATTCTTATATAAGGTTGGAGTGTTTGGTGGGTTGT-TATTGCAGCGGCTTTGCCTTAACCGGCTTAGCAGCTCGCTATAAAGATGTAGTTTATTATGTCTTAAGCGAGTGCT--GTGATACAACAAAAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGGCTC-TTTTGACAT---TAGTATGCATATACTT--TTGTATATGCATTGATTTTTATCAAGATACTTTGGAGTGA---------GT--A-C--GA-ATGTACATA-A-A-A--ATAAAAAAAG-ATCTAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTTGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTGTGCCATCTCCTAACGGTGATGTGTCTCAAGTGCATGATGTGATCATATGGATGTAACAGTTCATATATCATTAATAAAGAGATATG-GTTGTTGA-CG--TGC-A-TG--TTTGACCATTATTTTTATCTAATAAATAAAT-AATTTTGGTATAAAATCAAG--CGTGTACTGTTTGACACAAAAATCTTTAACTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATTATTAAAAAAAATATAATGATGT-TTC--ATTCAAGG-T--A-TGGTT-GT---TAATCTATTGCAATGGCTATTAATTTAGCAGCTTA-CA-C-CGCTATAAAGATGTGGTTTATCATATCTTAAGC-ATTCGTAGGTGTTGTGATAGAAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGTATATACTTAATTGTATATGCATTGATATTTTTCATGATACTTTGGTGTGATAATAAAAAGTAAATCTTTATATTTATATAGAGATAGGAAAAAAAAAGTAAAGAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTATCGATATTCACGAAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTTAT-T--TAATGGTAACGT-----AAGGGCATGTTGTGATTATATA-A-GTAAAA-TT-ATATATCACTAATAAAGT-ATATGAGATATGGAACAAATTTTAATGTATTTGACCATTATTTTTATTTAA-AATGATATGAATATTGGTTTAAA-TCAAATACAACTTTTGTTT-ATATATTATTATT-AT-TATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||| | | |||||||||||||||||| |||  ||  |||| |  | || || ||   |  | |||||||  |||| |   || | | ||||| || | |||||||||||||| |||||| || |||||||| | |  |  ||| |   | | ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  | | ||  ||  |   ||||||| ||||||||  |||||||||||||||| ||| ||| |||||||||| ||||         ||  | |   | || || ||| | | |  | |||||||| |   |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| | |||||||||  ||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||  || |  ||| ||| | ||     ||| ||||| |||||| ||||  | |||| | || |||||||| ||||||||  ||||| | | | || |   |   | ||  |||||||||||||||||| ||| ||  | || ||| ||||| |||| ||||   |   |  ||||| | | |  | | || |  |||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>9</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|20</Hit_id>
+  <Hit_def>AB462283.1 Culicoides matsuzawai genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: IS05_6</Hit_def>
+  <Hit_accession>20</Hit_accession>
+  <Hit_len>908</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>529.262</Hsp_bit-score>
+      <Hsp_score>286</Hsp_score>
+      <Hsp_evalue>6.58806e-153</Hsp_evalue>
+      <Hsp_query-from>183</Hsp_query-from>
+      <Hsp_query-to>774</Hsp_query-to>
+      <Hsp_hit-from>299</Hsp_hit-from>
+      <Hsp_hit-to>908</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>516</Hsp_identity>
+      <Hsp_positive>516</Hsp_positive>
+      <Hsp_gaps>40</Hsp_gaps>
+      <Hsp_align-len>621</Hsp_align-len>
+      <Hsp_qseq>AAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGGCTC-TTTTGACAT---TAGTATGCATATACTT--TTGTATATGCATTGATTTTTATCAAGATACTTTGGAGTGA-GTACGAA-TGTA-C-ATA-AAAATAAAAAAAGATCTAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTT-GATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTGTGCCATCTCCTAACGGTGATGTGTCTCAAGTGCATGATGTGATCATATGGATGTAACAGTTCATATATCATTAATAAAGAGATA---TGGT-TGTTGAC--G-T---GCATGTTTGACCATTATTTTTATCTAATA-AATAAATAATTTTGGTATAAAATCAAGC-GTGTA-CT-GT--TT-GACACAAAAATCTTTAACTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>AAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGCATACACTTARTTGAGTATGCATTGATATTTTTCATGATACTTTGGTGTGAAGTACATATTGTACCGATATAAACAAAAAAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTATCGATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTG-TCTTGAAAAAGA-ACAT-----AAGCGCATGATGTGATTATAAAAGTGTAAAAGCTTTTATATCACTAATAAAGGAATAAWATGGTGTTTTGCTTTGCTAAGGCATATTTAACCATAATTTTTATTTAATATAATATG-AATTTTGGTATAAAATGAATATGTCTAGCTTGGAATTCGCCTAAAAAACCATT---TATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  | | ||  ||  |   ||||||||||| ||||  |||  ||||||||||| ||| ||| |||||||||| |||| ||||  | |||| | ||| |||  ||||||||||| ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| | ||||||||||  |||||||||||||||||||||||||||||||||||||||||||||||||||||| ||   |||   ||  |  |  |     ||| |||||||||||| |||    ||||| || |  ||||||| ||||||||  |||   |||| | |||    | |   |||| ||| ||||| |||||||| ||||| ||||   |||||||||||||||| ||   || || || |   || | |  ||||| | ||   |||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>126.692</Hsp_bit-score>
+      <Hsp_score>68</Hsp_score>
+      <Hsp_evalue>1.00993e-31</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>181</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>172</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>150</Hsp_identity>
+      <Hsp_positive>150</Hsp_positive>
+      <Hsp_gaps>19</Hsp_gaps>
+      <Hsp_align-len>186</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATACTAAAAAAATATAATGATGTATTCTT-ATATAAGGTTGGAGTGTTTGGTGGGTTGTTATTG-CAGCGGCTTTGCCTTAACCGGCTTAGC-AGCTCGCTATAAAGATGTAGTTTATTAT-GTCTTAAGCGAGTGCTGTGATA-CAACA</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAAATATAATGATGT-TTCTTTATATAAGGTAT-A-TGGTTGTTATGTTGTC-TTGTCAACAGCTAT---TTGA-----TTAGCAAGCTTGCTATAAAGATGTAGTTTATTACGGTCTTAAGTAAGTG-T-TGACAGCAACA</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||| ||||||||||||||||||| ||||| |||||||||   | || ||| |  |||||  ||| || | ||| |   || |     ||||| |||| ||||||||||||||||||||||  ||||||||  |||| | ||| | |||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>10</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|15</Hit_id>
+  <Hit_def>AB462278.1 Culicoides erairai genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: IS05_2</Hit_def>
+  <Hit_accession>15</Hit_accession>
+  <Hit_len>931</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>518.182</Hsp_bit-score>
+      <Hsp_score>280</Hsp_score>
+      <Hsp_evalue>1.42606e-149</Hsp_evalue>
+      <Hsp_query-from>183</Hsp_query-from>
+      <Hsp_query-to>774</Hsp_query-to>
+      <Hsp_hit-from>309</Hsp_hit-from>
+      <Hsp_hit-to>931</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>524</Hsp_identity>
+      <Hsp_positive>524</Hsp_positive>
+      <Hsp_gaps>51</Hsp_gaps>
+      <Hsp_align-len>633</Hsp_align-len>
+      <Hsp_qseq>AAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGGCTC-TTTTGACAT---TAGTATGCATATACTTT--T--GTATATGCATTGATTTTTATCAAGATACTTTGGAGTGA--GTACG-A-ATGTAC--A--TAAAAA--T-AAAAAA-AGATCTAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTTGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTGTGCCATCTCC--T-AA-CGGTGATGTGTCTCAAGTGCATGATGTGATCATATGGATG-TAACAGTTCATATATCATTAATAAAG----A-GATATG-GT--T---GTTGACGTGCATGTTTGACCATTATTTTTATCTAATAAATAAATAATTTTGGTATAAAATCAA---GCGTGTACT--GTTTGACACAAAAATCTTTAACTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>AAAATTTCTTAGGTAGCTTTATTGAAGAGCTTTAAAGACTTGTATGCCTAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGCATATATTTTAATCGGTGTATGCATTGATATTTTTCATGATACTTTGGTGTGATATTTTGTATATTTACAAATGTAAAAATGTAAAAAAAGAGATC-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTACT-TATTCACAAAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTGTGATTTTTCTGGTGAAACAGA-AGCT-TA-CAAGTGCATGATGTGATCATATAGATGATTTCTGTCTATATATCATTAATAAAGTGGTATGATATGTGTACTAAAGTTGTGTTGCATATTTAACCATAATTTTTATTTAATAA-TAT-TAATTTTGGTATAAAATAAATAAGCACACACTTAGTTGTAT-CAAAAA-CTTTAAAT-TGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>|||||||||| ||||||||||| |||||||||||||||||||| |||| |||||||||||||||||||  | | ||  ||  |   ||||||||||||| |||  |  || ||||||||||| ||| ||| |||||||||| ||||   |  | | || |||  |  ||||||  | |||||| ||||| |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||    |||||||| ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||   | ||   | || | |  |  | |  |||||||||||||||||||||| |||| |  | ||  |||||||||||||||||    | |||||| ||  |   ||||   ||||| ||| ||||| |||||||| |||||| ||  ||||||||||||||||| ||   ||    |||  |||  |  |||||| |||||| | |||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>130.386</Hsp_bit-score>
+      <Hsp_score>70</Hsp_score>
+      <Hsp_evalue>7.80721e-33</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>187</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>175</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>152</Hsp_identity>
+      <Hsp_positive>152</Hsp_positive>
+      <Hsp_gaps>16</Hsp_gaps>
+      <Hsp_align-len>189</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATACTA-AAAAAATATAATGATGTATTCTTATATAAGGTTGGAGTGTTTGGTGGGTTGTTATTGCAGCGGCTTTGCCTTAACCGGCTTAGCAGCTCGCTATAAAGATGTAGTTTATTATGTCTTAAGCGAGTGCTG-TGATACAACAAAAAAT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTATAAAAAATATAATGATGTATCATTCTATAAG-T-GTA-TGGT-GGTTG-TTGTT-TCG-A-CAGCTAAAGTTTA-CT---TTAGCAGCCTACTATAAAGATGTAGTTTATTATGTCTTAAGT-A-TGGTGTTGATTCAACAAAAAAT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||| || |||||||||||||||||||  || |||||| | | | || | ||| | ||||| | | | | |||     ||| |    ||||||||   ||||||||||||||||||||||||||||||  | || || |||| |||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>11</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|2</Hit_id>
+  <Hit_def>AB462265.1 Culicoides arakawae genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Kag02</Hit_def>
+  <Hit_accession>2</Hit_accession>
+  <Hit_len>907</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>512.642</Hsp_bit-score>
+      <Hsp_score>277</Hsp_score>
+      <Hsp_evalue>6.63483e-148</Hsp_evalue>
+      <Hsp_query-from>183</Hsp_query-from>
+      <Hsp_query-to>774</Hsp_query-to>
+      <Hsp_hit-from>303</Hsp_hit-from>
+      <Hsp_hit-to>907</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>513</Hsp_identity>
+      <Hsp_positive>513</Hsp_positive>
+      <Hsp_gaps>43</Hsp_gaps>
+      <Hsp_align-len>620</Hsp_align-len>
+      <Hsp_qseq>AAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGGCTC-TTTTGACAT---TAGTATGCATATACTT--TTGTATATGCATTGATTTTTATCAAGATACTTTGGAGTG----AGTACGAATGTACA------TAAAAAT-AAAAAAAGATCTAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTTGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTGTGCCATCTCCTAACGGTGATGTGTCTCAAGTGCATGATGTGATCATAT--GGATGTAACAGTTCA--TATATCATTAATAAAG---AGATATGGTTGTTGACGTGCATGTTTGACCATTATTTTTATCTAATA-AATAAATAATTTTGGTATAAAATCAAGC-GTGTACT-GTTTGAC-ACAAAAATCTTTAACTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>AAAATTACTTAGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCTAAGGCCCTGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGTATATACTTAATTGTATATGCATTGATATTTTTCATGATACTTTGGTGTGATATAATAAAAATGTACAATTTTGTACTAATAAAAAAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATAAATAATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATATTATTTGAAAAAG-TAATAT-----AAGTGCATGATGTGATTATACAAGGCTTTAACAGG-CATGTATATCATTAATAAAGGATAGATATGGTAAATGA---GCATATTTAACCATTATTTTTATTTAAAATAATAAAGTATATTGGTATAAAATAAATATGTG-ACTTGCCTTATTACTTA---CTTTAATT-TGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>|||||| ||| ||||||||||||||||||||||||||||||||||||| ||||||| |||||||||||  | | ||  ||  |   ||||||| ||||||||  |||||||||||||||| ||| ||| |||||||||| |||    | ||  ||||||||      ||  ||| ||||||||||| |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||   | |||||||||  |||||||||||||||||||||||||||||||||||||||||||||||||||||| |   || |   || | | || |     |||||||||||||||| |||   || | ||||||  ||  ||||||||||||||||   |||||||||   |||   |||| ||| |||||||||||||| ||| | ||||||  || |||||||||||| ||   ||| ||| |  | |  ||  |   |||||| | |||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>104.533</Hsp_bit-score>
+      <Hsp_score>56</Hsp_score>
+      <Hsp_evalue>4.73209e-25</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>59</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>59</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>58</Hsp_identity>
+      <Hsp_positive>58</Hsp_positive>
+      <Hsp_gaps>0</Hsp_gaps>
+      <Hsp_align-len>59</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATACTAAAAAAATATAATGATGT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAAATATAATGATGT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||| |||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>12</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|11</Hit_id>
+  <Hit_def>AB462274.1 Culicoides peregrinus genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Yng26</Hit_def>
+  <Hit_accession>11</Hit_accession>
+  <Hit_len>794</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>507.102</Hsp_bit-score>
+      <Hsp_score>274</Hsp_score>
+      <Hsp_evalue>3.08689e-146</Hsp_evalue>
+      <Hsp_query-from>185</Hsp_query-from>
+      <Hsp_query-to>774</Hsp_query-to>
+      <Hsp_hit-from>190</Hsp_hit-from>
+      <Hsp_hit-to>794</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>516</Hsp_identity>
+      <Hsp_positive>516</Hsp_positive>
+      <Hsp_gaps>53</Hsp_gaps>
+      <Hsp_align-len>624</Hsp_align-len>
+      <Hsp_qseq>AATTTCTTGGGTAGCTTTA--TAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGGCTC-TTTTGACAT---TAGTATGCATATACTT--TTGTATATGCATTGAT-TT-TTATCAAGATACTTTGGAGTGA------G---TACG-A--A---TGTACATA-AAAATAAAAAAAGATCTAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTTGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTGTGCCATCTCCTAACGGTGATGTGTCTCAAGTGCATGATGTGATCATATGGA--TGTAACAG---TTCATATATCATTAATAAAGAGATATGGTTGTTGACGTGCATGTTTGACCATTATTTTT-ATCTAAT-AAATAAATAATTTTGGTATAAAATCAAGCGTGTACTGTTTGACACAAAAATCTTTAAC-TATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>AATTTCTTGGGTAGCTTTAATTTTAAGAGCTTTAAAGACTTTTTTGCCCAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGTATATACTTAATTGTATATACATTGATATTATTTTCATGATACTTTGGTGTGAAATAAAGTTATAAGTACTATTTTGTACATATAAAAAAAAAAAAGATCTAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCMTGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTTGATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTAT--ATTTTTTTAA---TAAAATAT---AAGTGCATGATGTGATTATATGAAAATGTAATATTTTTTCATATATCATTAATAAATATATAAAATTGGTG---T--ATATTTGACCATTATTTTTTATTTAATTAAAATAATAATATTGGTTTAAA-TCAAA--TATA-TATT-GAGA-AATATTGTTTTATTTATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||  |  ||||||||||||||||| ||||||||||||||||||||||||||  | | ||  ||  |   ||||||| ||||||||  |||||||| ||||||| || || ||| |||||||||| ||||      |   || | |  |   |||||||| |||| |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  |||||||||||||||||||||||||||||||||||||||||||||||||||||| |    | |  |||   | |  | |   |||||||||||||||| ||||| |  ||||| |    ||||||||||||||||||| | |||   ||| ||   |  || |||||||||||||||| || |||| |||  |||||| ||||| |||| ||||   | || | || || | || | | ||| |  |||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>98.9927</Hsp_bit-score>
+      <Hsp_score>53</Hsp_score>
+      <Hsp_evalue>2.20163e-23</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>59</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>60</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>58</Hsp_identity>
+      <Hsp_positive>58</Hsp_positive>
+      <Hsp_gaps>1</Hsp_gaps>
+      <Hsp_align-len>60</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATAC-TAAAAAAATATAATGATGT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATATAAAAAAATATAATGATGT</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||||  |||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>13</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|17</Hit_id>
+  <Hit_def>AB462280.1 Culicoides kibunensis genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: AM05_6</Hit_def>
+  <Hit_accession>17</Hit_accession>
+  <Hit_len>817</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>503.409</Hsp_bit-score>
+      <Hsp_score>272</Hsp_score>
+      <Hsp_evalue>3.99314e-145</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>774</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>817</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>662</Hsp_identity>
+      <Hsp_positive>662</Hsp_positive>
+      <Hsp_gaps>83</Hsp_gaps>
+      <Hsp_align-len>837</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATACTAAAAAAATATAATGATGTATTCTTATATAAGGTTGGAGTGTTTGGTGGGTTGTTATTGCAGCGGCTTTGCCTTAACCGGCTTAGCAGCTCGCTATAAAGATGTAGTTTATTATGTCTTAAGCGAGTGCTGTGATACAA-CA---A----AAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGGCTC-TTTTGACAT---TAGTATGCATATAC---T---TTTGTATATGCATTGATTTTTATCAAGATACTTTGGAGTGAGTA--------CGAA--TGTACA-TAA-AAA-TAAAAAAAGATCTAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTT--TGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTT--GTGCCATCTC--CTAACGGT-GATGTGTCTCAAGTGCATGATGTGATCATATG-GATGT-AACAGTTCATATATCATTAATAAAGAGATATGGTTGTTGAC--GTGCAT--G----T-TTG-ACCATTATTTTTATCTA--ATAAATAAATAATTTTGGTATAAAATCAAGC-GTGT---ACTGTT-TGA-C-A--CAAA-AAT-CTTTAACTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAAATATAATGATGTAT-CAT-TCTAAGG-T--A-TGGTT-GT--TTTGTCTCT-CAACAGC--T--ATTAA----CTTGGCAGCTTACT-CAAAGATGTAGCTTATTATGTTTTAAGTAAGTGTTGTTAGACAATCAGGTATGGTGAAATTWCTTAGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCTAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGCATATACAAGTAAAATTGTATATGCATTGATATTTTTCATGATACTTTGGTGTGAGTATAAAATTAATAATTTGTACAWAAACAAACAAAAAAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTCAAACTATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTGTTTTGTTGTCTAACAACAGCAGAAGCATAAGTGCATGATGTGATCATATAAGCTTTTAATYGCYTATATATCATTAATAAAGGTATAAGTATGGTAACAAGTGCTTTTGCACATATTTAACCATAATTTTTATTTAATATAAATATATAATTTTGGTATAAAATGAATATGTGTTGYAC-GTTGTAAGCTATACAAAGAAAACTTTAAAATTGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||| ||||||||||||||||||||| | | | ||||| |  | || || ||   ||||   | || | ||  |   ||||    ||| ||||||  ||  |||||||||| ||||||||| |||||  |||| ||| | |||| ||   |     ||||| ||| ||||||||||||||||||||||||||||||||||||| |||||||||||||||||||  | | ||  ||  |   ||||||||||||||   |    |||||||||||||||| ||| ||| |||||||||| |||||||          ||  ||||||  || |||  ||||||||||| ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||      |||||||||  ||||||||||||||||||||||||||||||||||||||||||||||||||||||  |||   | |   |||||    |  |   |  |||||||||||||||||||||  | | | ||  |   |||||||||||||||||  ||| |  || | ||  |||| |  |    | ||  ||||| |||||||| ||  ||||||| |||||||||||||||||| ||   ||||   || ||| | | | |  |||| ||  ||||||   |||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>14</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|3</Hit_id>
+  <Hit_def>AB462266.1 Culicoides japonicus genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Ngs24_1</Hit_def>
+  <Hit_accession>3</Hit_accession>
+  <Hit_len>925</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>501.562</Hsp_bit-score>
+      <Hsp_score>271</Hsp_score>
+      <Hsp_evalue>1.43619e-144</Hsp_evalue>
+      <Hsp_query-from>183</Hsp_query-from>
+      <Hsp_query-to>774</Hsp_query-to>
+      <Hsp_hit-from>316</Hsp_hit-from>
+      <Hsp_hit-to>925</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>518</Hsp_identity>
+      <Hsp_positive>518</Hsp_positive>
+      <Hsp_gaps>54</Hsp_gaps>
+      <Hsp_align-len>628</Hsp_align-len>
+      <Hsp_qseq>AAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGGCTC-TTTTGACAT---TAGTATGCATATACTT--TTGTATATGCATTGATTTTTATCAAGATACTTTGGAGTGA-----GT---AC-GAATGTACATAAAAATAAAAAAA--GATCTAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTTGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTGTGCCATCTCCTAACGGTGATGTGTCTCAAGTGCATGATGTGATCATATG-GATGTAACAGTTCATATATCATTAATAAAGA-G--ATA--TGGTTGTTGA--CG-TGCATGTTTGACCATTATTTTTATCTAATAAATAAATAATTTTGGTATAAAATCAAGC-GTGTAC---TGTTT-G--AC-AC-AAAAATCTTTAACTA-TGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>AAAATTACTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGTATATACTTAGTTGTATATGCATTGATATTTTTCATGATACTTTGGTGTGATTTTTGTAAAACAAAATATA-AT-AAAATAAAAAAATTGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATATTACTTATTCACAAAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATG---T-T--T---G-T--TGCAT---AAGTGCATGATGTGATCATATAAGCTTTATTGCTT-ATATATCATTAATAAAGGTGTGATAAATGGTACAAAATACTTTGCATATTTAACCATTATTTTTATTTAACATGAAAATAATTTTGGTATAAAATAAATATGTCTAAGAGTGTTTAGTTACTATTAAAAAAATTTTAAAATTGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>|||||| |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  | | ||  ||  |   ||||||| ||||||||  |||||||||||||||| ||| ||| |||||||||| ||||     ||   ||  ||| || || ||||||||||||  |||| ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||   |||||||| ||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||   | |  |   | |  ||  |   |||||||||||||||||||||  | | ||    || |||||||||||||||||  |  |||  ||||     |  |  ||||| ||| |||||||||||||| ||| |   |||||||||||||||||||| ||   || ||    ||||| |  || |  |||||  ||| |  | |||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>130.386</Hsp_bit-score>
+      <Hsp_score>70</Hsp_score>
+      <Hsp_evalue>7.80721e-33</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>174</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>170</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>143</Hsp_identity>
+      <Hsp_positive>143</Hsp_positive>
+      <Hsp_gaps>10</Hsp_gaps>
+      <Hsp_align-len>177</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATACTAAAAAAATATAATGATGTATT-CTTATAT-AAGGT-TGGAGTGTTTGGTGGGTTGTTATTGCAGCGGCTTTGCCTTAACCGGCTTAGCAGCTCGCTATAAAGATGTAGTTTATTATGTCTTAAGCGAGTGCTGTGA</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAAATATAATGATGTATCACTTATATTAAGGTATTGGTTGTTTATTGTGT-GTTGAAGCAGCAGCTATT--TTAATA----TAGCAGCTTACTATAAAAATATAGTTTATTATATTTTAAGTAAGTGCTGTGA</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||| |||||||||||||||||||||  ||||||| ||||| | |  |||||  || || |||   ||||| ||| |   ||||      ||||||||  ||||||| || ||||||||||| | |||||  ||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>15</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|9</Hit_id>
+  <Hit_def>AB462272.1 Culicoides nipponensis genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Isg22</Hit_def>
+  <Hit_accession>9</Hit_accession>
+  <Hit_len>794</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>490.482</Hsp_bit-score>
+      <Hsp_score>265</Hsp_score>
+      <Hsp_evalue>3.1088e-141</Hsp_evalue>
+      <Hsp_query-from>184</Hsp_query-from>
+      <Hsp_query-to>566</Hsp_query-to>
+      <Hsp_hit-from>183</Hsp_hit-from>
+      <Hsp_hit-to>570</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>353</Hsp_identity>
+      <Hsp_positive>353</Hsp_positive>
+      <Hsp_gaps>15</Hsp_gaps>
+      <Hsp_align-len>393</Hsp_align-len>
+      <Hsp_qseq>AAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGGCTC-TTTTGACAT---TAGTATGCATATACTTTTGTATATGCATTGATTTTTATCAAGATACTTTGGAGTGAGTACGAATGTACATAAAAATAAAAAAAGATCT---AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATAT-TTTT-GATATTCACA-GAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTGTG</Hsp_qseq>
+      <Hsp_hseq>AAATTTCTTGGGTAGCTTTATTGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGTATATATTCATTTATATACATTGATATTTTTCATGATACTTTGGATTGA-TATG-AT-AAAACAAACAAAAAAAAAG-TGTAAGAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATATTTTTGATATTCACAAGA-TCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTGTG</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||| |||||||||||||||||||||||||||||||||||||||||||||  | | ||  ||  |   ||||||| ||||| |  | ||||| ||||||| ||| ||| ||||||||||| ||| || | ||  | | ||| | |||||||| | |   ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| |||| |||||||||| || ||||||||||||||||||||||||||||||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>91.6061</Hsp_bit-score>
+      <Hsp_score>49</Hsp_score>
+      <Hsp_evalue>3.6841e-21</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>59</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>58</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>56</Hsp_identity>
+      <Hsp_positive>56</Hsp_positive>
+      <Hsp_gaps>1</Hsp_gaps>
+      <Hsp_align-len>59</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATACTAAAAAAATATAATGATGT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATTATAAAAAA-TATAATGATGT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||  ||||||| |||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>16</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|4</Hit_id>
+  <Hit_def>AB462267.1 Culicoides aterinervis genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: AM05_5</Hit_def>
+  <Hit_accession>4</Hit_accession>
+  <Hit_len>891</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>490.482</Hsp_bit-score>
+      <Hsp_score>265</Hsp_score>
+      <Hsp_evalue>3.1088e-141</Hsp_evalue>
+      <Hsp_query-from>183</Hsp_query-from>
+      <Hsp_query-to>563</Hsp_query-to>
+      <Hsp_hit-from>276</Hsp_hit-from>
+      <Hsp_hit-to>677</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>360</Hsp_identity>
+      <Hsp_positive>360</Hsp_positive>
+      <Hsp_gaps>21</Hsp_gaps>
+      <Hsp_align-len>402</Hsp_align-len>
+      <Hsp_qseq>AAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGGCTC-TTTTGACAT---TAGTATGCATATACTT--TTGTATATGCATTGATTTTTATCAAGATACTTTGGAGTGAGTA-----C--GAA-TGTACAT--A-AA-AAT---AAAAAAAGATCTAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTTGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTT</Hsp_qseq>
+      <Hsp_hseq>AAAATTTCTTAGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCTAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGCATACACTTAGTTGTGTATGCATTGATATTTTTCATGATACTTTGGAGTGAGTATAATACAAAAATTGTACATAAATAATAATAAAAAAAAAAGATGAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTATAATATTTTTGATATTCATAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTT</Hsp_hseq>
+      <Hsp_midline>|||||||||| ||||||||||||||||||||||||||||||||||||| |||||||||||||||||||  | | ||  ||  |   ||||||||||| ||||  |||| ||||||||||| ||| ||| ||||||||||||||||||     |   || |||||||  | || |||   ||||||||||  |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| |||||||||||||||||| |  ||||||||||||||||||||||||||||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>124.846</Hsp_bit-score>
+      <Hsp_score>67</Hsp_score>
+      <Hsp_evalue>3.63234e-31</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>178</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>160</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>144</Hsp_identity>
+      <Hsp_positive>144</Hsp_positive>
+      <Hsp_gaps>18</Hsp_gaps>
+      <Hsp_align-len>178</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATACTAAAAAAATATAATGATGTATTCTTATATAAGGTTGGAGTGTTTGGTGGGTTGTTATTGCAGCGGCTTTGCCTTAACCGGCTTAGCAGCTCGCTATAAAGATGTAGTTTATTATGTCTTAAGCGAGTGCTGTGATACA</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATA--AAAATA-TATAATGATGT-T-CAT-TCTAAGGTTGT-G-GAT--GTATGTTGTTATTGTAACAGCTAT---TTA---G--TTAGCAGCTTGCTATAAAGATGTAGTTTATTATGTCTTAAGTAAGTGTTATGATACA</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||||  |||| | ||||||||||| | | | | ||||||||  | | |  ||  |||||||||| | | ||| |   |||   |  ||||||||| |||||||||||||||||||||||||||||||  |||| | |||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>17</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|8</Hit_id>
+  <Hit_def>AB462271.1 Culicoides lungchiensis genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: AM05_8</Hit_def>
+  <Hit_accession>8</Hit_accession>
+  <Hit_len>776</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>483.096</Hsp_bit-score>
+      <Hsp_score>261</Hsp_score>
+      <Hsp_evalue>5.20213e-139</Hsp_evalue>
+      <Hsp_query-from>184</Hsp_query-from>
+      <Hsp_query-to>563</Hsp_query-to>
+      <Hsp_hit-from>182</Hsp_hit-from>
+      <Hsp_hit-to>582</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>359</Hsp_identity>
+      <Hsp_positive>359</Hsp_positive>
+      <Hsp_gaps>23</Hsp_gaps>
+      <Hsp_align-len>402</Hsp_align-len>
+      <Hsp_qseq>AAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGGCTC-TTTTGACAT---TAGTATGCATATAC---T-TTTGTATATGCATTGAT-TTTTATCAAGATACTTTGG-----AG------TGAGTACGAA--TGTACATAAAAATAAAAAAAGATCTAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTTGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTT</Hsp_qseq>
+      <Hsp_hseq>AAATTACTTGGGTAGCTTTATTGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGTATATACATTTATTTGTATATACATTGATATTTTTTCATGATACTTTGGTATAAAGAAAAAAAAAGTACAATTTTGTACATATAAA-AAAAAAAGATCTAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTTGATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTT</Hsp_hseq>
+      <Hsp_midline>||||| ||||||||||||||| |||||||||||||||||||||||||||||||||||||||||||||  | | ||  ||  |   ||||||| ||||||   | ||||||||| ||||||| |||| ||| ||||||||||     ||        ||||| |   |||||||| ||| |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  ||||||||||||||||||||||||||||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>95.2994</Hsp_bit-score>
+      <Hsp_score>51</Hsp_score>
+      <Hsp_evalue>2.84798e-22</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>75</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>75</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>70</Hsp_identity>
+      <Hsp_positive>70</Hsp_positive>
+      <Hsp_gaps>6</Hsp_gaps>
+      <Hsp_align-len>78</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTA-TACTAAAAAAATATAATGATGTATTCTTAT-ATAAG-GTT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATTAAAAAAAAAATATAATGATGT-T-CT-ATCATAAGTGTT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||| ||  |||||||||||||||||| | || || ||||| |||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>18</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|6</Hit_id>
+  <Hit_def>AB462269.1 Culicoides cylindratus genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Kag08, long type</Hit_def>
+  <Hit_accession>6</Hit_accession>
+  <Hit_len>820</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>479.403</Hsp_bit-score>
+      <Hsp_score>259</Hsp_score>
+      <Hsp_evalue>6.72938e-138</Hsp_evalue>
+      <Hsp_query-from>183</Hsp_query-from>
+      <Hsp_query-to>563</Hsp_query-to>
+      <Hsp_hit-from>234</Hsp_hit-from>
+      <Hsp_hit-to>616</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>350</Hsp_identity>
+      <Hsp_positive>350</Hsp_positive>
+      <Hsp_gaps>18</Hsp_gaps>
+      <Hsp_align-len>391</Hsp_align-len>
+      <Hsp_qseq>AAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGGCTCTTTTGACATTAGTATGCATATACTTTTGTATATGCATTGATTTTTATCAAGATACTTTGGAGTGAGTA-----C--GAA-TGTACATAAAA-ATA-AAAAAAGATCTAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTTGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTT</Hsp_qseq>
+      <Hsp_hseq>AAAATTTCTTAGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCTAAGGCCCCGTAAAACTAGTAAC-CCATTG-C-GAGGT-GGC---TA-GTATGCATATGCATTGATATTTTTCATGATACTTTGGAGTGAGTATAATACAAAAATTGTACATAAAACAAATAAAAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTATAATATTTTTGATATTCATAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTT</Hsp_hseq>
+      <Hsp_midline>|||||||||| ||||||||||||||||||||||||||||||||||||| |||||||||||||||||||  | |  ||| |    ||  ||   ||  | || |||||||||||| ||| ||| ||||||||||||||||||     |   || ||||||||||| | | |||||||||| |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| |||||||||||||||||| |  ||||||||||||||||||||||||||||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>97.1461</Hsp_bit-score>
+      <Hsp_score>52</Hsp_score>
+      <Hsp_evalue>7.91846e-23</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>59</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>58</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>57</Hsp_identity>
+      <Hsp_positive>57</Hsp_positive>
+      <Hsp_gaps>1</Hsp_gaps>
+      <Hsp_align-len>59</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATACTAAAAAAATATAATGATGT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAA-TATAATGATGT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||| ||||||| |||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>19</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|10</Hit_id>
+  <Hit_def>AB462273.1 Culicoides ohmorii genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Kag05</Hit_def>
+  <Hit_accession>10</Hit_accession>
+  <Hit_len>825</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>466.476</Hsp_bit-score>
+      <Hsp_score>252</Hsp_score>
+      <Hsp_evalue>5.23906e-134</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>651</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>697</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>562</Hsp_identity>
+      <Hsp_positive>562</Hsp_positive>
+      <Hsp_gaps>58</Hsp_gaps>
+      <Hsp_align-len>703</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTAT-ACTAAAAAAATATAATGATGT--ATTCTTATATAAGGTTGGAGTGTTTGGTG-GGTTGTTATTGCAGCGGCTTTGCCTTAACCGGCTTAGCAGCTC-GC-TATAAAGATGTAGTTTAT--TA---T---GT---C-TTA--AGCGAGTGCTGTGATA-CAA-CAAAAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGGCTC-TTTTGACAT---TAGTATGCATATACTT--TTGTATATGCATTGATTTTTATCAAGATACTTTGG--AGTG---A-GT---------A-C--GA-ATGTACATA-A-A-AATAAAAAAAGAT--CTAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTTGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTGTGCCATCTCCTAACGGTGATGTGTCTCAAGTGCATGATGTGATCATATGGATGTAACAGTTCATATATCATTAATAAAGAGATATGG</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATTAACATAAAAATATAATGATGTTCATTCATATATATGAAAAAAG-GTATGGTGTTGTTGCTATTACAAYAGCTATTAATTTAGCAGCTT-GCA--TCAACTTATAAAGATGTGGTTTATCATATCTTAAAGTACACATTATTAGTAAGTGTTGTAATAGAAAGGTKTAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGTATATACTTAATTGTATATGCATTGATATTTTTCATGATACTTTGGTGTGTGATAATATAAAAAAAAAATCTTTATATTTATATAGAGAGAAAAAAAAAAAATAAGAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTTGATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTTATTTG-TAAAAAAAAGAAGCAT-AAGTGCATGATGTGATTATATAAATACATCAATTTATATATCACTAATAAAAAGGTATGG</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||| |  | ||||||||||||||||  |||| |||||| |     || || |||||  |||| |||| ||   ||| |   || | | |||| |||  ||  | ||||||||||| ||||||  ||   |   ||   | |||  ||  |||| ||| |||  ||     |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  | | ||  ||  |   ||||||| ||||||||  |||||||||||||||| ||| ||| ||||||||||   |||   |  |         | |   | || || ||| | | || ||||||| ||    |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  |||||||||||||||||||||||||||||||||||||||||||||||||||||| ||  || |  |||     |   |  | |||||||||||||||| ||||  ||  | || || |||||||| ||||||| || |||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>20</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|14</Hit_id>
+  <Hit_def>AB462277.1 Culicoides charadraeus genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: KC05_14</Hit_def>
+  <Hit_accession>14</Hit_accession>
+  <Hit_len>913</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>435.083</Hsp_bit-score>
+      <Hsp_score>235</Hsp_score>
+      <Hsp_evalue>1.47741e-124</Hsp_evalue>
+      <Hsp_query-from>184</Hsp_query-from>
+      <Hsp_query-to>563</Hsp_query-to>
+      <Hsp_hit-from>296</Hsp_hit-from>
+      <Hsp_hit-to>662</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>339</Hsp_identity>
+      <Hsp_positive>339</Hsp_positive>
+      <Hsp_gaps>23</Hsp_gaps>
+      <Hsp_align-len>385</Hsp_align-len>
+      <Hsp_qseq>AAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGGCTCTTTTGACATTAGTATGC-A-TATACTTTTGTATATGCATTGATTTTTATCAAGATACTTTGGAGTGAGTACGAATGTACATAAAAATAAA-AAAAGATCTAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAAT--ATTTTTGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTT</Hsp_qseq>
+      <Hsp_hseq>AAATTTCTTAGGTAGCTTTATCGAAGAGCTTTAAAGACTTGTTTGCCTAAGGCCCCGTAAAACTAGTAAC-CCATTG-C-GAGGT-GGCTAGTATGCATTTG----TGCATTGATATTTTTCATGATACTTTGG--TGTGTTTG--TGTA-ATAAAAAAAAATAAAAAATC-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATTGATATTTGTTAT--A-A-AGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTT</Hsp_hseq>
+      <Hsp_midline>||||||||| ||||||||||| ||||||||||||||||||||||||| |||||||||||||||||||  | |  ||| |    ||  || | ||| | ||||    ||||||||| ||| ||| ||||||||||  || ||  |  |||| ||||||| ||| |||| ||| |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  || |||| |||  | | |||||||||||||||||||||||||||||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>89.7595</Hsp_bit-score>
+      <Hsp_score>48</Hsp_score>
+      <Hsp_evalue>1.32504e-20</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>64</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>68</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>63</Hsp_identity>
+      <Hsp_positive>63</Hsp_positive>
+      <Hsp_gaps>6</Hsp_gaps>
+      <Hsp_align-len>69</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTA-TACTAAAA-AAA---TATAATGATGTATTCT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTAATA-TAAAACAAAAATTATAATGATGTATTCT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||| || ||||| |||   ||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>21</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|16</Hit_id>
+  <Hit_def>AB462279.1 Culicoides oxystoma genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Naha16_1</Hit_def>
+  <Hit_accession>16</Hit_accession>
+  <Hit_len>796</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>422.156</Hsp_bit-score>
+      <Hsp_score>228</Hsp_score>
+      <Hsp_evalue>1.15022e-120</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>562</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>572</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>482</Hsp_identity>
+      <Hsp_positive>482</Hsp_positive>
+      <Hsp_gaps>56</Hsp_gaps>
+      <Hsp_align-len>595</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATACT-AAAAAA-ATATAATGATGTATTCTTATATAAGGTTGGAGTGTTTGGTGGGTTGTTATTGCAGCGGCTTTGCCTTAACCGGCTTAGCAGCTCGCTATAAAGATGTAGTTTATTATGTCTTAAGCGAGTGC-TGTGATA-CAACAAAAAAT-TTCTTGGGTAGCTTT-ATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGGCTC-TTTTGACAT---TAGTATG--CAT-ATA-CTTTTGTA---TATGCATTGATTTTTATCAAGATACT--T-TG-GA-G-TGAGTACGAATGTAC-A-TAAAAATAAAAAAA--GATCTAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTG-T-AATATTTT---TGAT-ATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTA-ATTAAAAAAACATATAATGATGT-TTC----ATAAGGTATG-GTG-TTGTTAATATGGTAGTG--TCGTC-TTG---TCA-C-G---A-CAGCTTGTTATAAAGATGTAGTTTATTATGTCTTAAACAAGTCAATATCATATTAACGCAAAATAATCTTAGGTAGCTTTTATGTAAGAGCTTTAAAGACTTTTTTGCCTAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGTATATAATACCTTGCGTATTGTATGCATTGA-TTTT-TCATGATATTAATGTGTGATGTTGTTTATGCAA-AACAATTAATAATAAAAAAATTGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCTAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATACGATTAGATTTTGATTAATAATCTCAATGATAATTGACAAAATCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||| | | |||||| |||||||||||| |||    |||||||  | ||| ||| |    || || ||   || | |||   | | | |   | ||||| | |||||||||||||||||||||||||||| | |||   | | |||  |||  |||||  |||| ||||||||| ||  ||||||||||||||||| |||||| |||||||||||||||||||  | | ||  ||  |   |||||||   || ||| |||  |||   |||||||||| |||| ||| |||| |  | || || | ||  || | |   || | ||| ||||||||||  |||| ||||||||||||||||||||||||||||||||||||||||||||||||||| ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||||||||||||| | |||| | |   |||| ||| ||| | ||||||||||||||||||||||||||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>22</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|7</Hit_id>
+  <Hit_def>AB462270.1 Culicoides dubius genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Isg23</Hit_def>
+  <Hit_accession>7</Hit_accession>
+  <Hit_len>1096</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>374.144</Hsp_bit-score>
+      <Hsp_score>202</Hsp_score>
+      <Hsp_evalue>3.26663e-106</Hsp_evalue>
+      <Hsp_query-from>333</Hsp_query-from>
+      <Hsp_query-to>563</Hsp_query-to>
+      <Hsp_hit-from>597</Hsp_hit-from>
+      <Hsp_hit-to>829</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>224</Hsp_identity>
+      <Hsp_positive>224</Hsp_positive>
+      <Hsp_gaps>4</Hsp_gaps>
+      <Hsp_align-len>234</Hsp_align-len>
+      <Hsp_qseq>ATAAAAATAAAAAAAGATCTAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATAT-TT--TTGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTT</Hsp_qseq>
+      <Hsp_hseq>ATAAAAA-AAAAAATTAAATAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATCTTAGTTGTTATTCACAGAATCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTT</Hsp_hseq>
+      <Hsp_midline>||||||| ||||||  |  |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||  ||| |||||||||| |||||||||||||||||||||||||||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>128.539</Hsp_bit-score>
+      <Hsp_score>69</Hsp_score>
+      <Hsp_evalue>2.80797e-32</Hsp_evalue>
+      <Hsp_query-from>182</Hsp_query-from>
+      <Hsp_query-to>250</Hsp_query-to>
+      <Hsp_hit-from>393</Hsp_hit-from>
+      <Hsp_hit-to>461</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>69</Hsp_identity>
+      <Hsp_positive>69</Hsp_positive>
+      <Hsp_gaps>0</Hsp_gaps>
+      <Hsp_align-len>69</Hsp_align-len>
+      <Hsp_qseq>AAAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGT</Hsp_qseq>
+      <Hsp_hseq>AAAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGT</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>3</Hsp_num>
+      <Hsp_bit-score>73.1396</Hsp_bit-score>
+      <Hsp_score>39</Hsp_score>
+      <Hsp_evalue>1.33445e-15</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>52</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>51</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>48</Hsp_identity>
+      <Hsp_positive>48</Hsp_positive>
+      <Hsp_gaps>1</Hsp_gaps>
+      <Hsp_align-len>52</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATACTAAAAAAATATA</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATA-AAAATATATATA</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||||  ||| | |||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+</Iteration_hits>
+  <Iteration_stat>
+    <Statistics>
+      <Statistics_db-num>22</Statistics_db-num>
+      <Statistics_db-len>18669</Statistics_db-len>
+      <Statistics_hsp-len>16</Statistics_hsp-len>
+      <Statistics_eff-space>13884286</Statistics_eff-space>
+      <Statistics_kappa>0.46</Statistics_kappa>
+      <Statistics_lambda>1.28</Statistics_lambda>
+      <Statistics_entropy>0.85</Statistics_entropy>
+    </Statistics>
+  </Iteration_stat>
+</Iteration>
+<Iteration>
+  <Iteration_iter-num>3</Iteration_iter-num>
+  <Iteration_query-ID>Query_3</Iteration_query-ID>
+  <Iteration_query-def>AB462259.1 Culicoides actoni genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Kag01</Iteration_query-def>
+  <Iteration_query-len>776</Iteration_query-len>
+<Iteration_hits>
+<Hit>
+  <Hit_num>1</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|0</Hit_id>
+  <Hit_def>AB462263.1 Culicoides maculatus genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Kag12_1</Hit_def>
+  <Hit_accession>0</Hit_accession>
+  <Hit_len>764</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>800.72</Hsp_bit-score>
+      <Hsp_score>433</Hsp_score>
+      <Hsp_evalue>0</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>776</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>764</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>678</Hsp_identity>
+      <Hsp_positive>678</Hsp_positive>
+      <Hsp_gaps>42</Hsp_gaps>
+      <Hsp_align-len>791</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAATATAATGATGTATTCTTATAAAGTGTATGGTTGTTGGTTGTT-TTGCAGCGGCC-CTTG-TGGCAGCTCRCTATAAAGATGTAGTTTATTATGTCTTAAGCGAGTGCTGTGAAACAACAAAAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCAGTAAAACTAGTGATTTCGTGTCGCTAGTATGCATACATCTCTTTCGGGAGGGTATGCATTGATTTTATATCAAGATACTTTGGTGTGATAGTACGAATAGTACATATAAAA-TAAAAAATATAAGAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCATGATATTCACGAAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTCATGC-TTGT-TGAAAGACATAGTT-TGAGTGCATGATGTGATCATATGAATTT--TTTCATATATCATTAATAGAGTATATGGTTTATA-CTACT-TGCTTACGCGGCATGTTTGACCATTATTTTTATTTAACAAAATAACAAATTTTGGTATAAAATCAAGCGTGTTGTAGGCTGACG-TAGATAAAACTCT-TTCT-T-TATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTA-ACT-AAACATTCAATGATGTATTCTT-T-AAG-GTATGGTTG-TCGTTGTTATTGCAGCAGCCTCTCGCGGGCAGCTTGCTATAAAGATGTAGTTTATTATGTCTTAAGCAAGTGTTGTGGTTCAACAAAAAATTACTTGGGTAGCTTTATTTAAGAGCTTTAAAGACTTGTTTGCCCAAGGCTCCCGTAAAACTAGTGATCTTGTTTCATTAGTATGCA-A-TTATATTT--ATA-TATTTGCATTGATTTTATATCAAGATACTTTGGTGTGA--GTACGTAT-GTACATATAAAACAAAAAAAGATCA-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTTCGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTATTGTCTGAAA-AGATAAATGTAAGTGCATGATGTGATCATATGGATTWACTTTCATATATCATTAATGGAGGATATGGTT-ATCGCTGCTATGTTT--GCA-CAC-TTGG-CCATTATTTTTATTTAGTTAAA-AATATATATTGGTATAAAATCAAGTG-GT-GTAG-CTGGCGCTAAAGCGAT-TCTATTCTATCTATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||| | | ||| ||  |||||||||||||| | ||| ||||||||| | |||||| ||||||| ||| || |  |||||||  ||||||||||||||||||||||||||||||| |||| ||||   |||||||||||| |||||||||||||||  |||||||||||||||||||||||||||||| || |||||||||||||| | || ||  ||||||||| |  | | |||    |   | ||||||||||||||||||||||||||||||||||  ||||| || ||||||||||||  |||||| || | |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||   |||||||||  |||||||||||||||||||||||||||||||||||||||||||||||||||||| |||  |||| ||||| | |||  | | ||||||||||||||||||||| |||   ||||||||||||||||| ||| |||||||| ||  || || || ||  ||  ||  || | ||||||||||||||||   ||| || | || |||||||||||||||| | || |||| ||| || || |   |  ||| |||| | |||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>2</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|1</Hit_id>
+  <Hit_def>AB462264.1 Culicoides wadai genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Isg18_1</Hit_def>
+  <Hit_accession>1</Hit_accession>
+  <Hit_len>834</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>704.694</Hsp_bit-score>
+      <Hsp_score>381</Hsp_score>
+      <Hsp_evalue>0</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>713</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>761</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>656</Hsp_identity>
+      <Hsp_positive>656</Hsp_positive>
+      <Hsp_gaps>76</Hsp_gaps>
+      <Hsp_align-len>775</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATAT-TAAAAAATATAATGATGTATTCTTATAAAGTGTATGGTTGTTG-----GTTGTT-TTGCAGCGGC-C--C-----T-T-GT--GGCAGCTCRCTATAAAGATGTAGTTTATTATGTCTTAAGCGAGTGCTGTGAAACAAC-A-A-AAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGG-CCCCAGTAAAACTAGTGAT-TTCGTGTCGCTAGTATGCATA------CAT--C-TCT-TTC-G-GGAG-G----G-TATGCATTGATTTTATATCAAGATACTTTGGTGTGATAGTACGAATAGTACATATAAAATAAAAAATATAAG---AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCATGATATTCACGAAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTCATG-CTTGTT-GAAAGACATAGTTTGAGTGCATGATGTGATCATATGAATTTT----TTCATATATCATTAATA--G-AGTATATGGTTTATA-C-TACTTGCTTAC---GCG---GCATGTTTGACCATTATTTTTATTTAACAAAATAACAAATTTTGGTATAAAATCAA</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTA-ATCTAAAACATTCAATGATGTATTCTCA-CAAGTGTATGGTTGTTGTTTCCGTTGTTATTGTAGCAGCTCGTCGTAATTATCGTCGGGCAGCTTGCTATAAAGATGTAGTTTATTATGTCTTAAGCGAGTGCTGCAATACAACAATACAAAATTTCTTAGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCTAAGGCCCCCAGTAAAACTAGTGATCTTTGTGTCACTAGTATGCATATTAATGCATAACATCTCTTCGGAGGTGCGCTTTGATATGCATTGA-TTTATATCAAGATACTTTGGAGTGA--GTAC-ATTCGTACA-ATAAAACAAACAAAAAAAGATCAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTT-TGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGACTCGTTTGAACGTCTCA-TA--AGTGCATGATGTGATCATATGGATTTCGCGATTCATATATCATTAATAAAGGAGAATATGGTTGTTAACGTGCGTG-TTACATTGCGTTTGCA--TTTGACCATTATTTTTATTTAATAAAATAATAAATTTTGGTATAAAATCAA</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||| || ||||| ||  ||||||||||||| |  ||||||||||||||||     |||||| ||| ||| || |  |     | | ||  |||||||  |||||||||||||||||||||||||||||||||||||||  | ||||| | | |||||||||| ||||||||||||||||||||||||||||||||||||| |||| ||||||||||||||||||| || ||||| ||||||||||||      |||  | ||| ||| | || | |    | |||||||||| |||||||||||||||||||| ||||  |||| | | ||||| |||||| ||| || | |||   |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  ||||||||||  |||||||||||||||||||||||||||||||||||||||||||||||||||||| ||| || ||| ||| | |  | |   ||||||||||||||||||||| ||||     |||||||||||||||||  | || ||||||||  || | | | || ||||   |||   |||  |||||||||||||||||||||| ||||||| ||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>3</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|12</Hit_id>
+  <Hit_def>AB462275.1 Culicoides punctatus genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Kag13_1</Hit_def>
+  <Hit_accession>12</Hit_accession>
+  <Hit_len>787</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>645.601</Hsp_bit-score>
+      <Hsp_score>349</Hsp_score>
+      <Hsp_evalue>0</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>776</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>787</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>671</Hsp_identity>
+      <Hsp_positive>671</Hsp_positive>
+      <Hsp_gaps>67</Hsp_gaps>
+      <Hsp_align-len>815</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAATATAATGATGTATTCTTATAAAGTGTATGGTTGTTG-GTTGT-TTTG-CAGCGGCCCTT-G-TGGCAGCTCRCTATAAAGATGTAGTTTATTATGTCTTAAGCGAGTGCTGTG-A-AACAAC-AAAAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCAGTAAAACTAGT----GATTTCG-TGTCGCTAGTATGCATACATCTCTTTCGGGAGGGTATGCATTGATTTTATATC-AAGATAC-TTTG-GTGTG-AT-A--GT-ACG-AATAGTACAT--ATAAAATAAAAAATATAAGAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCATGATATTCACGAAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTCATG-CTTGT--TGAAAGACATAGTTTGAGTGCATGATGTGATCATAT-GA--ATTTT--TTCATATATCATTAATAGAGTATA-TGGTTTATACTACT-TGCTT-ACGCGGCATGTTTGACCATTATTTTTATTTAACAAAATAACAAATTTTGGTATAAAATCAA--GC-GTGTT-GTAGGCTGACGTAGATAAAACTCTTTCTTTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATTATAAAACATATAATGATGT-TCATTCTATAG-GTATGGTTGTTGTGTTGTCATTGTAAGAGTCATTTAGTTGGCAGCTCTCTATAAAGACATAGTTTATTATGTTTTAAGGGAGTACCTTGCAGTGCGACAAAAAAATTACTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCC-GTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGCATATACTTAATT--GTA---TATGCATTGA-TTTATTTCAAAGATACATTGGAGAGAGTATAATTGTAATGAAATTGTACATAAACAAAACAAAAAAAGTAA-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTTCGATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTCTTTCACTGAAAG-CATA-----AGTGCATGATGTGATTATATAGGTGATATCAACTTATATATCATTAATAAAGTGTGGTGGT--A-ACAAATATACTTTAAGCT--ATGTTTGACCATTATTTTTATCTAA-AAAATAATAAATTTTGGTATAAAATCAAATGTAGTGTTTGTTTGTT-AC-TC-ATAACA-TCCA--TTTATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||  ||||| |||||||||||| |  || || || |||||||||||| |||||  |||  || | |  || | ||||||||| |||||||||  ||||||||||||| ||||| |||| |  || |   | || |||||||| |||||||||||||||||||||||||||||||||||||||||||||||||| |||||||||||     ||| ||  || ||||||||||||| |  |  ||  | |   |||||||||| ||||| || ||||||| || | | | | || |  || | | ||| ||||||  | |||| ||||||  ||| |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||   ||||||||| | ||||||||||||||||||||||||||||||||||||||||||||||||||||| ||| |||    |||||| ||||     ||||||||||||||| |||| |   || |    | |||||||||||||| ||| |  ||||  | || | | | ||| | ||   ||||||||||||||||||||| ||| ||||||| ||||||||||||||||||||  |  ||||| ||  | | || |  |||| | ||    |||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>4</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|21</Hit_id>
+  <Hit_def>AB462284.1 Culicoides paraflavescens genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: OKYN05_13</Hit_def>
+  <Hit_accession>21</Hit_accession>
+  <Hit_len>842</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>566.195</Hsp_bit-score>
+      <Hsp_score>306</Hsp_score>
+      <Hsp_evalue>5.03458e-164</Hsp_evalue>
+      <Hsp_query-from>165</Hsp_query-from>
+      <Hsp_query-to>776</Hsp_query-to>
+      <Hsp_hit-from>248</Hsp_hit-from>
+      <Hsp_hit-to>842</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>526</Hsp_identity>
+      <Hsp_positive>526</Hsp_positive>
+      <Hsp_gaps>43</Hsp_gaps>
+      <Hsp_align-len>625</Hsp_align-len>
+      <Hsp_qseq>AAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCAGTAAAACTAGT----GATTTCG-TGTCGCTAGTATGCATACATCTCTTTCGGGAGGGTATGCATTGATTTTATATCAAGATACTTTGGTGTGATAGTACGAATAGTACATAT-A-AAAT-AAAAAA-TATAAGAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCATGATATTCACGAAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTCATGCTTGT-T-GA-A-AGACATAGTTTGAGTGCATGATGTGATCATATGAATTTTTTCATATATCATTAATAGAGTATATGGTTTATACTACTTGCTTACGCGGCATGTTTGACCATTATTTTTATTTAACAAAATAACAAATTTTGGTATAAAATCAAGCGTGTTGTAGGCTGACGTAGATAAAACTCTTTCTTTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>AAAATTTCTTGGGTAGCTTTATTGAAGAGCTTTAAAGACTTATTTGCCCAAGGCCCC-GTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGCATAC--C-CTTT--ATTGGGTATGCATTGATATTTT-TCATGATACTTTGGTGTG--AGTACTTATTGTACATATGATAAATAAAAAAACGATCA-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTTTGATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGCGTCTCTAGCGATAGA-AGCGCTTAAGTGCATGATGTGATTATATAAGTAAAATTATATATCATTAATAAAGGA-ATA----A-A--A-TGG--TATGAATCATATTTAACCATTATTTTTATTTAA-AAAATAACAAATTTTGGTATAAAAT-A-GA-TA-TGTATGATTACCTT-A-AAAATTCTTTA-TTATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||| |||||||||||||||||| ||||||||||||||| |||||||||||     ||| ||  || ||||||||||||||  | ||||     |||||||||||||| || | ||| ||||||||||||||  |||||  || |||||||| | |||| ||||||  || | |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  |||||||||| | ||||||||||||||||||||||||||||||||||||||||||||||||||||| |||| | | | |  | ||| |  | || ||||||||||||||| |||| | |    | |||||||||||||| || | ||     | |  | | |  || |   ||| ||| |||||||||||||||||| ||||||||||||||||||||||||| | |  |  |||| | | || |  | |||| |||||  ||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>134.079</Hsp_bit-score>
+      <Hsp_score>72</Hsp_score>
+      <Hsp_evalue>6.05127e-34</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>144</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>143</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>124</Hsp_identity>
+      <Hsp_positive>124</Hsp_positive>
+      <Hsp_gaps>9</Hsp_gaps>
+      <Hsp_align-len>148</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAATATAATGATGTATTCTTATAAAGTGTATGGTTGTTGGTTGTTT-TGCAGCGGCCCTTG-TG-GC-AGCTCRCTATAAAGATGTAGTTTATTATGTCTTAAG</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAACATATAATGATGT-TTCTT-TAA-G-GTATGGT-GTTTGATATTTGTTGATAGCTATTTGATTAGCAAGCTTACTATAAAGATGTAGTTTATTATGTCTTAAG</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||||||||| |||||||||||| ||||| ||| | ||||||| ||| | | ||| |  |  |    ||| |  || ||||  ||||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>5</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|17</Hit_id>
+  <Hit_def>AB462280.1 Culicoides kibunensis genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: AM05_6</Hit_def>
+  <Hit_accession>17</Hit_accession>
+  <Hit_len>817</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>556.962</Hsp_bit-score>
+      <Hsp_score>301</Hsp_score>
+      <Hsp_evalue>3.03004e-161</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>776</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>817</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>661</Hsp_identity>
+      <Hsp_positive>661</Hsp_positive>
+      <Hsp_gaps>61</Hsp_gaps>
+      <Hsp_align-len>827</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATT-AAAAAATATAATGATGTATTCTTATAAAGTGTATGGTTGTTGGTTGTTTTGCAGCGGCCCTT---GTGGCAGCTCRCTATAAAGATGTAGTTTATTATGTCTTAAGCGAGTGCTGTGAAACAA-CA---A----AAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCAGTAAAACTAGT----GATTTCG-TGTCGCTAGTATGCATACATCTCTTTCGGGAGGGTATGCATTGATTTTATATCAAGATACTTTGGTGTGA---T---AGTACGAA-TAGTAC--ATATAAA-ATAAAAAATATAAGAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCA-TGATATTCACGAAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTCATGC-TT--GTTG---AA-AG-A-CAT-AGTTTGAGTGCATGATGTGATCATATGAATTTTT--T--C--ATATATCATTAATAGAG-TATATGGTTTATACTACTTGCTTACGCGGCATGTTTGACCATTATTTTTATTTAACA-AAATAACAAATTTTGGTATAAAATCAAGC-GTGTTGTAGGCTG-ACG-TAGATAAA-ACT-CTTTCTTTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAAATATAATGATGTATCATTCT-AAG-GTATGGTTGTT--TTGTCTCTCAACAGCTATTAACTTGGCAGCTTACT-CAAAGATGTAGCTTATTATGTTTTAAGTAAGTGTTGTTAGACAATCAGGTATGGTGAAATTWCTTAGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCTAAGGCCCC-GTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGCATATA-CAAGTAAAATTGTATATGCATTGATATTTT-TCATGATACTTTGGTGTGAGTATAAAATTAATAATTTGTACAWAAACAAACAAAAAAAAGATCA-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTCAAACTATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTGTTTTGTTGTCTAACAACAGCAGAAGCATAAGTGCATGATGTGATCATATAAGCTTTTAATYGCYTATATATCATTAATAAAGGTATAAGTATGGTAACAAGTGCTTTTGCA-CATATTTAACCATAATTTTTATTTAATATAAATATATAATTTTGGTATAAAATGAATATGTGTTGYACGTTGTAAGCTATACAAAGAAAACTTTAAAATTGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||||| |||||||||||||||||||  || | ||| |||||||||||  |||| |  || | ||  ||    ||||||||  ||  |||||||||| ||||||||| |||||  |||| ||| | |||| ||   |     ||||| ||| ||||||||||||||||||||||||||||||||||||| |||||||| |||||||||||     ||| ||  || ||||||||||||| | |   |      |  ||||||||||| || | ||| |||||||||||||||   |   | ||  || | ||||  | | ||| | |||||| || | ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  |   |||||||| | ||||||||||||||||||||||||||||||||||||||||||||||||||||| |||  ||  ||||   || |  | ||  ||  | |||||||||||||||||||| |  ||||  |  |  |||||||||||||| || |||| |  |  ||  |  |||||  ||  ||| ||| ||||| |||||||||||| | |||||   |||||||||||||||| ||   |||||| | | || | | || | ||| |   ||||     |||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>6</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|5</Hit_id>
+  <Hit_def>AB462268.1 Culicoides cylindratus genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Kag08, short type</Hit_def>
+  <Hit_accession>5</Hit_accession>
+  <Hit_len>748</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>547.729</Hsp_bit-score>
+      <Hsp_score>296</Hsp_score>
+      <Hsp_evalue>1.82361e-158</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>776</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>748</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>636</Hsp_identity>
+      <Hsp_positive>636</Hsp_positive>
+      <Hsp_gaps>64</Hsp_gaps>
+      <Hsp_align-len>794</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAATATAATGATGTATTCTTATAAAGTGTATGGTTGTTGGTTGTTTTGCAGCGGC-CCTT--GTGGCAGCTCRCTATAAAGATGTAGTTTATTATGTCTTAAGCGAGTGCTGTGAAACAACAAAAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCAGTAAAACTAGTGATTTCGTGTCGCTAGTATGCATACATCTCTTTCGGGAGGGTATGCATTGATTTTATATCAAGATACTTTGG--TGTG-ATAGTAC--GAATAGTACAT---A-TAAA-ATAAAAAATATAAGAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCATGATATTCACGAAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTCATGCTTGTTGAAAGACATAGTTTGAGTGCATGATGTGATCATATGAATTTTTTCATATATCATTAATAGAGTATATGGTTT-A--TACTACTTGCT-TACGCGGCATGTTTGACCATTATTTTTATTTAACAAAATAACAAATTTTGGTATAAAATCAAGCGTGTTGTAGGCT-GACGTAGATAAAACTCTTTCTTTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTA---TAAAATATATAATGATGT--TCAT-TCAA---TAAGGTTGGTGGTTGTATTGTAACAGCTATTTACTTAGCAGCTTGCTATAAAGATGTRGTTTATYATGTCTTAAGYAAGTGTTGYGATACARCAAAAAATTTCTTAGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCTAAGGCCCC-GTAAAACTAGT-AACCCAT-T-GCGAGGTGGC-T--A---GTAT--GCA---TATGCATTGATATTTT-TCATGATACTTTGGAGTGAGTATAATACAAAAATTGTACATAAAACAAAAYAAAAAAAAGATCA-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTATAATATTTT-TGATATTCATAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATAYATTAAACTATCTTATGTGTGTA-AAAG-CATA-----AGTGCATGATGTGATCATAAAAGTCTACTTTTATATCATTAATRAAGG-T--GGTAACAAATA-TACTTGATATAA---GCATATTTGACCATTATTTTTATTTATTTTAATATG-AATTTTGGTTTAAA-TCAAATATGT-GTAT-CTCGTTGTTGTTTATAWA-TAACTTTATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||   ||||| ||||||||||||  || | | ||   || ||||| ||||||| ||| | | ||   ||   | ||||||  |||||||||||| |||||| ||||||||||  |||| || || ||| ||||||||||||| ||||||||||||||||||||||||||||||||||||| |||||||| ||||||||||| |   | | | || ||   || |  |    | |  | |   ||||||||||| || | ||| ||||||||||  || | ||| |||   ||| ||||||   |  ||| | |||||| || | |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||||||||  |||||||||  | |||||||||||||||||||||||||||||||||||||||| |||||||||||| |||  |||  |||| ||||     |||||||||||||||||||  | | |  |  ||||||||||||  ||  |  |||   |  || |||||| | ||    |||| |||||||||||||||||||||    ||||   ||||||||| |||| ||||   ||| |||  || |  || | | | |   |  ||||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>7</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|20</Hit_id>
+  <Hit_def>AB462283.1 Culicoides matsuzawai genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: IS05_6</Hit_def>
+  <Hit_accession>20</Hit_accession>
+  <Hit_len>908</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>542.189</Hsp_bit-score>
+      <Hsp_score>293</Hsp_score>
+      <Hsp_evalue>8.48444e-157</Hsp_evalue>
+      <Hsp_query-from>165</Hsp_query-from>
+      <Hsp_query-to>776</Hsp_query-to>
+      <Hsp_hit-from>299</Hsp_hit-from>
+      <Hsp_hit-to>908</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>527</Hsp_identity>
+      <Hsp_positive>527</Hsp_positive>
+      <Hsp_gaps>44</Hsp_gaps>
+      <Hsp_align-len>633</Hsp_align-len>
+      <Hsp_qseq>AAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCAGTAAAACTAGT----GATTTCG-TGTCGCTAGTATGCATACATCTCTTTCGGGAGGGTATGCATTGATTTTATATCAAGATACTTTGGTGTGATAGTACGAATAGTA-C-ATATAAA-ATAAAAAATATAAGAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCAT-GATATTCACGAAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTCATGCTTGTTGAAAGACATAGTTTGAGTGCATGATGTGATCATA----TG-AATTTTTTCATATATCATTAATAGAGTA-TA---TGGT-TTATACTACTTGCTTACGCGGCATGTTTGACCATTATTTTTATTTAACAAAATAACAAATTTTGGTATAAAATCAAGCGTGTTGTAGGCTG-ACGTAGA-TAAAACTCTTTCTTTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>AAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCC-GTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGCATACA---CTTARTTGA--GTATGCATTGATATTTT-TCATGATACTTTGGTGTGA-AGTACATATTGTACCGATATAAACAAAAAAAAGATCA-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTT-ATCGATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTGTCTTGAAAAAGA-ACATA-AGCGCATGATGTGATTATAAAAGTGTAAAAGCTTT-TATATCACTAATAAAGGAATAAWATGGTGTTTTGCT--TTGCTAA---GGCATATTTAACCATAATTTTTATTTAATATAATATG-AATTTTGGTATAAAATGAATA-TGTC-TAGCTTGGAATTCGCCTAAAAAACCA--TTTATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||||||||||||||||||||| |||||||||||     ||| ||  || |||||||||||||||   |||    ||  |||||||||||| || | ||| ||||||||||||||| |||||  || ||| | ||||||| | |||||| || | ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| || ||||||||| | ||||||||||||||||||||||||||||||||||||||||||||||||||||| |||  | |||||| | | |  |  || |||||||||||| |||    || ||    ||  ||||||| ||||| || | ||   |||| || | ||  ||||| |   ||||| ||| ||||| |||||||||||| | ||||   |||||||||||||||| ||   |||  |||  || |  | |  |||||  |    |||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>150.699</Hsp_bit-score>
+      <Hsp_score>81</Hsp_score>
+      <Hsp_evalue>6.00861e-39</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>163</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>172</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>146</Hsp_identity>
+      <Hsp_positive>146</Hsp_positive>
+      <Hsp_gaps>15</Hsp_gaps>
+      <Hsp_align-len>175</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAA-TATAATGATGTATTCTT-ATA-AA-GTGTATGGTTGTTG-GTTGTTTTG-CAGCGGCCCTT-G-TG-GC-AGCTCRCTATAAAGATGTAGTTTATTAT-GTCTTAAGCGAGTGCTGTGAAA-CAACA</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAAATATAATGATGT-TTCTTTATATAAGGTATATGGTTGTTATGTTGTCTTGTCAACAGCTATTTGATTAGCAAGCTTGCTATAAAGATGTAGTTTATTACGGTCTTAAGTAAGTG-T-TGACAGCAACA</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||||||||||| ||||||||||| ||||| ||| || || ||||||||||  ||||| ||| || | ||  || | |  || ||||  |||||||||||||||||||||  ||||||||  |||| | ||| | |||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>8</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|13</Hit_id>
+  <Hit_def>AB462276.1 Culicoides sumatrae genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: ONYK05_17</Hit_def>
+  <Hit_accession>13</Hit_accession>
+  <Hit_len>784</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>527.415</Hsp_bit-score>
+      <Hsp_score>285</Hsp_score>
+      <Hsp_evalue>2.37574e-152</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>635</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>654</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>551</Hsp_identity>
+      <Hsp_positive>551</Hsp_positive>
+      <Hsp_gaps>53</Hsp_gaps>
+      <Hsp_align-len>671</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTAT-ATT--AAAAAATATAATGATGTATTCTTATAAAGTGTATGGTTGTTGGTTGTTTTGCAGCGGC-CCT--TGTGGCAGC-T----CRCTATAAAGATGTAGTTTATTATGTCTTAAGCGAGTGCT--GTGAAACAACAAAAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCAGTAAAACTAGT----GATTTCG-TGTCGCTAGTATGCATACATCTCTTTCGGGAGGGTATGCATTGATTTTATATCAAGATACTTTGGTGTGATAGTA---CG--AAT-AGTACA--TATA-A-A-AT----AAAAAATA-T-AAGAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATT-TCATGATATTCACGAAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTCATGCTTGTTGAAAGACATAGTTTGAGTGCATGATGTGATCATATGAATTTTTTCATATATCATTAATAGAGTATATG</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATTATTAAAAAAAATATAATGATGT-TTCAT-TCAAG-GTATGGTTGTT-AATCTATTGCAATGGCTATTAATTTAGCAGCTTACACCGCTATAAAGATGTGGTTTATCATATCTTAAGC-ATTCGTAGGTGTTGTGATAGAAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCC-GTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGTATATACTTAATT--GTA---TATGCATTGATATTTT-TCATGATACTTTGGTGTGATAATAAAAAGTAAATCTTTATATTTATATAGAGATAGGAAAAAAAAAGTAAAGAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTATC--GATATTCACGAAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATG-TTATTTAATGGTAACGTAAG-G-GCATGTTGTGATTATATAAGTAAAATTATATATCACTAATAAAGTATATG</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||| |||  ||||||||||||||||| ||| | | ||| |||||||||||   | | |||||  |||   |  | | ||||| |    | |||||||||||| |||||| || |||||||| | |  |  |||     | | ||||||||||||||||||||||||||||||||||||||||||||||||||||||||| |||||||||||     ||| ||  || ||||||||| ||| |  |  ||  | |   ||||||||||| || | ||| ||||||||||||||||| ||    |  |||   || |  |||| | | ||    |||||| | | ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||  ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||| || || || |  |  ||  | | ||||| |||||| |||| | |    | |||||||| ||||| ||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>52.8265</Hsp_bit-score>
+      <Hsp_score>28</Hsp_score>
+      <Hsp_evalue>1.74306e-09</Hsp_evalue>
+      <Hsp_query-from>749</Hsp_query-from>
+      <Hsp_query-to>776</Hsp_query-to>
+      <Hsp_hit-from>757</Hsp_hit-from>
+      <Hsp_hit-to>784</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>28</Hsp_identity>
+      <Hsp_positive>28</Hsp_positive>
+      <Hsp_gaps>0</Hsp_gaps>
+      <Hsp_align-len>28</Hsp_align-len>
+      <Hsp_qseq>TTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>TTATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>9</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|18</Hit_id>
+  <Hit_def>AB462281.1 Culicoides verbosus genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: OKYN05_18</Hit_def>
+  <Hit_accession>18</Hit_accession>
+  <Hit_len>805</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>525.569</Hsp_bit-score>
+      <Hsp_score>284</Hsp_score>
+      <Hsp_evalue>8.54468e-152</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>710</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>732</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>609</Hsp_identity>
+      <Hsp_positive>609</Hsp_positive>
+      <Hsp_gaps>68</Hsp_gaps>
+      <Hsp_align-len>755</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAA-TATAATGATG-T-ATTCTTATAAAGTGTATGGTTGTTGGTTGTTTTGCAGCGGCCCTT---GTGGC-AGCTCRCTATAAAGATGTAGTTTATTATGTCTTAAGCGAGTGCTGTGAAACAACAA------------AAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCAGTAAAACTAGT----GATTTCG-TGTCGCTAGTATGCATACATCTCTTTCGGGAGGGTATGCATTGATTTTATATCAAGATACTTTGG--TGT--G-AT--AGTACGAA-TAGTAC--ATA-TAAAATAAAAAATATAAGAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCATGATATTCACGAAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTCATG-CTTGTTGAAA-GACATAGTTTGAGTGCATGATGTGATCATATGAATTTT-TT-C--ATATATCATTAATAGAG-TATATGGTTTA-TACTACTTGCTTACGCGGCATGTTTGACCATTATTTTTATTTAACA-AAATAACA-AATTTTGGTATAAAAT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAAATATAATGATGTTCATTCATA-AAAG-GTATAACGGTT-GTTGTCTTTCAATGGCTATTCACTTAGCAAGCTTGCTATAAAAATGTAGTTTATTATGTTTTAAGCAAGTGTTGTTAGACAA-AAGGTTGGTTGTTCAAAATTACTTAGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCTAAGGCCCC-GTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGTATATACTTAATT--GTA---TATGCATTGATATTTT-TCATGATACTTTGGAGTGTGAGTATAAAATTAAAATTTGTACAAAAACAAAAACAAAAAAGATCA-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATAAACTAATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTCTT-TAAAATTGAGATA-TA--AGTGCATGATGTGATCATATAAGCTTAATTGCCTATATATCATTAATAAAGGTGGA-GGTATGGTGCTA-TTGTGTA-----CATATTTAACCATCATTTTTATTTAATATAAATAATATAATTTTGGTATAAAAT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||||||||||| |||||||||| | |||| || |||| ||||    ||| ||||| || ||  |||  ||    | || ||||  ||||||| |||||||||||||||| |||||| |||| ||| | |||| ||            |||||| ||| ||||||||||||||||||||||||||||||||||||| |||||||| |||||||||||     ||| ||  || ||||||||| ||| |  |  ||  | |   ||||||||||| || | ||| ||||||||||  |||  | ||  | |   || | ||||  | |  |||| |||||| || | |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||    | |||||||| | ||||||||||||||||||||||||||||||||||||||||||||||||||||| ||| ||| |  ||  || ||| |   |||||||||||||||||||| |  ||  || |  |||||||||||||| || |  | ||| |  | ||| |||  ||     ||| ||| ||||| |||||||||||| | |||||| | ||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>10</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|4</Hit_id>
+  <Hit_def>AB462267.1 Culicoides aterinervis genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: AM05_5</Hit_def>
+  <Hit_accession>4</Hit_accession>
+  <Hit_len>891</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>520.029</Hsp_bit-score>
+      <Hsp_score>281</Hsp_score>
+      <Hsp_evalue>3.97545e-150</Hsp_evalue>
+      <Hsp_query-from>165</Hsp_query-from>
+      <Hsp_query-to>776</Hsp_query-to>
+      <Hsp_hit-from>276</Hsp_hit-from>
+      <Hsp_hit-to>891</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>530</Hsp_identity>
+      <Hsp_positive>530</Hsp_positive>
+      <Hsp_gaps>54</Hsp_gaps>
+      <Hsp_align-len>641</Hsp_align-len>
+      <Hsp_qseq>AAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCAGTAAAACTAGT----GATTTCG-TGTCGCTAGTATGCATACATCTCTTTCGGGAGGGTATGCATTGATTTTATATCAAGATACTTTGG--TGTG-ATAGTAC--GAATAGTACAT--ATAA-AATAAAAAATATA-A-G-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCATGATATTCACGAAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTCATGCTTGTTGAAAGACATAGTTTGAGTGCATGATGTGATCATAT-GA-ATTTT-T-T-C--ATATATCATTAATAGAGTATATGGTTT-A--TACTACTTGCT-TACGCGGCATGTTTGACCATTATTTTTATTTAACAAAATAACAAATTTTGGTATAAAATCAAGCGTGTTGTAGGCT-GACGTAGATAA-AACTCTTTCTTTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>AAAATTTCTTAGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCTAAGGCCCC-GTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGCATACA---C-TT-AGTTGTGTATGCATTGATATTTT-TCATGATACTTTGGAGTGAGTATAATACAAAAATTGTACATAAATAATAATAAAAAAAAAAGATGAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTATAATATTTT-TGATATTCATAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATG-T-GTTTTAC-ACGTA-----AGTGCATGATGTGATCATATAGGTACTTTGTGTACTTATATATCATTAATAAAGG-TGTGGTAACAAATA-TACTTGATATAAGCGT-A--TTTGACCATTATTTTTATTTAATTTAATATG-AATTTTGGTTTAAA-TCAAATATGT-GTAT-CTCGTTGTTGTTTATAACTCTAACATTATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>|||||||||| ||||||||||||||||||||||||||||||||||||| |||||||| |||||||||||     ||| ||  || |||||||||||||||   | ||  |  | |||||||||||| || | ||| ||||||||||  || | ||| |||   ||| ||||||  |||| ||||||||| | | | | |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||||||||  |||||||||  | ||||||||||||||||||||||||||||||||||||||||||||||||||||| ||| | |||  |  || ||     |||||||||||||||||||| |  | ||| | | |  |||||||||||||| ||  | ||||   |  || |||||| | || |||  |  ||||||||||||||||||||||   ||||   ||||||||| |||| ||||   ||| |||  || |  || | | | ||||||  | ||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>132.232</Hsp_bit-score>
+      <Hsp_score>71</Hsp_score>
+      <Hsp_evalue>2.17642e-33</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>160</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>160</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>134</Hsp_identity>
+      <Hsp_positive>134</Hsp_positive>
+      <Hsp_gaps>8</Hsp_gaps>
+      <Hsp_align-len>164</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAATATAATGATGTATTCTTATAAAGTGTATGGTTGTTGGTTGTT-TTGCAGCGGC-CCTT-G-TGGCAGCTCRCTATAAAGATGTAGTTTATTATGTCTTAAGCGAGTGCTGTGAAACA</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATA--AAAATATATAATGATGT-TCATTCTAAGGT-TGTGGATGTATGTTGTTATTGTAACAGCTATTTAGTTAGCAGCTTGCTATAAAGATGTAGTTTATTATGTCTTAAGTAAGTGTTATGATACA</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||||  |||| |||||||||||| |  || ||| || | ||| |||  |||||| ||| | | ||   || | | ||||||  ||||||||||||||||||||||||||||||  |||| | ||| |||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>11</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|9</Hit_id>
+  <Hit_def>AB462272.1 Culicoides nipponensis genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Isg22</Hit_def>
+  <Hit_accession>9</Hit_accession>
+  <Hit_len>794</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>514.489</Hsp_bit-score>
+      <Hsp_score>278</Hsp_score>
+      <Hsp_evalue>1.8496e-148</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>602</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>607</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>524</Hsp_identity>
+      <Hsp_positive>524</Hsp_positive>
+      <Hsp_gaps>57</Hsp_gaps>
+      <Hsp_align-len>633</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAATATAATGATGT--ATTCTTATAAAGTGT-ATGGTTGTTGGTTGTT-TTGCAGCGGC--CCT-TGTGGCAGC-T-CRCTATAAAGATGTAGTTTATTATGTC-T-TA--AGCGAG--TGCTGTGA-AACAACAAA-------AAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCAGTAAAACTAGT----GATTTCG-TGTCGCTAGTATGCATACATCTCTTTCGGGAGGGTATGCATTGATTTTATATCAAGATACTTTGGTGTGATAGTACGAATAGTACATATAAAATAAAAAATATAAGAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATAT-TTCATGATATTCACGAAG-TCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTCATGC-TTGTTGAAAGACATAGTTTGAGTGCATGATGTGATCATAT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATTATAAAAAATATAATGATGTTCATTC-TAT-TAGTGTAATGG-TGTT-ATTATTATTACAATTGCAATATATTTTGCAGCTTACAC-A-AAAGATGTAGTTTATTATATCATATATGTGCAAGTATATTGTAATAATAAAAGAGTTGGTTAAATTTCTTGGGTAGCTTTATTGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCC-GTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGTATATAT-TCATTT---A---TATACATTGATATTTT-TCATGATACTTTGGATTGATA-T--G-ATAAAACAAACAAAA-AAAAAGTGTAAGAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATATTTTTGATATTCAC-AAGATCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTGTGTTTTGTCAAAAGACATA-----AGTGCATGATGTGATTATAT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||  ||||||||||||||||||  |||| |||  ||||| |||| ||||  || || || ||   ||    | | | ||||| | | | | |||||||||||||||||| || | ||   || ||  |  ||| | || || | |       ||||||||||||||||||||| |||||||||||||||||||||||||||||||||| |||||||||||     ||| ||  || ||||||||| ||| || || ||    |   ||| ||||||| || | ||| ||||||||||  ||||| |  | |||  ||| | |||| ||||| | ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||  |||||||||| ||| ||||||||||||||||||||||||||||||||||||||||||||||||||||  ||  ||||  |||||||||     ||||||||||||||| ||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>65.753</Hsp_bit-score>
+      <Hsp_score>35</Hsp_score>
+      <Hsp_evalue>2.23889e-13</Hsp_evalue>
+      <Hsp_query-from>663</Hsp_query-from>
+      <Hsp_query-to>776</Hsp_query-to>
+      <Hsp_hit-from>682</Hsp_hit-from>
+      <Hsp_hit-to>794</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>94</Hsp_identity>
+      <Hsp_positive>94</Hsp_positive>
+      <Hsp_gaps>13</Hsp_gaps>
+      <Hsp_align-len>120</Hsp_align-len>
+      <Hsp_qseq>TTTGACCATTATTTTTATTTAA--CAA-AATAACAAATTTTGGTATAAAATC-AAGCGTGT-TGTAG-GCTGACGTAGATAAAACTCTTTCTTTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>TTTGACCATTATTTTTATTTAAATTAATAATAA-ATATTTTGGT-TTAAATCAAATGGTATATG-AGAGAAAAAGT-G-TTATA-T-TTTTTTTATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||   || ||||| | |||||||| | ||||| ||  || | || || |   | || | | | | | ||| |||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>12</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|19</Hit_id>
+  <Hit_def>AB462282.1 Culicoides humeralis genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Kag15_1</Hit_def>
+  <Hit_accession>19</Hit_accession>
+  <Hit_len>912</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>499.716</Hsp_bit-score>
+      <Hsp_score>270</Hsp_score>
+      <Hsp_evalue>5.17908e-144</Hsp_evalue>
+      <Hsp_query-from>165</Hsp_query-from>
+      <Hsp_query-to>602</Hsp_query-to>
+      <Hsp_hit-from>296</Hsp_hit-from>
+      <Hsp_hit-to>739</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>398</Hsp_identity>
+      <Hsp_positive>398</Hsp_positive>
+      <Hsp_gaps>28</Hsp_gaps>
+      <Hsp_align-len>455</Hsp_align-len>
+      <Hsp_qseq>AAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCAGTAAAACTAGT----GATTTCG-TGTCGCTAGTATGCATACATCTCTTTCGGGAGGGTATGCATTGATTTTATATCAAGATACTTTGGTGTG---ATAGTACGAATAGTACATA--TAA-AATAAAAAA-TATAAGAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCAT-GATATTCACGAAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTCATGCTTGT-T-GAAA--GACATAGTTTGAGTGCATGATGTGATCATAT</Hsp_qseq>
+      <Hsp_hseq>AAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCC-GTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGCATACA---CTTAATTGA--GTATGCATTGATATTTT-TCATGATACTTTGGTGTGAGTATAATTTGTATTGTACATAAACAAGAAAAAAAAACGATCA-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTT-ATCGATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTGTGTCTTGAAAAAGACATCATA--AGTGCATGATGTGATTATAT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||||||||||||||||||||| |||||||||||     ||| ||  || |||||||||||||||   |||    ||  |||||||||||| || | ||| ||||||||||||||   ||| |  | || |||||||   || || ||||||  || | ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| || ||||||||| | ||||||||||||||||||||||||||||||||||||||||||||||||||||| |||  ||| | ||||  |||||  |   ||||||||||||||| ||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>141.466</Hsp_bit-score>
+      <Hsp_score>76</Hsp_score>
+      <Hsp_evalue>3.61625e-36</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>144</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>152</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>130</Hsp_identity>
+      <Hsp_positive>130</Hsp_positive>
+      <Hsp_gaps>14</Hsp_gaps>
+      <Hsp_align-len>155</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAA-TATAATGATGTATTC--T-TATA-AA-GTGTATGGTTGTTGGTTGTTTTG-CAGCGGCCCTT-G--TGGC-AGCTCRCTATAAAGATGTAGTTTATTATGTCTTAAG</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAAATATAATGATGT-TTCTTTATATATAAGGTATATGGTT-AT-GTTGTCTTGTCAAYRGCTATTYGATTAGCAAGCTTGCTATAAAGATGTAGTTTATTATGTCTTAAG</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||||||||||| ||||||||||| |||  | |||| || || |||||||  | ||||| ||| ||   ||  || |  | || ||||  ||||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>3</Hsp_num>
+      <Hsp_bit-score>52.8265</Hsp_bit-score>
+      <Hsp_score>28</Hsp_score>
+      <Hsp_evalue>1.74306e-09</Hsp_evalue>
+      <Hsp_query-from>749</Hsp_query-from>
+      <Hsp_query-to>776</Hsp_query-to>
+      <Hsp_hit-from>885</Hsp_hit-from>
+      <Hsp_hit-to>912</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>28</Hsp_identity>
+      <Hsp_positive>28</Hsp_positive>
+      <Hsp_gaps>0</Hsp_gaps>
+      <Hsp_align-len>28</Hsp_align-len>
+      <Hsp_qseq>TTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>TTATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>13</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|15</Hit_id>
+  <Hit_def>AB462278.1 Culicoides erairai genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: IS05_2</Hit_def>
+  <Hit_accession>15</Hit_accession>
+  <Hit_len>931</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>496.022</Hsp_bit-score>
+      <Hsp_score>268</Hsp_score>
+      <Hsp_evalue>6.69957e-143</Hsp_evalue>
+      <Hsp_query-from>165</Hsp_query-from>
+      <Hsp_query-to>710</Hsp_query-to>
+      <Hsp_hit-from>309</Hsp_hit-from>
+      <Hsp_hit-to>868</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>478</Hsp_identity>
+      <Hsp_positive>478</Hsp_positive>
+      <Hsp_gaps>40</Hsp_gaps>
+      <Hsp_align-len>573</Hsp_align-len>
+      <Hsp_qseq>AAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCAGTAAAACTAGT----GATTTCG-TGTCGCTAGTATGCATACATCTCTT-TCGGGAGGGTATGCATTGATTTTATATCAAGATACTTTGGTGTGATAGTACGAATA-GTAC--ATAT-AAAA--T-AAAAAATATAAGAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCATGATATTCACGAAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTCATGCTTGTT--GA-AAGACATA-GTTTG--AGTGCATGATGTGATCATAT-GA--ATTTTT-TC-ATATATCATTAATAGAGTA-TATGGT-T-TATACTACTTGCTTACGCGGCATGTTTGACCATTATTTTTATTTAACAAAATAACAAATTTTGGTATAAAAT</Hsp_qseq>
+      <Hsp_hseq>AAAATTTCTTAGGTAGCTTTATTGAAGAGCTTTAAAGACTTGTATGCCTAAGGCCCC-GTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGCATATAT-TTTAATC--G-GTGTATGCATTGATATTTT-TCATGATACTTTGGTGTGATATTTTGTATATTTACAAATGTAAAAATGTAAAAAAAGAGATCAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTACT--TATTCACAAAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTGTGATTTTTCTGGTGAAACAGAAGCTTACAAGTGCATGATGTGATCATATAGATGATTTCTGTCTATATATCATTAATAAAGTGGTATGATATGTGTACTAAA-G-TTGTGTTGCATATTTAACCATAATTTTTATTTAATAATATT---AATTTTGGTATAAAAT</Hsp_hseq>
+      <Hsp_midline>|||||||||| ||||||||||| |||||||||||||||||||| |||| |||||||| |||||||||||     ||| ||  || ||||||||||||| || | |  ||  | | |||||||||||| || | ||| ||||||||||||||||| |  | |||  |||  || | ||||  | |||||| | |  |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  |  ||||||| |||||||||||||||||||||||||||||||||||||||||||||||||||||||  || || ||  |   | ||| | | ||   |||||||||||||||||||| ||  |||| | || |||||||||||||| |||  |||| | | | |||||   | ||  |  |||| ||| ||||| |||||||||||| || ||    ||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>154.392</Hsp_bit-score>
+      <Hsp_score>83</Hsp_score>
+      <Hsp_evalue>4.64494e-40</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>169</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>175</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>149</Hsp_identity>
+      <Hsp_positive>149</Hsp_positive>
+      <Hsp_gaps>14</Hsp_gaps>
+      <Hsp_align-len>179</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATAT--TAAAAAATATAATGATGTATTCTTATA-AAGTGTATGGTTGTTGGTTGTTTTG-CAGCG---GCC--CTTGTGGCAGCTCRCTATAAAGATGTAGTTTATTATGTCTTAAGCGAGTGCTG-TGAAACAACAAAAAAT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTATAAAAAATATAATGATGTATCATTCTATAAGTGTATGGTGGTTG-TTGTTTCGACAGCTAAAGTTTACTT-TAGCAGCCTACTATAAAGATGTAGTTTATTATGTCTTAAGT-A-TGGTGTTGATTCAACAAAAAAT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||||  ||||||||||||||||||||  || || ||||||||||| |||| |||||| | ||||    |    ||| | |||||   ||||||||||||||||||||||||||||||  | || || |||  |||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>14</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|3</Hit_id>
+  <Hit_def>AB462266.1 Culicoides japonicus genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Ngs24_1</Hit_def>
+  <Hit_accession>3</Hit_accession>
+  <Hit_len>925</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>492.329</Hsp_bit-score>
+      <Hsp_score>266</Hsp_score>
+      <Hsp_evalue>8.66644e-142</Hsp_evalue>
+      <Hsp_query-from>165</Hsp_query-from>
+      <Hsp_query-to>710</Hsp_query-to>
+      <Hsp_hit-from>316</Hsp_hit-from>
+      <Hsp_hit-to>854</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>471</Hsp_identity>
+      <Hsp_positive>471</Hsp_positive>
+      <Hsp_gaps>41</Hsp_gaps>
+      <Hsp_align-len>563</Hsp_align-len>
+      <Hsp_qseq>AAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCAGTAAAACTAGT----GATTTCG-TGTCGCTAGTATGCATACATCTCTTTCGGGAGGGTATGCATTGATTTTATATCAAGATACTTTGGTGTGAT---AGTACGAATAGTACAT-ATAAAAT-AAAAAA-T-ATAAGAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATAT-TTCATGATATTCACGAAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTCATGCTTGTTGAAAGACATAGTTTGAGTGCATGATGTGATCATATGAATTTT-TT-C--ATATATCATTAATAGAGTATATGGTTTATACTACTTGCTTACGCGGCATGTTTGACCATTATTTTTATTTAACAAAATAACAAATTTTGGTATAAAAT</Hsp_qseq>
+      <Hsp_hseq>AAAATTACTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCC-GTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATG--TATAT-AC-TT-AGTTGTATATGCATTGATATTTT-TCATGATACTTTGGTGTGATTTTTGTA-AAACAAAATATAATAAAATAAAAAAATTGATCA-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATATTACT--TATTCACAAAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTTTGTTG-----CATA-----AGTGCATGATGTGATCATATAAGCTTTATTGCTTATATATCATTAATAAAGG-TGTGATAAATGGTACAAAA-TACTTTGCATATTTAACCATTATTTTTATTTAACATGAAAAT-AATTTTGGTATAAAAT</Hsp_hseq>
+      <Hsp_midline>|||||| |||||||||||||||||||||||||||||||||||||||||||||||||| |||||||||||     ||| ||  || |||||||||  || ||  | ||  |  |  ||||||||||| || | ||| ||||||||||||||||    |||  || |  | || ||||||| |||||| | || | ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||  |  ||||||| ||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||| ||||||     ||||     |||||||||||||||||||| |  ||| || |  |||||||||||||| ||  | || |  ||  |||     |||   |||| ||| ||||||||||||||||||||  | ||  ||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>126.692</Hsp_bit-score>
+      <Hsp_score>68</Hsp_score>
+      <Hsp_evalue>1.01259e-31</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>156</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>170</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>139</Hsp_identity>
+      <Hsp_positive>139</Hsp_positive>
+      <Hsp_gaps>16</Hsp_gaps>
+      <Hsp_align-len>171</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATT-AAAAAATATAATGATGTATT-CTTATA--AAGTGTA-TGGTTGTTGGTTGT-T-TTGCAGCGGCC-CT-TGTG------GCAGCTCRCTATAAAGATGTAGTTTATTATGTCTTAAGCGAGTGCTGTGA</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAAATATAATGATGTATCACTTATATTAAG-GTATTGGTTGTTTATTGTGTGTTGAAGCAGCAGCTATTTTAATATAGCAGCTTACTATAAAAATATAGTTTATTATATTTTAAGTAAGTGCTGTGA</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||||| |||||||||||||||||||  ||||||  ||| ||| ||||||||  |||| | ||| ||| ||  || | |       ||||||  ||||||| || ||||||||||| | |||||  ||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>15</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|16</Hit_id>
+  <Hit_def>AB462279.1 Culicoides oxystoma genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Naha16_1</Hit_def>
+  <Hit_accession>16</Hit_accession>
+  <Hit_len>796</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>468.323</Hsp_bit-score>
+      <Hsp_score>253</Hsp_score>
+      <Hsp_evalue>1.4605e-134</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>557</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>572</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>483</Hsp_identity>
+      <Hsp_positive>483</Hsp_positive>
+      <Hsp_gaps>45</Hsp_gaps>
+      <Hsp_align-len>587</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATT--AAAAA-ATATAATGATGTATTCTTATAAAGTGTATGGTTGTTGGTTGTTTTGCAGCGGC-CCTTGT---GGCAGCTCRCTATAAAGATGTAGTTTATTATGTCTTAAGCGAGTGC-TGTGA-AACAACAAAAAAT-TTCTTGGGTAGCTTT-ATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCAGTAAAACTAGT----GATTTCG-TGTCGCTAGTATGCATA-CATCTCTTTCGGGAGGGTATGCATTGATTTTATATCAAGATACTTTGGTGTGA--TAG--TACGAATAGTACATATAA-AAT-AAAAAA-T-ATAAGAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTG-T-AATATT-TCA-TGAT-ATTCACGAAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTA-ATTAAAAAAACATATAATGATGT-TTC--AT-AAG-GTATGG-TGTTGTTAATATGGTAGTGTCGTCTTGTCACGACAGCTTGTTATAAAGATGTAGTTTATTATGTCTTAAACAAGTCAATATCATATTAACGCAAAATAATCTTAGGTAGCTTTTATGTAAGAGCTTTAAAGACTTTTTTGCCTAAGGCCCC-GTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGTATATAATACCTTGC-GTATTGTATGCATTGATTTT---TCATGATATTAATGTGTGATGTTGTTTATGCAAA--ACAATTAATAATAAAAAAATTGATCA-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCTAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATACGATTAGATTTTGATTAATAATCTCAATGATAATTGACAAAATCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||| |||  ||||| |||||||||||| |||  || ||| |||||| ||||| |  | | | || | |  |||||   | |||||   |||||||||||||||||||||||||||| | |||   | | | |  |||  |||||  |||| ||||||||| ||  ||||||||||||||||| |||||| |||||||| |||||||||||     ||| ||  || ||||||||| |||  ||  ||| | | |  |||||||||||||||   ||| |||| |   ||||||  | |  || | | |  |||  ||| ||| |||||| | || | ||||||||||||||||||||||||||||||||||||||||||||||||||| ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||||||||||||| | |||| | ||| |||| ||| || || ||||||||||||||||||||||||||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>16</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|6</Hit_id>
+  <Hit_def>AB462269.1 Culicoides cylindratus genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Kag08, long type</Hit_def>
+  <Hit_accession>6</Hit_accession>
+  <Hit_len>820</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>457.243</Hsp_bit-score>
+      <Hsp_score>247</Hsp_score>
+      <Hsp_evalue>3.16142e-131</Hsp_evalue>
+      <Hsp_query-from>165</Hsp_query-from>
+      <Hsp_query-to>776</Hsp_query-to>
+      <Hsp_hit-from>234</Hsp_hit-from>
+      <Hsp_hit-to>820</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>505</Hsp_identity>
+      <Hsp_positive>505</Hsp_positive>
+      <Hsp_gaps>49</Hsp_gaps>
+      <Hsp_align-len>624</Hsp_align-len>
+      <Hsp_qseq>AAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCAGTAAAACTAGTGATTTCGTGTCGCTAGTATGCATACATCTCTTTCGGGAGGGTATGCATTGATTTTATATCAAGATACTTTGG--TGTG-ATAGTAC--GAATAGTACAT-ATA-AAATAAAAAATATAAGAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCATGATATTCACGAAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTCATGCTTGTTGAAAGACATAGTTTGAGTGCATGATGTGATCATATGAATTTTTTCATATATCATTAATAGAGTATATGGTTT-A--TACTACTTGCTTACGCGGCATGTTTGACCATTATTTTTATTTAACAAAATAACAAATTTTGGTATAAAATCAAGCGTGTTGTAGGCT-GACGTAGAT-AAAACTCTTTCTTTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>AAAATTTCTTAGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCTAAGGCCCC-GTAAAACTAGT-AACCCAT-T-GCGAGGTGGC-T--A---GTAT--GCA---TATGCATTGATATTTT-TCATGATACTTTGGAGTGAGTATAATACAAAAATTGTACATAAAACAAATAAAAAAGATCA-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTATAATATTTT-TGATATTCATAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATG-T-GTKTWAAWACRTA-----AGTGCATGATGTGATCATAAAAGTCTACTTTTATATCATTAAT-GA--AGGTGGTAACAAATA-TACTTGAT-AYMA-GCGTRTTTGACCATTATTTTTATTTAATTTAATATG-AATTTTGGTTTAAA-TCAAATATGT-GTAT-CTCGTTGTTGTTTATAAATAA--CTTTATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>|||||||||| ||||||||||||||||||||||||||||||||||||| |||||||| ||||||||||| |   | | | || ||   || |  |    | |  | |   ||||||||||| || | ||| ||||||||||  || | ||| |||   ||| |||||| | | |||||||||| || | |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||||||||  |||||||||  | ||||||||||||||||||||||||||||||||||||||||||||||||||||| ||| | ||   || || ||     |||||||||||||||||||  | | |  |  |||||||||||| ||  |  ||||   |  || |||||| | |    || | ||||||||||||||||||||||   ||||   ||||||||| |||| ||||   ||| |||  || |  || | | | || |    ||||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>108.226</Hsp_bit-score>
+      <Hsp_score>58</Hsp_score>
+      <Hsp_evalue>3.66778e-26</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>58</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>58</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>58</Hsp_identity>
+      <Hsp_positive>58</Hsp_positive>
+      <Hsp_gaps>0</Hsp_gaps>
+      <Hsp_align-len>58</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAATATAATGATGT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAATATAATGATGT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>17</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|8</Hit_id>
+  <Hit_def>AB462271.1 Culicoides lungchiensis genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: AM05_8</Hit_def>
+  <Hit_accession>8</Hit_accession>
+  <Hit_len>776</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>449.856</Hsp_bit-score>
+      <Hsp_score>243</Hsp_score>
+      <Hsp_evalue>5.29018e-129</Hsp_evalue>
+      <Hsp_query-from>166</Hsp_query-from>
+      <Hsp_query-to>626</Hsp_query-to>
+      <Hsp_hit-from>182</Hsp_hit-from>
+      <Hsp_hit-to>650</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>408</Hsp_identity>
+      <Hsp_positive>408</Hsp_positive>
+      <Hsp_gaps>34</Hsp_gaps>
+      <Hsp_align-len>482</Hsp_align-len>
+      <Hsp_qseq>AAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCAGTAAAACTAGT----GATTTCG-TGTCGCTAGTATG--CATACATCTCTTTCGGGAGGGTATGCATTGATTTTATATCAAGATACTTTGGTGT---G------ATAGTACGAA-TAGTACATATAAAATAAAAAATATAAGAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCATGATATTCACGAAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTCATGCTTGTTGAAAGACATA-GTT--TGA-GTGCATGATGTGATCATATGAATTTTTTCATATATCATTAATA</Hsp_qseq>
+      <Hsp_hseq>AAATTACTTGGGTAGCTTTATTGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCC-GTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGTATATACATTTATTT--GTA---TATACATTGATATTTTTTCATGATACTTTGGTATAAAGAAAAAAAAAGTACAATTTTGTACATATAAAA-AAAAAAGAT-CTAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTT-TGATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTTCCTTTTA---CATAAGTGCATGATGTG-ATTATATGAAAATATTATATTTTTCATATATCATTAATA</Hsp_hseq>
+      <Hsp_midline>||||| ||||||||||||||| |||||||||||||||||||||||||||||||||| |||||||||||     ||| ||  || |||||||||   |||||| | |||  | |   ||| ||||||| || | ||| ||||||||||| |   |      | ||||| |  | |||||||||||| |||||| ||   |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  |||||||||| | ||||||||||||||||||||||||||||||||||||||||||||||||||||| ||| |  ||  |   |||| ||   ||| ||| || || |||  |||| |  ||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>91.6061</Hsp_bit-score>
+      <Hsp_score>49</Hsp_score>
+      <Hsp_evalue>3.69382e-21</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>82</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>83</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>76</Hsp_identity>
+      <Hsp_positive>76</Hsp_positive>
+      <Hsp_gaps>9</Hsp_gaps>
+      <Hsp_align-len>87</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTAT-ATTAAAAAA-TATAATGATGTATTCT-T-ATAAAGTGT-ATGGTTGTT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATTAAAAAAAAAATATAATGATGT-T-CTATCATAA-GTGTTATGGT-GTT</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||| |  |||||| ||||||||||| | || | |||| |||| ||||| |||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>3</Hsp_num>
+      <Hsp_bit-score>56.5198</Hsp_bit-score>
+      <Hsp_score>30</Hsp_score>
+      <Hsp_evalue>1.34747e-10</Hsp_evalue>
+      <Hsp_query-from>744</Hsp_query-from>
+      <Hsp_query-to>776</Hsp_query-to>
+      <Hsp_hit-from>744</Hsp_hit-from>
+      <Hsp_hit-to>776</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>32</Hsp_identity>
+      <Hsp_positive>32</Hsp_positive>
+      <Hsp_gaps>0</Hsp_gaps>
+      <Hsp_align-len>33</Hsp_align-len>
+      <Hsp_qseq>TTTCTTTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>TTTATTTATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>||| |||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>18</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|2</Hit_id>
+  <Hit_def>AB462265.1 Culicoides arakawae genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Kag02</Hit_def>
+  <Hit_accession>2</Hit_accession>
+  <Hit_len>907</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>444.316</Hsp_bit-score>
+      <Hsp_score>240</Hsp_score>
+      <Hsp_evalue>2.46128e-127</Hsp_evalue>
+      <Hsp_query-from>165</Hsp_query-from>
+      <Hsp_query-to>601</Hsp_query-to>
+      <Hsp_hit-from>303</Hsp_hit-from>
+      <Hsp_hit-to>742</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>385</Hsp_identity>
+      <Hsp_positive>385</Hsp_positive>
+      <Hsp_gaps>25</Hsp_gaps>
+      <Hsp_align-len>451</Hsp_align-len>
+      <Hsp_qseq>AAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCAGTAAAACTAGT----GATTTCG-TGTCGCTAGTATGCATACATCTCTTTCGGGAGGGTATGCATTGATTTTATATCAAGATACTTTGGTGTGATA--GTACGAATAGTAC-A-----TA-TAAAATAAAAAATATAAGAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCATGATATTCACGAAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTCATGCTTGTTGAAAGACATAGTTTGAGTGCATGATGTGATCATA</Hsp_qseq>
+      <Hsp_hseq>AAAATTACTTAGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCTAAGG-CCCTGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGTATATACTTAATT--GTA---TATGCATTGATATTTT-TCATGATACTTTGGTGTGATATAATAAAAAT-GTACAATTTTGTACTAATAAAAAAAAGATCA-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATAA-ATAATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATATTATTTGAAAAAG-TAATATAAGTGCATGATGTGATTATA</Hsp_hseq>
+      <Hsp_midline>|||||| ||| ||||||||||||||||||||||||||||||||||||| |||| ||| |||||||||||     ||| ||  || ||||||||| ||| |  |  ||  | |   ||||||||||| || | ||| |||||||||||||||||   ||  ||| |||| |     || ||| | |||||| || | |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||   || |||||||| | ||||||||||||||||||||||||||||||||||||||||||||||||||||| ||  |  |||||| |  || | | ||||||||||||||| |||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>111.919</Hsp_bit-score>
+      <Hsp_score>60</Hsp_score>
+      <Hsp_evalue>2.83537e-27</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>82</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>81</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>78</Hsp_identity>
+      <Hsp_positive>78</Hsp_positive>
+      <Hsp_gaps>7</Hsp_gaps>
+      <Hsp_align-len>85</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAA-TATAATGATGT--ATTCTTATAAAGTGTATGGTTGTT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAAATATAATGATGTTCATTC--ATAA-G-GTATGGTTGTT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||||||||||| |||||||||||  ||||  |||| | |||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>19</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|11</Hit_id>
+  <Hit_def>AB462274.1 Culicoides peregrinus genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Yng26</Hit_def>
+  <Hit_accession>11</Hit_accession>
+  <Hit_len>794</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>435.083</Hsp_bit-score>
+      <Hsp_score>235</Hsp_score>
+      <Hsp_evalue>1.48131e-124</Hsp_evalue>
+      <Hsp_query-from>167</Hsp_query-from>
+      <Hsp_query-to>634</Hsp_query-to>
+      <Hsp_hit-from>190</Hsp_hit-from>
+      <Hsp_hit-to>675</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>417</Hsp_identity>
+      <Hsp_positive>417</Hsp_positive>
+      <Hsp_gaps>42</Hsp_gaps>
+      <Hsp_align-len>498</Hsp_align-len>
+      <Hsp_qseq>AATTTCTTGGGTAGCTTTA--TAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCAGTAAAACTAGT----GATTTCG-TGTCGCTAGTATGCATACATCTCTTTCGGGAGGGTATGCATTGATTTTA-TATCAAGATACTTTGGTGTGA--T--AG---TACG-A--A--TAGTACATAT-AAAATAAAAAATATAAGAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCATGATATTCACGAAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTCATGCTTGTTGAAAGACATAGTTTGAGTGCATGATGTGATCATATGA---------ATTTTTTCATATATCATTAATAGAGTATAT</Hsp_qseq>
+      <Hsp_hseq>AATTTCTTGGGTAGCTTTAATTTTAAGAGCTTTAAAGACTTTTTTGCCCAAGGCCCC-GTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGTATATACTTAATT--GTA---TATACATTGATATTATTTTCATGATACTTTGGTGTGAAATAAAGTTATAAGTACTATTTTGTACATATAAAAAAAAAAAAGAT-CTAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCMTGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTT-TGATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATATTTTTTTAATAAAATA-TA--AGTGCATGATGTGATTATATGAAAATGTAATATTTTTTCATATATCATTAATAAA-TATAT</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||  |  ||||||||||||||||| ||||||||||||||| |||||||||||     ||| ||  || ||||||||| ||| |  |  ||  | |   ||| ||||||| ||| | ||| |||||||||||||||  |  ||   || | |  |  | |||||||| |||| |||||| ||   |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  |||||||||| | ||||||||||||||||||||||||||||||||||||||||||||||||||||| ||  || || ||  | ||| |   ||||||||||||||| ||||||         |||||||||||||||||||||| | |||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>106.379</Hsp_bit-score>
+      <Hsp_score>57</Hsp_score>
+      <Hsp_evalue>1.31917e-25</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>82</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>87</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>79</Hsp_identity>
+      <Hsp_positive>79</Hsp_positive>
+      <Hsp_gaps>7</Hsp_gaps>
+      <Hsp_align-len>88</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATAT-T-AAAAAATATAATGATGTA-T-TC-TTATAAAGTGT-ATGGTTGTT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATATAAAAAAATATAATGATGTTCTCTCATTAAAAAGTGTTATGGT-GTT</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||||| | |||||||||||||||||  | || ||| ||||||| ||||| |||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>3</Hsp_num>
+      <Hsp_bit-score>58.3664</Hsp_bit-score>
+      <Hsp_score>31</Hsp_score>
+      <Hsp_evalue>3.74646e-11</Hsp_evalue>
+      <Hsp_query-from>660</Hsp_query-from>
+      <Hsp_query-to>776</Hsp_query-to>
+      <Hsp_hit-from>687</Hsp_hit-from>
+      <Hsp_hit-to>794</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>92</Hsp_identity>
+      <Hsp_positive>92</Hsp_positive>
+      <Hsp_gaps>13</Hsp_gaps>
+      <Hsp_align-len>119</Hsp_align-len>
+      <Hsp_qseq>ATGTTTGACCATTATTTTT-ATTTAA-CAAAATAACAAATTTTGGTATAAAATCAAGCGTGTTGTAGGCTGACGTAGATAAAACTCTTTCTTTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>ATATTTGACCATTATTTTTTATTTAATTAAAATAA-TAATATTGGT-TTAAATCAA--AT-ATATA--TTGA-G-AAAT-ATTGT-TTTATTTATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>|| |||||||||||||||| ||||||  |||||||  ||| ||||| | |||||||   |  | ||   ||| | | || |   | ||| |||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>20</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|10</Hit_id>
+  <Hit_def>AB462273.1 Culicoides ohmorii genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Kag05</Hit_def>
+  <Hit_accession>10</Hit_accession>
+  <Hit_len>825</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>429.543</Hsp_bit-score>
+      <Hsp_score>232</Hsp_score>
+      <Hsp_evalue>6.89186e-123</Hsp_evalue>
+      <Hsp_query-from>166</Hsp_query-from>
+      <Hsp_query-to>606</Hsp_query-to>
+      <Hsp_hit-from>202</Hsp_hit-from>
+      <Hsp_hit-to>662</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>396</Hsp_identity>
+      <Hsp_positive>396</Hsp_positive>
+      <Hsp_gaps>36</Hsp_gaps>
+      <Hsp_align-len>469</Hsp_align-len>
+      <Hsp_qseq>AAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCAGTAAAACTAGT----GATTTCG-TGTCGCTAGTATGCATACATCTCTTTCGGGAGGGTATGCATTGATTTTATATCAAGATACTTTGGTGTG--AT-A-GT---------A-C-GAATA-GTACAT--ATA-AAATAAAAAATATAAG-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCATGATATTCACGAAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTCATGCTTGTTG-AAAGACAT--AGTTTGAGTGCATGATGTGATCATATGAAT</Hsp_qseq>
+      <Hsp_hseq>AAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCC-GTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGTATATACTTAATT--GTA---TATGCATTGATATTTT-TCATGATACTTTGGTGTGTGATAATATAAAAAAAAAATCTTTATATTTATATAGAGAGAAAAAAAAAAAATAAGAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTT-TGATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTTATTTGTAAAAAAAAGAAGCATAAGTGCATGATGTGATTATATAAAT</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||||||||||||||||||||| |||||||||||     ||| ||  || ||||||||| ||| |  |  ||  | |   ||||||||||| || | ||| ||||||||||||||  || |  |         | |   |||  || ||  | | ||| |||||| ||||| |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  |||||||||| | ||||||||||||||||||||||||||||||||||||||||||||||||||||| ||| |  ||| ||| | |   ||  | ||||||||||||||| |||| |||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>89.7595</Hsp_bit-score>
+      <Hsp_score>48</Hsp_score>
+      <Hsp_evalue>1.32853e-20</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>67</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>71</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>64</Hsp_identity>
+      <Hsp_positive>64</Hsp_positive>
+      <Hsp_gaps>4</Hsp_gaps>
+      <Hsp_align-len>71</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTAT-ATTA-AAAAATATAATGATGT--ATTCTTATA</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATTAACATAAAAATATAATGATGTTCATTCATATA</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||| |  | ||||||||||||||||  |||| ||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>3</Hsp_num>
+      <Hsp_bit-score>54.6731</Hsp_bit-score>
+      <Hsp_score>29</Hsp_score>
+      <Hsp_evalue>4.84635e-10</Hsp_evalue>
+      <Hsp_query-from>745</Hsp_query-from>
+      <Hsp_query-to>776</Hsp_query-to>
+      <Hsp_hit-from>794</Hsp_hit-from>
+      <Hsp_hit-to>825</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>31</Hsp_identity>
+      <Hsp_positive>31</Hsp_positive>
+      <Hsp_gaps>0</Hsp_gaps>
+      <Hsp_align-len>32</Hsp_align-len>
+      <Hsp_qseq>TTCTTTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>TTATTTATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>|| |||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>21</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|14</Hit_id>
+  <Hit_def>AB462277.1 Culicoides charadraeus genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: KC05_14</Hit_def>
+  <Hit_accession>14</Hit_accession>
+  <Hit_len>913</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>374.144</Hsp_bit-score>
+      <Hsp_score>202</Hsp_score>
+      <Hsp_evalue>3.27525e-106</Hsp_evalue>
+      <Hsp_query-from>166</Hsp_query-from>
+      <Hsp_query-to>557</Hsp_query-to>
+      <Hsp_hit-from>296</Hsp_hit-from>
+      <Hsp_hit-to>661</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>335</Hsp_identity>
+      <Hsp_positive>335</Hsp_positive>
+      <Hsp_gaps>30</Hsp_gaps>
+      <Hsp_align-len>394</Hsp_align-len>
+      <Hsp_qseq>AAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCAGTAAAACTAGTGATTTCGTGTCGCTAGTATGCATACATCTCTTTCGGGAGGGTATGCATTGATTTTATATCAAGATACTTTGGTGTGATAGTACGAATAGTACATATAAAATAAAAAATATAAGAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAAT--ATTTCATGATATTCACGAAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCT</Hsp_qseq>
+      <Hsp_hseq>AAATTTCTTAGGTAGCTTTATCGAAGAGCTTTAAAGACTTGTTTGCCTAAGGCCCC-GTAAAACTAGT-AACCCAT-T-GCGAGGTGGC-T--A---GTAT--GCA-TTTGTGCATTGATATTTT-TCATGATACTTTGGTGTGTTTGT--G--TAATA-AAAAAAAAT-AAAAA-AT--CAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATTGATATT-TGTTAT--A--AAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCT</Hsp_hseq>
+      <Hsp_midline>||||||||| ||||||||||| ||||||||||||||||||||||||| |||||||| ||||||||||| |   | | | || ||   || |  |    | |  | |   | ||||||||| || | ||| |||||||||||||| | ||  |  || || | | ||||| ||||| ||   |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  || |  || |||  |  |||||||||||||||||||||||||||||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>87.9128</Hsp_bit-score>
+      <Hsp_score>47</Hsp_score>
+      <Hsp_evalue>4.77826e-20</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>63</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>68</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>62</Hsp_identity>
+      <Hsp_positive>62</Hsp_positive>
+      <Hsp_gaps>5</Hsp_gaps>
+      <Hsp_align-len>68</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTA-TATTAAA-AAA---TATAATGATGTATTCT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTAATATAAAACAAAAATTATAATGATGTATTCT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||| ||| ||| |||   ||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>22</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|7</Hit_id>
+  <Hit_def>AB462270.1 Culicoides dubius genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Isg23</Hit_def>
+  <Hit_accession>7</Hit_accession>
+  <Hit_len>1096</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>366.757</Hsp_bit-score>
+      <Hsp_score>198</Hsp_score>
+      <Hsp_evalue>5.48065e-104</Hsp_evalue>
+      <Hsp_query-from>328</Hsp_query-from>
+      <Hsp_query-to>557</Hsp_query-to>
+      <Hsp_hit-from>597</Hsp_hit-from>
+      <Hsp_hit-to>828</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>222</Hsp_identity>
+      <Hsp_positive>222</Hsp_positive>
+      <Hsp_gaps>4</Hsp_gaps>
+      <Hsp_align-len>233</Hsp_align-len>
+      <Hsp_qseq>ATAAAATAAAAAATATAAGAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCA-T-GATATTCAC-GAAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCT</Hsp_qseq>
+      <Hsp_hseq>ATAAAAAAAAAAATTAAATAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATCTTAGTTGTTATTCACAGAA-TCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCT</Hsp_hseq>
+      <Hsp_midline>|||||| |||||||  || ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| | | | | ||||||| ||| ||||||||||||||||||||||||||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>122.999</Hsp_bit-score>
+      <Hsp_score>66</Hsp_score>
+      <Hsp_evalue>1.30987e-30</Hsp_evalue>
+      <Hsp_query-from>164</Hsp_query-from>
+      <Hsp_query-to>233</Hsp_query-to>
+      <Hsp_hit-from>393</Hsp_hit-from>
+      <Hsp_hit-to>461</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>69</Hsp_identity>
+      <Hsp_positive>69</Hsp_positive>
+      <Hsp_gaps>1</Hsp_gaps>
+      <Hsp_align-len>70</Hsp_align-len>
+      <Hsp_qseq>AAAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCAGTAAAACTAGT</Hsp_qseq>
+      <Hsp_hseq>AAAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCC-GTAAAACTAGT</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||||||||||||||||||||||| |||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>3</Hsp_num>
+      <Hsp_bit-score>76.8329</Hsp_bit-score>
+      <Hsp_score>41</Hsp_score>
+      <Hsp_evalue>1.03431e-16</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>51</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>49</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>48</Hsp_identity>
+      <Hsp_positive>48</Hsp_positive>
+      <Hsp_gaps>2</Hsp_gaps>
+      <Hsp_align-len>51</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAATATA</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATA--AAAATATATA</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||||  |||| |||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+</Iteration_hits>
+  <Iteration_stat>
+    <Statistics>
+      <Statistics_db-num>22</Statistics_db-num>
+      <Statistics_db-len>18669</Statistics_db-len>
+      <Statistics_hsp-len>16</Statistics_hsp-len>
+      <Statistics_eff-space>13920920</Statistics_eff-space>
+      <Statistics_kappa>0.46</Statistics_kappa>
+      <Statistics_lambda>1.28</Statistics_lambda>
+      <Statistics_entropy>0.85</Statistics_entropy>
+    </Statistics>
+  </Iteration_stat>
+</Iteration>
+<Iteration>
+  <Iteration_iter-num>4</Iteration_iter-num>
+  <Iteration_query-ID>Query_4</Iteration_query-ID>
+  <Iteration_query-def>AB462260.1 Culicoides brevipalpis genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Isg21</Iteration_query-def>
+  <Iteration_query-len>780</Iteration_query-len>
+<Iteration_hits>
+<Hit>
+  <Hit_num>1</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|0</Hit_id>
+  <Hit_def>AB462263.1 Culicoides maculatus genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Kag12_1</Hit_def>
+  <Hit_accession>0</Hit_accession>
+  <Hit_len>764</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>673.301</Hsp_bit-score>
+      <Hsp_score>364</Hsp_score>
+      <Hsp_evalue>0</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>780</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>764</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>664</Hsp_identity>
+      <Hsp_positive>664</Hsp_positive>
+      <Hsp_gaps>56</Hsp_gaps>
+      <Hsp_align-len>800</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTATAAAAAAATATAATGATGTATTCT--AGTGTATGGTTGTTTCGTTGGCATTGCAACTGCTCGCTCGAGGGCAGCTCACTATAAAGATGTAGTTTATTATGTCTTAAGTGAGTGTTGTGATACAAC-AAAAATTACTTGGGTAGCTTTATCGAAGAGCTTTAAAGATTTGTATGCCCAAGG--CCCGTAAAACTAGTGA-CTTCGTGTCACTAGTATGCATGT-TCTCTCGCAGAGCATGCATTGATTTT-TATCAAGATACTTTGGAGTGATAGTACGAATGTACGCATAACAAACAAACAAAAAAAGATC-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCT-GATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGT-T-GTTTCACAGCATCA---TAAGTGCATGATGTGATTATATGGGCCGCGCTCTCACGAGCAACGCTCATATATCATTAATAGATG-TGTGGTTTAGTGCAGC-A-GTGTGCATGTTTGACCATTATTTTTATTTAATGCAAATAACAAATTTTGGTATAAAATCAAGCG-TGCCTCTG-CGACAAAACTGTAACATTTAAATTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTA-A--CT--AAACATTCAATGATGTATTCTTTAAGGTATGGTTG--TCGTTGTTATTGCAGCAGC-CTCTCGCGGGCAGCTTGCTATAAAGATGTAGTTTATTATGTCTTAAGCAAGTGTTGTGGTTCAACAAAAAATTACTTGGGTAGCTTTATTTAAGAGCTTTAAAGACTTGTTTGCCCAAGGCTCCCGTAAAACTAGTGATCTT-GTTTCATTAGTATGCAATTATAT-TTATATA-TTTGCATTGATTTTATATCAAGATACTTTGGTGTGA--GTACGTATGTA--CAT---ATA-AAACAAAAAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTTCGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTATTGTCTGAAAAGATAAATGTAAGTGCATGATGTGATCATATGGA------T-TWACTT-------TCATATATCATTAATGGAGGATATGGTT-ATCGCTGCTATGTTTGCACACTTGGCCATTATTTTTATTTAGTT-AAA-AATATATATTGGTATAAAATCAAGTGGTGTAGCTGGCGCTAAAGCGATTCTATTCTATCTATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||| |   |  ||| ||  |||||||||||||  |  |||||||||  ||||||  |||||| | || | |||| ||||||||  ||||||||||||||||||||||||||||||  ||||||||| | |||| |||||||||||||||||||||||  |||||||||||||| |||| |||||||||  |||||||||||||||| ||| || ||| |||||||||  | | | |   | |   |||||||||||| |||||||||||||||| ||||  ||||| |||||  |||   | | ||||||||||||||| ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| | |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| | || | | |  || |   ||||||||||||||||| ||||||       | | ||         ||||||||||||||| || | | ||||| |  || || | || ||||   ||| |||||||||||||||| |  ||| || | || |||||||||||||||| | ||   ||| ||  ||| |  |   |||  |  |||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>2</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|12</Hit_id>
+  <Hit_def>AB462275.1 Culicoides punctatus genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Kag13_1</Hit_def>
+  <Hit_accession>12</Hit_accession>
+  <Hit_len>787</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>632.674</Hsp_bit-score>
+      <Hsp_score>342</Hsp_score>
+      <Hsp_evalue>0</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>780</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>787</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>665</Hsp_identity>
+      <Hsp_positive>665</Hsp_positive>
+      <Hsp_gaps>57</Hsp_gaps>
+      <Hsp_align-len>812</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTATAAAAAAATATAATGATGT--ATTC--TAGTGTATGGTTGTTTCGTTGGCATTGCAACTGCTCGCTCGAG--GGCAGCTCACTATAAAGATGTAGTTTATTATGTCTTAAGTGAGT--GTT---GTGATACAACAAAAATTACTTGGGTAGCTTTATCGAAGAGCTTTAAAGATTTGTATGCCCAAGG-CCCGTAAAACTAGTGAC---TT-CG-TGTCACTAGTATGCATGTTCTCTCGCAGAGCATGCATTGATTTTTATC-AAGATACTTTGGAGTGA-TAGTA-CG-AATGTACGCATA-ACAAAC-AAACAAAAAAAGATCAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCT-GATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTTGTTTCACAGCAT-CATAAGTGCATGATGTGATTATATGGGCCGCGCTCTCACGAGCAACGCTCATATATCATTAATAGATGTGTGGTT-TAGTGCAGC-AGTGT--GC-ATGTTTGACCATTATTTTTATTTAATGCAAATAACAAATTTTGGTATAAAATCAAGCGT-GCCTCTGCGACAAAACTG-TAACATTTAAATTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTAT--TAT-AAAACATATAATGATGTTCATTCTATAG-GTATGGTTGTTGTGTTGTCATTGTAAGAG-TC-ATTTAGTTGGCAGCTCTCTATAAAGACATAGTTTATTATGTTTTAAGGGAGTACCTTGCAGTGCGACAA-AAAAATTACTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGCATATACT-TAATTGTATATGCATTGATTTATTTCAAAGATACATTGGAGAGAGTATAATTGTAATGAAATTGTACATAAACAAAACAAAAAAAGTAAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTTCGATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTC-TTTCACTGAAAGCATAAGTGCATGATGTGATTATATAGGT-GA--TATCA--A-CT----T-ATATATCATTAATAAA-GTGTGGTGGTAACAAATATACTTTAAGCTATGTTTGACCATTATTTTTATCTAAA--AAATAATAAATTTTGGTATAAAATCAAATGTAGTGTTTGTTTGTTA-CTCATAACATCCAT-TTATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||  ||| |||| ||||||||||||  ||||  ||| |||||||||||  |||| ||||| ||  | ||  |  ||  |||||||| |||||||||  ||||||||||||| ||||| ||||   ||   |||  |||| ||||||||||||||||||||||| ||||||||||||||| |||| ||||||||| |||||||||||||| ||   || ||  ||  ||||||||||| | || |    |   |||||||||||| | || ||||||| |||||| || ||  |  | |||| |    || | |||| ||||||||||||   ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| | ||||||||||  ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  |||||| | |  |||||||||||||||||||||||| ||  |   | |||  | |     | |||||||||||||| | |||||||  ||    |   | | |  || ||||||||||||||||||||| |||   |||||| ||||||||||||||||||||  || |  | ||      | ||  ||||||  |  ||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>3</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|1</Hit_id>
+  <Hit_def>AB462264.1 Culicoides wadai genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Isg18_1</Hit_def>
+  <Hit_accession>1</Hit_accession>
+  <Hit_len>834</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>627.135</Hsp_bit-score>
+      <Hsp_score>339</Hsp_score>
+      <Hsp_evalue>0</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>780</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>834</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>696</Hsp_identity>
+      <Hsp_positive>696</Hsp_positive>
+      <Hsp_gaps>90</Hsp_gaps>
+      <Hsp_align-len>852</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTATAAAAAAATATAATGATGTATTCT----AGTGTAT-G--GTTGTTT-CGTTGGCATTGCAACTGCTCG-C-------TCG-AGGGCAGCTCACTATAAAGATGTAGTTTATTATGTCTTAAGTGAGTGTTGTGATACAACA----AAAATTACTTGGGTAGCTTTATCGAAGAGCTTTAAAGATTTGTATGCCCAAGGCCC---GTAAAACTAGTGA-CTTCGTGTCACTAGTATGCAT------G--T----TCTC-TCGCA---GAGC------ATGCATTGATTTTTATCAAGATACTTTGGAGTGATAGTACGAAT-GTACGCATAACAAACAAACAAAAAAAGATCAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCTGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGT-T-GTTTCACAGCATCATAAGTGCATGATGTGATTATATGGGC--CGCGCTCTCACGAGCAACGCTCATATATCATTAATAGATGTGTGGTTTA-GTGCA-G---CAGTGTGCATG--TTTGACCATTATTTTTATTTAATGCAAATAACAAATTTTGGTATAAAATCAAGCGT-GC-C--TCTG-CGACAAA--ACTG-TAACA-TT-T-AA--ATTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTA-A-TCT-AAAACATTCAATGATGTATTCTCACAAGTGTATGGTTGTTGTTTCCGTTGTTATTGTAGCAGCTCGTCGTAATTATCGTCGGGCAGCTTGCTATAAAGATGTAGTTTATTATGTCTTAAGCGAGTGCTGCAATACAACAATACAAAATTTCTTAGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCTAAGGCCCCCAGTAAAACTAGTGATCTTTGTGTCACTAGTATGCATATTAATGCATAACATCTCTTCGGAGGTGCGCTTTGATATGCATTGATTTATATCAAGATACTTTGGAGTGA--GTAC-ATTCGTAC-AAT-A-AAACAAACAAAAAAAGATCAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTTGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGACTCGTTTGAACGTCTCATAAGTGCATGATGTGATCATATGGATTTCGCGAT-TCAT-AT-ATCATTAATAAAGGAG-AATA--TG-GTTGTTAACGTGCGTGTTACATTGCGTTTGCATTTGACCATTATTTTTATTTAATA-AAATAATAAATTTTGGTATAAAATCAAATGTAGCGCAGTATATCG-CATACTACTACTACCACTTCTTAACCACTATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||| | | | |||| ||  |||||||||||||    ||||||| |  ||||||| |||||  |||| | | ||||| |       |||  ||||||||  |||||||||||||||||||||||||||||| ||||| ||  ||||||||    |||||| ||| ||||||||||| ||||||||||||||| |||| |||| |||||||   ||||||||||||| ||| |||||||||||||||||      |  |    |||| ||| |   | ||      |||||||||||| |||||||||||||||||||||  |||| | | ||||  || | |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  | |||| |  |  |||||||||||||||||||| ||||||    |||| | |||  |  | |  | ||| |  |  ||||  || || ||| | ||||  |   || || |  ||  |||||||||||||||||||||||  |||||| ||||||||||||||||||||  || || |  | |  || || |  |||  || || || | ||  | |||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>4</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|5</Hit_id>
+  <Hit_def>AB462268.1 Culicoides cylindratus genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Kag08, short type</Hit_def>
+  <Hit_accession>5</Hit_accession>
+  <Hit_len>748</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>549.575</Hsp_bit-score>
+      <Hsp_score>297</Hsp_score>
+      <Hsp_evalue>5.09701e-159</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>596</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>580</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>508</Hsp_identity>
+      <Hsp_positive>508</Hsp_positive>
+      <Hsp_gaps>38</Hsp_gaps>
+      <Hsp_align-len>607</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTATAAAAAAATATAATGATGT--ATTCTAGTGTATGGTTGTTTCGTTGGCATTGCAACTGCTCGCTCGAGGGCAGCTCACTATAAAGATGTAGTTTATTATGTCTTAAGTGAGTGTTGTGATACAAC-AAAAATTACTTGGGTAGCTTTATCGAAGAGCTTTAAAGATTTGTATGCCCAAGG-CCCGTAAAACTAGTGACTTCGTGTCACTAGTATGCATGTTCTCTCGCAGAGCATGCATTGATTTTTATCAAGATACTTTGGAGTGA---TAGTAC--GAA-TGTACGCATAACAAACAAACAAAAAAAGATC-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCTGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTTGTTTCACAGCATCATAAGTGCATGATGTGATTATA</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTAT------AAAATATATAATGATGTTCATTC-A--ATAAGGTTG-GTGGTT-GTATTGTAACAGCTATTTACTTAGCAGCTTGCTATAAAGATGTRGTTTATYATGTCTTAAGYAAGTGTTGYGATACARCAAAAAATTTCTTAGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCTAAGGCCCCGTAAAACTAGTAAC-CCAT-T-GCGAGGTGGC---TAGTAT-GC--A-TATGCATTGATATTTTTCATGATACTTTGGAGTGAGTATAATACAAAAATTGTACATAAAACAAA-AYA-AAAAAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTATAATATTTTTGATATTCATAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATAYATTAAACTATCTTATG-TGTGTAAAAG---CATAAGTGCATGATGTGATCATA</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||      |||| ||||||||||||  |||| |   || |||||  | ||| | |||| ||| |||   |     ||||||  |||||||||||| |||||| ||||||||||  ||||||| |||||| | ||||||| ||| ||||||||||| ||||||||||||||| |||| |||| |||| |||||||||||||| ||  | | |  | ||   ||   |  | | ||  |  |||||||||| ||| ||| |||||||||||||||   || |||   || |||||  | |||||| | | ||||||||||| |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| |||||||| ||||||||| |  |||||||||||||||||||||||||||||||||||||||| |||||||||||||||| ||| | | ||   ||||||||||||||||||| |||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>52.8265</Hsp_bit-score>
+      <Hsp_score>28</Hsp_score>
+      <Hsp_evalue>1.75223e-09</Hsp_evalue>
+      <Hsp_query-from>753</Hsp_query-from>
+      <Hsp_query-to>780</Hsp_query-to>
+      <Hsp_hit-from>721</Hsp_hit-from>
+      <Hsp_hit-to>748</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>28</Hsp_identity>
+      <Hsp_positive>28</Hsp_positive>
+      <Hsp_gaps>0</Hsp_gaps>
+      <Hsp_align-len>28</Hsp_align-len>
+      <Hsp_qseq>TTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>TTATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>5</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|17</Hit_id>
+  <Hit_def>AB462280.1 Culicoides kibunensis genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: AM05_6</Hit_def>
+  <Hit_accession>17</Hit_accession>
+  <Hit_len>817</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>527.415</Hsp_bit-score>
+      <Hsp_score>285</Hsp_score>
+      <Hsp_evalue>2.38824e-152</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>565</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>585</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>498</Hsp_identity>
+      <Hsp_positive>498</Hsp_positive>
+      <Hsp_gaps>40</Hsp_gaps>
+      <Hsp_align-len>595</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTATAAAAAAATATAATGATGTAT---TCTAGTGTATGGTTGTTTCGTTGGCATTGCAACTGCTCGCTCGAGGGCAGCTCACTATAAAGATGTAGTTTATTATGTCTTAAGTGAGTGTTGTGATACAA-CA---A-----AAATTACTTGGGTAGCTTTATCGAAGAGCTTTAAAGATTTGTATGCCCAAGG-CCCGTAAAACTAGTGAC---TT-CG-TGTCACTAGTATGCATGTTC-TCTCGCA--GAGCATGCATTGATTTTTATCAAGATACTTTGGAGTGA-TAGTACGAAT-GT-ACGCATA-ACAAACAAAC-AAAAAAAGATC-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTT---CTGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTTGTTT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATAT--TAAAAAAATATAATGATGTATCATTCTAAGGTATGGTTG-TT--TTGTCTCT-CAACAGCTATTAACTTGGCAGCTTACT-CAAAGATGTAGCTTATTATGTTTTAAGTAAGTGTTGTTAGACAATCAGGTATGGTGAAATTWCTTAGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCTAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGCATATACAAGTAAAATTGTATATGCATTGATATTTTTCATGATACTTTGGTGTGAGTA-TAAAATTAATAATTTGTACAWAAACAAACAAAAAAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTCAAACT-ATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGT-GTTT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||||  |||||||||||||||||||||   ||||  ||||||||| ||  ||| |  | |||| |||        ||||||| |||  |||||||||| ||||||||| |||||| |||||||| | |||| ||   |     ||||| ||| ||||||||||| ||||||||||||||| |||| |||| |||| |||||||||||||| ||   || ||  ||  ||||||||||| | |   |   |  |   |||||||||| ||| ||| |||||||||| |||| || ||  | |  | |    || | |||||||| ||||||||||| ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||    || |||||||||  |||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>6</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|18</Hit_id>
+  <Hit_def>AB462281.1 Culicoides verbosus genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: OKYN05_18</Hit_def>
+  <Hit_accession>18</Hit_accession>
+  <Hit_len>805</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>523.722</Hsp_bit-score>
+      <Hsp_score>283</Hsp_score>
+      <Hsp_evalue>3.08939e-151</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>716</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>732</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>609</Hsp_identity>
+      <Hsp_positive>609</Hsp_positive>
+      <Hsp_gaps>64</Hsp_gaps>
+      <Hsp_align-len>756</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTATAAAAAAATATAATGATGT--ATTC-T---A-GTGT-ATGGTTGTT-TCGTTGGCATTGCAACTGCTCGCTCGAGGGCAGCTCACTATAAAGATGTAGTTTATTATGTCTTAAGTGAGTGTTGTGATACAACA------------AAAATTACTTGGGTAGCTTTATCGAAGAGCTTTAAAGATTTGTATGCCCAAGG-CCCGTAAAACTAGTGAC---TT-CG-TGTCACTAGTATGCATGTTCTCTCGCAGAGCATGCATTGATTTTTATCAAGATACTTTGGAGTGATAGTA-CGAA-T---GTACGCATAACAAACAAACA-AAAAAAGATC-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTT-CTGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTTGTTTCACA--GC-ATCATAAGTGCATGATGTGATTATATGGGCCGCGCTCTCACGAGCAACGCTCATATATCATTAATAGATGTGT-GGTTTAGTGCAGCAGTGTGCATGTTTGACCATTATTTTTATTTAATGCAAATAACA-AATTTTGGTATAAAAT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATAT--TAAAAAAATATAATGATGTTCATTCATAAAAGGTATAACGGTTGTTGTC-TTTCAATGGCTA-T--TCACT-TA-GCAAGCTTGCTATAAAAATGTAGTTTATTATGTTTTAAGCAAGTGTTGTTAGACAAAAGGTTGGTTGTTCAAAATTACTTAGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCTAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGTATATACT-TAATTGTATATGCATTGATATTTTTCATGATACTTTGGAGTGTGAGTATAAAATTAAAATTTGTACAA-AAACAAAAACAAAAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATAAACTAATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTC-TTTAAAATTGAGAT-ATAAGTGCATGATGTGATCATATAAGC-----T-TAATT-GC--C--T-ATATATCATTAATAAAGGTGGAGGTATGGTGCTATTGTGTACATATTTAACCATCATTTTTATTTAATATAAATAATATAATTTTGGTATAAAAT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||||  |||||||||||||||||||  |||| |   | || | | ||||||| || ||   || || | |  || ||  | |  ||||  ||||||| |||||||||||||||| |||||  |||||||| | |||| |            |||||||||| ||||||||||| ||||||||||||||| |||| |||| |||| |||||||||||||| ||   || ||  ||  |||||||| || | || |    |   |||||||||| ||| ||| ||||||||||||||  ||||   || |    |  | | || ||||||| | |||||||||| |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||   || |||||||||  ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  ||| | |  |  || |||||||||||||||||| ||||  ||     | | |   ||  |  | |||||||||||||| | |||  ||| | ||||    |||| ||| ||| ||||| |||||||||||||  |||||| | ||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>7</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|20</Hit_id>
+  <Hit_def>AB462283.1 Culicoides matsuzawai genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: IS05_6</Hit_def>
+  <Hit_accession>20</Hit_accession>
+  <Hit_len>908</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>512.642</Hsp_bit-score>
+      <Hsp_score>277</Hsp_score>
+      <Hsp_evalue>6.68735e-148</Hsp_evalue>
+      <Hsp_query-from>167</Hsp_query-from>
+      <Hsp_query-to>596</Hsp_query-to>
+      <Hsp_hit-from>299</Hsp_hit-from>
+      <Hsp_hit-to>732</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>389</Hsp_identity>
+      <Hsp_positive>389</Hsp_positive>
+      <Hsp_gaps>18</Hsp_gaps>
+      <Hsp_align-len>441</Hsp_align-len>
+      <Hsp_qseq>AAAATTACTTGGGTAGCTTTATCGAAGAGCTTTAAAGATTTGTATGCCCAAGG-CCCGTAAAACTAGTGAC---TT-CG-TGTCACTAGTATGCATGTTCTCTCGCAGAGCATGCATTGATTTTTATCAAGATACTTTGGAGTGATAGTACGAA-TGTACGCATAACAAACAAACAAAAAAAGATC-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCT-GATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTTGT-TTCACA-GCATCATAAGTGCATGATGTGATTATA</Hsp_qseq>
+      <Hsp_hseq>AAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGCATACACT-TARTTGAGTATGCATTGATATTTTTCATGATACTTTGGTGTGA-AGTACATATTGTACCGAT-ATAAAC--A-AAAAAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTATCGATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGT-GTCTTGAAAAAGAACATAAGCGCATGATGTGATTATA</Hsp_hseq>
+      <Hsp_midline>|||||| ||||||||||||||| ||||||||||||||| |||| ||||||||| |||||||||||||| ||   || ||  ||  |||||||||||   || |    ||| |||||||||| ||| ||| |||||||||| |||| |||||  | |||||  || | ||||  | ||||||||||| ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| | ||||||||||  |||||||||||||||||||||||||||||||||||||||||||||||||||||||||| || || | |   | |||||| ||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>122.999</Hsp_bit-score>
+      <Hsp_score>66</Hsp_score>
+      <Hsp_evalue>1.31676e-30</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>156</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>163</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>137</Hsp_identity>
+      <Hsp_positive>137</Hsp_positive>
+      <Hsp_gaps>17</Hsp_gaps>
+      <Hsp_align-len>168</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTATAAAAAAATATAATGATGTATTCT--AG-T--G-TAT--GGTTGTTTCGTTGGCATTG-CAACTGCTCGCTCGAGG-GC-AGCTCACTATAAAGATGTAGTTTATTAT-GTCTTAAGTGAGTGTTG</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTA-AAAAAA-TATAATGATGT-TTCTTTATATAAGGTATATGGTTGTTATGTTGTC-TTGTCAACAGCTATTT-GATTAGCAAGCTTGCTATAAAGATGTAGTTTATTACGGTCTTAAGTAAGTGTTG</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||||||| |||||| ||||||||||| ||||  |  |  | |||  |||||||  |||| | ||| |||| |||   | ||   || ||||  |||||||||||||||||||||  ||||||||| |||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>3</Hsp_num>
+      <Hsp_bit-score>52.8265</Hsp_bit-score>
+      <Hsp_score>28</Hsp_score>
+      <Hsp_evalue>1.75223e-09</Hsp_evalue>
+      <Hsp_query-from>753</Hsp_query-from>
+      <Hsp_query-to>780</Hsp_query-to>
+      <Hsp_hit-from>881</Hsp_hit-from>
+      <Hsp_hit-to>908</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>28</Hsp_identity>
+      <Hsp_positive>28</Hsp_positive>
+      <Hsp_gaps>0</Hsp_gaps>
+      <Hsp_align-len>28</Hsp_align-len>
+      <Hsp_qseq>TTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>TTATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>8</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|13</Hit_id>
+  <Hit_def>AB462276.1 Culicoides sumatrae genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: ONYK05_17</Hit_def>
+  <Hit_accession>13</Hit_accession>
+  <Hit_len>784</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>510.796</Hsp_bit-score>
+      <Hsp_score>276</Hsp_score>
+      <Hsp_evalue>2.4052e-147</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>597</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>621</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>524</Hsp_identity>
+      <Hsp_positive>524</Hsp_positive>
+      <Hsp_gaps>52</Hsp_gaps>
+      <Hsp_align-len>635</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTAT-ATTATAAAAAAATATAATGATGT---ATTCTAGTGTATGGTTGTTTCGTTGGCATTGCAACTGC--TCGCTCGAGGGCAGC-T-CA---CTATAAAGATGTAGTTTATTATGTCTTAAG---T-G-A-GTGTTGTGATACAACAAAAATTACTTGGGTAGCTTTATCGAAGAGCTTTAAAGATTTGTATGCCCAAGG-CCCGTAAAACTAGTGAC---TT-CG-TGTCACTAGTATGCATGTTCTCTCGCAGAGCATGCATTGATTTTTATCAAGATACTTTGGAGTGATAGTACGAATGT--A-C-GCATA---ACA-A-ACA-A--ACAAAAAAAG--ATCAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATT-TCTGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTTGTTTCACAGCATCATAAGTGCATGATGTGATTATAT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATTATTA-AAAAAAATATAATGATGTTTCATTCAAG-GTATGGTTG-TT-AAT-CTATTGCAATGGCTATTAATTTA--GCAGCTTACACCGCTATAAAGATGTGGTTTATCATATCTTAAGCATTCGTAGGTGTTGTGAT---A-GAAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGTATATACT-TAATTGTATATGCATTGATATTTTTCATGATACTTTGGTGTGATAATA-AAAAGTAAATCTTTATATTTATATAGAGATAGGAAAAAAAAAGTAAAGAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTATC-GATATTCACGAAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTTATTTAATGGTAACGTAAGGGCATGTTGTGATTATAT</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||| |||| ||||||||||||||||||   |||| || ||||||||| ||   |   |||||||  ||  |   |  |  ||||| | ||   |||||||||||| |||||| || |||||||   | | | ||||||||||   |  |||||| ||||||||||||||| ||||||||||||||| |||| ||||||||| |||||||||||||| ||   || ||  ||  |||||||| || | || |    |   |||||||||| ||| ||| |||||||||| |||||| ||  || ||  | |   |||   | | | | | |  | ||||||||  |  |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| || |||||||||  |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||| |  | | | |||| ||||| |||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>54.6731</Hsp_bit-score>
+      <Hsp_score>29</Hsp_score>
+      <Hsp_evalue>4.87186e-10</Hsp_evalue>
+      <Hsp_query-from>752</Hsp_query-from>
+      <Hsp_query-to>780</Hsp_query-to>
+      <Hsp_hit-from>756</Hsp_hit-from>
+      <Hsp_hit-to>784</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>29</Hsp_identity>
+      <Hsp_positive>29</Hsp_positive>
+      <Hsp_gaps>0</Hsp_gaps>
+      <Hsp_align-len>29</Hsp_align-len>
+      <Hsp_qseq>ATTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>ATTATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>9</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|19</Hit_id>
+  <Hit_def>AB462282.1 Culicoides humeralis genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Kag15_1</Hit_def>
+  <Hit_accession>19</Hit_accession>
+  <Hit_len>912</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>508.949</Hsp_bit-score>
+      <Hsp_score>275</Hsp_score>
+      <Hsp_evalue>8.65063e-147</Hsp_evalue>
+      <Hsp_query-from>167</Hsp_query-from>
+      <Hsp_query-to>597</Hsp_query-to>
+      <Hsp_hit-from>296</Hsp_hit-from>
+      <Hsp_hit-to>739</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>394</Hsp_identity>
+      <Hsp_positive>394</Hsp_positive>
+      <Hsp_gaps>21</Hsp_gaps>
+      <Hsp_align-len>448</Hsp_align-len>
+      <Hsp_qseq>AAAATTACTTGGGTAGCTTTATCGAAGAGCTTTAAAGATTTGTATGCCCAAGG-CCCGTAAAACTAGTGAC---TT-CG-TGTCACTAGTATGCATGTTCTCTCGCAGAGCATGCATTGATTTTTATCAAGATACTTTGGAGTGA---TAGTACG-AATGTACGCATAACAAACAAACAAAAAAAGATC-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCT-GATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGT-TGT-TTCACA--G-CATCATAAGTGCATGATGTGATTATAT</Hsp_qseq>
+      <Hsp_hseq>AAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGCATACACT-TAATTGAGTATGCATTGATATTTTTCATGATACTTTGGTGTGAGTATAATTTGTATTGTA--CATAAACAAGAAA-AAAAAACGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTATCGATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTGTGTCTTGAAAAAGACATCATAAGTGCATGATGTGATTATAT</Hsp_hseq>
+      <Hsp_midline>|||||| ||||||||||||||| ||||||||||||||| |||| ||||||||| |||||||||||||| ||   || ||  ||  |||||||||||   || |    ||| |||||||||| ||| ||| |||||||||| ||||   || |  | | ||||  |||||  || ||| |||||| |||| ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| | ||||||||||  |||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||| || | |  | |||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>124.846</Hsp_bit-score>
+      <Hsp_score>67</Hsp_score>
+      <Hsp_evalue>3.66109e-31</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>156</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>161</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>135</Hsp_identity>
+      <Hsp_positive>135</Hsp_positive>
+      <Hsp_gaps>15</Hsp_gaps>
+      <Hsp_align-len>166</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTATAAAAAAATATAATGATGTATTCT-AGTGTAT--GGT-T--G-TTTCGTTGGCATTG-CAACTGCTCGCTCGAGG-GC-AGCTCACTATAAAGATGTAGTTTATTATGTCTTAAGTGAGTGTTG</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTA-AAAAAA-TATAATGATGT-TTCTTTATATATAAGGTATATGGTTATGTTGTC-TTGTCAAYRGCTAT-TYGATTAGCAAGCTTGCTATAAAGATGTAGTTTATTATGTCTTAAGTAAGTGTTG</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||||||| |||||| ||||||||||| ||||   | |||  ||| |  | ||  |||| | ||| |||  |||   | ||   || ||||  ||||||||||||||||||||||||||||||| |||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>3</Hsp_num>
+      <Hsp_bit-score>54.6731</Hsp_bit-score>
+      <Hsp_score>29</Hsp_score>
+      <Hsp_evalue>4.87186e-10</Hsp_evalue>
+      <Hsp_query-from>752</Hsp_query-from>
+      <Hsp_query-to>780</Hsp_query-to>
+      <Hsp_hit-from>884</Hsp_hit-from>
+      <Hsp_hit-to>912</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>29</Hsp_identity>
+      <Hsp_positive>29</Hsp_positive>
+      <Hsp_gaps>0</Hsp_gaps>
+      <Hsp_align-len>29</Hsp_align-len>
+      <Hsp_qseq>ATTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>ATTATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>10</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|9</Hit_id>
+  <Hit_def>AB462272.1 Culicoides nipponensis genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Isg22</Hit_def>
+  <Hit_accession>9</Hit_accession>
+  <Hit_len>794</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>503.409</Hsp_bit-score>
+      <Hsp_score>272</Hsp_score>
+      <Hsp_evalue>4.02475e-145</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>597</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>607</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>520</Hsp_identity>
+      <Hsp_positive>520</Hsp_positive>
+      <Hsp_gaps>56</Hsp_gaps>
+      <Hsp_align-len>630</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTATAAAAAAATATAATGATGT--ATTC---TAGTGT-ATGGTTGTTTCGTTGGCATTGCAACTGCTCGCTCGAGGGCAGCT--CACTATAAAGATGTAGTTTATTATGTC-T-TAAGTG--AG--TGTTGTGAT-ACAACA-A-------AAATTACTTGGGTAGCTTTATCGAAGAGCTTTAAAGATTTGTATGCCCAAGG-CCCGTAAAACTAGTGAC---TT-CG-TGTCACTAGTATGCATGTTCTCTCGCAGAGCATGCATTGATTTTTATCAAGATACTTTGGAGTGATAGTACGAATGTACGCATAACAAACAAACAAAAAAAG-ATCAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATAT-TTCT-GATATTCACA-GAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTTGTTTCACAGCATCATAAGTGCATGATGTGATTATAT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTAT--TAT-AAAAAATATAATGATGTTCATTCTATTAGTGTAATGG-TG-TT-ATTATTATTACAATTGCAATATATTTTGCAGCTTACAC-A-AAAGATGTAGTTTATTATATCATATATGTGCAAGTATATTGTAATAATAAAAGAGTTGGTTAAATTTCTTGGGTAGCTTTATTGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGTAT-ATAT-TCATTTA-TATACATTGATATTTTTCATGATACTTTGGATTGATA-T--G-A--TA---A-AACAAACAAAAAAAAAGTGTAAGAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATATTTTTGATATTCACAAGA-TCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTGTGTTTTGTCAAAAGA-CATAAGTGCATGATGTGATTATAT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||  ||| |||||||||||||||||  ||||   |||||| |||| || ||  ||   ||| ||| |||    |     ||||||  ||| | |||||||||||||||||| || | || |||  ||  | |||| || | || | |       ||||| ||||||||||||||| ||||||||||||||| |||| ||||||||| |||||||||||||| ||   || ||  ||  |||||||| ||  | | ||    |  || ||||||| ||| ||| ||||||||||| ||||| |  | |  ||   | |||||||||| |||||  | |  ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| || | |||||||||| || ||||||||||||||||||||||||||||||||||||||||||||||||||||| |||| | ||| |  | ||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>82.3729</Hsp_bit-score>
+      <Hsp_score>44</Hsp_score>
+      <Hsp_evalue>2.23481e-18</Hsp_evalue>
+      <Hsp_query-from>668</Hsp_query-from>
+      <Hsp_query-to>780</Hsp_query-to>
+      <Hsp_hit-from>682</Hsp_hit-from>
+      <Hsp_hit-to>794</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>93</Hsp_identity>
+      <Hsp_positive>93</Hsp_positive>
+      <Hsp_gaps>6</Hsp_gaps>
+      <Hsp_align-len>116</Hsp_align-len>
+      <Hsp_qseq>TTTGACCATTATTTTTATTTAA-TGCA-AATAACAAATTTTGGTATAAAATCAAGCGTGCCTCTGCGACAAAAC-TGTAACATTTAAATTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>TTTGACCATTATTTTTATTTAAATTAATAATAA-ATATTTTGGTTTAAA-TCAAATG-GTATATGAGAGAAAAAGTGTTATATTTTTTTTATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||| |  | ||||| | |||||||| |||| ||||  | |  | || || ||||  ||| | ||||   ||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>11</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|8</Hit_id>
+  <Hit_def>AB462271.1 Culicoides lungchiensis genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: AM05_8</Hit_def>
+  <Hit_accession>8</Hit_accession>
+  <Hit_len>776</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>475.709</Hsp_bit-score>
+      <Hsp_score>257</Hsp_score>
+      <Hsp_evalue>8.7739e-137</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>598</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>619</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>516</Hsp_identity>
+      <Hsp_positive>516</Hsp_positive>
+      <Hsp_gaps>49</Hsp_gaps>
+      <Hsp_align-len>633</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTATAAAAAAATATAATGATGT-AT-TC-T-AGTG-TATGGTTGTTTCGT-TGGCATTGCAACTGCTCGCTCGAGGGCAGCTCACTATAAAGATGTAGTTTATTA--TGTC-T-TAAGTGAGTGTTGT--GATA---CAA---CA--AAAATTACTTGGGTAGCTTTATCGAAGAGCTTTAAAGATTTGTATGCCCAAGG-CCCGTAAAACTAGTGAC---TT-CG-TGTCACTAGTATGCATGTTC-TCTCGCAGAGCATGCATTGAT-TTTTATCAAGATACTTTGGAGTGATAG--TACGAATGTACGCA--T-AACAAACAAACAAAAAAAGATC-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCTGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTTG-TTTCACAGCATCATAAGTGCATGATGTGATTATATG</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTAT-TAAAAAAAAAATATAATGATGTTCTATCATAAGTGTTATGG-TGTTATATATTACAAT--AACTATTTAAT-TA-GTAAGCTTATTATAAAGATGTGGTTTATCACTTATCTTATAAATAAGTATTGTAATATATTTTAAGTGTATGGAAATTACTTGGGTAGCTTTATTGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGTATATACATTTATTTGTATATACATTGATATTTTTTCATGATACTTTGGTAT-AAAGAAAAAAAAAGTACAATTTTGTACATATAAA-AAAAAAAGATCTAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTTGATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTTCCTTTTA------CATAAGTGCATGATGTGATTATATG</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||| | | ||||||||||||||||||  | || | |||| ||||| ||||   | |  || |  ||||  |   |  | |  |||| | ||||||||||| |||||| |  | || | ||| | ||| ||||   |||    ||    |   ||||||||||||||||||||| ||||||||||||||| |||| ||||||||| |||||||||||||| ||   || ||  ||  |||||||| || | | | |    |   || ||||||| |||| ||| ||||||||||  | | ||   |  || ||||     |  ||| | ||| ||||||||||| ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| |||||||||||  |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  ||| |      |||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>52.8265</Hsp_bit-score>
+      <Hsp_score>28</Hsp_score>
+      <Hsp_evalue>1.75223e-09</Hsp_evalue>
+      <Hsp_query-from>746</Hsp_query-from>
+      <Hsp_query-to>780</Hsp_query-to>
+      <Hsp_hit-from>743</Hsp_hit-from>
+      <Hsp_hit-to>776</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>33</Hsp_identity>
+      <Hsp_positive>33</Hsp_positive>
+      <Hsp_gaps>1</Hsp_gaps>
+      <Hsp_align-len>35</Hsp_align-len>
+      <Hsp_qseq>ATTTAAATTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>ATTT-ATTTATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>|||| | ||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>12</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|4</Hit_id>
+  <Hit_def>AB462267.1 Culicoides aterinervis genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: AM05_5</Hit_def>
+  <Hit_accession>4</Hit_accession>
+  <Hit_len>891</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>475.709</Hsp_bit-score>
+      <Hsp_score>257</Hsp_score>
+      <Hsp_evalue>8.7739e-137</Hsp_evalue>
+      <Hsp_query-from>167</Hsp_query-from>
+      <Hsp_query-to>597</Hsp_query-to>
+      <Hsp_hit-from>276</Hsp_hit-from>
+      <Hsp_hit-to>713</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>388</Hsp_identity>
+      <Hsp_positive>388</Hsp_positive>
+      <Hsp_gaps>25</Hsp_gaps>
+      <Hsp_align-len>447</Hsp_align-len>
+      <Hsp_qseq>AAAATTACTTGGGTAGCTTTATCGAAGAGCTTTAAAGATTTGTATGCCCAAGG-CCCGTAAAACTAGTGAC---TT-CG-TGTCACTAGTATGCATGTTCTCTCGCAGAGCATGCATTGATTTTTATCAAGATACTTTGGAGTGA---TAGTAC--GAA-TGTACGCAT-AA-CA-AACAAACAAAAAAAGAT-CAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCTGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTTGTTTCACAGCATCATAAGTGCATGATGTGATTATAT</Hsp_qseq>
+      <Hsp_hseq>AAAATTTCTTAGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCTAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGCATACACT-TAGTTGTGTATGCATTGATATTTTTCATGATACTTTGGAGTGAGTATAATACAAAAATTGTA--CATAAATAATAATAAA-AAAAAAAGATGAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTATAATATTTTTGATATTCATAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGT-GTTTTACA-CG---TAAGTGCATGATGTGATCATAT</Hsp_hseq>
+      <Hsp_midline>|||||| ||| ||||||||||| ||||||||||||||| |||| |||| |||| |||||||||||||| ||   || ||  ||  |||||||||||   || | |  | | |||||||||| ||| ||| |||||||||||||||   || |||   || ||||  ||| ||  | || ||| ||||||||||  |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| |||||||| ||||||||| |  |||||||||||||||||||||||||||||||||||||||||||||||||||||||||| |||| ||| |    ||||||||||||||||| ||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>132.232</Hsp_bit-score>
+      <Hsp_score>71</Hsp_score>
+      <Hsp_evalue>2.18788e-33</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>163</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>160</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>136</Hsp_identity>
+      <Hsp_positive>136</Hsp_positive>
+      <Hsp_gaps>9</Hsp_gaps>
+      <Hsp_align-len>166</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTATAAAAAAATATAATGATGT--ATTCTAGTGTA-TGGTTGTTTCGTTGGCATTGCAACTGCTCGCTCGAGGGCAGCTCACTATAAAGATGTAGTTTATTATGTCTTAAGTGAGTGTTGTGATACA</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATA--A-AAATA--TATAATGATGTTCATTCTAAGGTTGTGGATGTAT-GTTGTTATTGTAACAGCTATTTAGTTAGCAGCTTGCTATAAAGATGTAGTTTATTATGTCTTAAGTAAGTGTTATGATACA</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||||  | ||| |  |||||||||||  ||||||  ||  ||| ||| | ||||  |||| ||| |||   | |   ||||||  ||||||||||||||||||||||||||||||| |||||| |||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>3</Hsp_num>
+      <Hsp_bit-score>58.3664</Hsp_bit-score>
+      <Hsp_score>31</Hsp_score>
+      <Hsp_evalue>3.76617e-11</Hsp_evalue>
+      <Hsp_query-from>668</Hsp_query-from>
+      <Hsp_query-to>780</Hsp_query-to>
+      <Hsp_hit-from>780</Hsp_hit-from>
+      <Hsp_hit-to>891</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>90</Hsp_identity>
+      <Hsp_positive>90</Hsp_positive>
+      <Hsp_gaps>9</Hsp_gaps>
+      <Hsp_align-len>117</Hsp_align-len>
+      <Hsp_qseq>TTTGACCATTATTTTTATTTAATGCAAATAACAAATTTTGGTATAAAATC-AA-GCGTGCCTCTGCG-ACAAAACTGTAACATTTAA-ATTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>TTTGACCATTATTTTTATTTAAT-TTAAT-ATGAATTTTGGT-TTAAATCAAATATGTGTATCT-CGTTGTTGTTTATAAC-TCTAACATTATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||   ||| |  ||||||||| | ||||| ||   |||  ||| ||        | |||| | ||| |||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>13</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|2</Hit_id>
+  <Hit_def>AB462265.1 Culicoides arakawae genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Kag02</Hit_def>
+  <Hit_accession>2</Hit_accession>
+  <Hit_len>907</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>472.016</Hsp_bit-score>
+      <Hsp_score>255</Hsp_score>
+      <Hsp_evalue>1.13498e-135</Hsp_evalue>
+      <Hsp_query-from>167</Hsp_query-from>
+      <Hsp_query-to>780</Hsp_query-to>
+      <Hsp_hit-from>303</Hsp_hit-from>
+      <Hsp_hit-to>907</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>512</Hsp_identity>
+      <Hsp_positive>512</Hsp_positive>
+      <Hsp_gaps>41</Hsp_gaps>
+      <Hsp_align-len>630</Hsp_align-len>
+      <Hsp_qseq>AAAATTACTTGGGTAGCTTTATCGAAGAGCTTTAAAGATTTGTATGCCCAAGGCCC-GTAAAACTAGTGAC---TT-CG-TGTCACTAGTATGCATGTTCTCTCGCAGAGCATGCATTGATTTTTATCAAGATACTTTGGAGTG--ATAGTACGAATGTACGCATAACAAAC-AAACAAAAAAAGATC-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCTGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTTGTTTCACA--GCATCATAAGTGCATGATGTGATTATATGGGCCGCGCTCTCACGAGCAACGCTCATATATCATTAATAGATGTGTGGTTTAGTGCAGCAGTGTGCATGTTTGACCATTATTTTTATTTAATGCAAATAACAAA-T-T-TTGGTATAAAATCAAGC-GTGCCTCTGCGACAAAACTGTAACATTTAAATTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>AAAATTACTTAGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCTAAGGCCCTGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGTATATACT-TAATTGTATATGCATTGATATTTTTCATGATACTTTGGTGTGATATAATAAAAATGTAC-AATTTTGTACTAATAAAAAAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATAAATAATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATATTATTTGAAAAAGTAATATAAGTGCATGATGTGATTATACAAG--GCT-T-TAACAGGCAT-G----TATATCATTAATAAAGGATAGATATGGTA-A--A-TGAGCATATTTAACCATTATTTTTATTTAA---AA-TAATAAAGTATATTGGTATAAAATAAATATGTGACT-TGCCTTATTACT-TA-C-TTTAA-TT-TGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>|||||||||| ||||||||||| ||||||||||||||| |||| |||| ||||||| ||||||||||| ||   || ||  ||  |||||||| || | || |    |   |||||||||| ||| ||| |||||||||| |||  ||| ||  |||||||  ||     || ||  ||||||||||| |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||   | |||||||||  |||||||||||||||||||||||||||||||||||||||||||||||||||||||| || ||| | |  | |  ||||||||||||||||||||||   |  ||  | | ||  |||  |    ||||||||||||| | |   | | | ||  |  | || |||| ||| ||||||||||||||||||   || ||| ||| | | |||||||||||| ||   ||| || |||   |  ||| || | ||||| || |||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>111.919</Hsp_bit-score>
+      <Hsp_score>60</Hsp_score>
+      <Hsp_evalue>2.85029e-27</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>81</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>82</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>77</Hsp_identity>
+      <Hsp_positive>77</Hsp_positive>
+      <Hsp_gaps>5</Hsp_gaps>
+      <Hsp_align-len>84</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTATAAAAAAATATAATGATGT--ATTC-TAGTGTATGGTTGTTT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTA-AAAAAA-TATAATGATGTTCATTCATAAGGTATGGTTGTTT</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||||||| |||||| |||||||||||  |||| ||  ||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>14</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|21</Hit_id>
+  <Hit_def>AB462284.1 Culicoides paraflavescens genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: OKYN05_13</Hit_def>
+  <Hit_accession>21</Hit_accession>
+  <Hit_len>842</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>466.476</Hsp_bit-score>
+      <Hsp_score>252</Hsp_score>
+      <Hsp_evalue>5.28053e-134</Hsp_evalue>
+      <Hsp_query-from>167</Hsp_query-from>
+      <Hsp_query-to>597</Hsp_query-to>
+      <Hsp_hit-from>248</Hsp_hit-from>
+      <Hsp_hit-to>687</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>387</Hsp_identity>
+      <Hsp_positive>387</Hsp_positive>
+      <Hsp_gaps>25</Hsp_gaps>
+      <Hsp_align-len>448</Hsp_align-len>
+      <Hsp_qseq>AAAATTACTTGGGTAGCTTTATCGAAGAGCTTTAAAGATTTGTATGCCCAAGG-CCCGTAAAACTAGTGAC---TT-CG-TGTCACTAGTATGCATGTTCTCTCGCAGAGCATGCATTGATTTTTATCAAGATACTTTGGAGTGATAGTAC-GAATGTACGCATAACAAACAAACAAAAAAA-GATC-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCT-GATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTTGTTTC-A-C-A--GCATCA--TAAGTGCATGATGTGATTATAT</Hsp_qseq>
+      <Hsp_hseq>AAAATTTCTTGGGTAGCTTTATTGAAGAGCTTTAAAGACTTATTTGCCCAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGCATACCCT-TTATTGGGTATGCATTGATATTTTTCATGATACTTTGGTGTGA--GTACTTATTGTA--CAT-A-TGATAAATAAAAAAACGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTTTGATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGC-GTCTCTAGCGATAGAAGCGCTTAAGTGCATGATGTGATTATAT</Hsp_hseq>
+      <Hsp_midline>|||||| ||||||||||||||| ||||||||||||||| || | ||||||||| |||||||||||||| ||   || ||  ||  |||||||||||   || |    | | |||||||||| ||| ||| |||||||||| ||||  ||||  | ||||  ||| |   | ||| ||||||| |||| ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| | ||||||||||  |||||||||||||||||||||||||||||||||||||||||||||||||||||||||  || || | | |  | | |   ||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>108.226</Hsp_bit-score>
+      <Hsp_score>58</Hsp_score>
+      <Hsp_evalue>3.68709e-26</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>156</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>152</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>131</Hsp_identity>
+      <Hsp_positive>131</Hsp_positive>
+      <Hsp_gaps>18</Hsp_gaps>
+      <Hsp_align-len>163</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTATAAAAAAATATAATGATGTATTCT--AGTGTATGGT-T--G-T-TTCGTTGGCATTGCAACTGCTCGCTCGAGGGCAGCTCACTATAAAGATGTAGTTTATTATGTCTTAAGTGAGTGTTG</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTA-AAACA--TATAATGATGT-TTCTTTAAGGTATGGTGTTTGATATTTGTTG--ATAGCTATT--T-GATT-AG-CAAGCTTACTATAAAGATGTAGTTTATTATGTCTTAAGTAAGTATTG</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||||||| ||| |  ||||||||||| ||||  |  ||||||| |  | | || ||||  || || | |  | | |  ||   |||| |||||||||||||||||||||||||||||||| ||| |||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>3</Hsp_num>
+      <Hsp_bit-score>71.293</Hsp_bit-score>
+      <Hsp_score>38</Hsp_score>
+      <Hsp_evalue>4.83751e-15</Hsp_evalue>
+      <Hsp_query-from>664</Hsp_query-from>
+      <Hsp_query-to>780</Hsp_query-to>
+      <Hsp_hit-from>733</Hsp_hit-from>
+      <Hsp_hit-to>842</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>93</Hsp_identity>
+      <Hsp_positive>93</Hsp_positive>
+      <Hsp_gaps>9</Hsp_gaps>
+      <Hsp_align-len>118</Hsp_align-len>
+      <Hsp_qseq>CATGTTTGACCATTATTTTTATTTAATGCAAATAACAAATTTTGGTATAAAATCAAGCGTGCCTCTGCGACAAAACTGTAACATT-TAAATTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>CATATTTAACCATTATTTTTATTTAA--AAAATAACAAATTTTGGTATAAAAT--AG-AT--ATGTATGA-TTACCTTAAAAATTCTTTATTATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>||| ||| ||||||||||||||||||   ||||||||||||||||||||||||  ||  |   | |  ||   | ||  || ||| |  |||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>15</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|15</Hit_id>
+  <Hit_def>AB462278.1 Culicoides erairai genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: IS05_2</Hit_def>
+  <Hit_accession>15</Hit_accession>
+  <Hit_len>931</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>459.089</Hsp_bit-score>
+      <Hsp_score>248</Hsp_score>
+      <Hsp_evalue>8.83619e-132</Hsp_evalue>
+      <Hsp_query-from>167</Hsp_query-from>
+      <Hsp_query-to>566</Hsp_query-to>
+      <Hsp_hit-from>309</Hsp_hit-from>
+      <Hsp_hit-to>717</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>362</Hsp_identity>
+      <Hsp_positive>362</Hsp_positive>
+      <Hsp_gaps>19</Hsp_gaps>
+      <Hsp_align-len>414</Hsp_align-len>
+      <Hsp_qseq>AAAATTACTTGGGTAGCTTTATCGAAGAGCTTTAAAGATTTGTATGCCCAAGG-CCCGTAAAACTAGTGAC---TT-CG-TGTCACTAGTATGCAT--GTTCT-CTCGCAGAGCATGCATTGATTTTTATCAAGATACTTTGGAGTGATAGTACG-A-ATGTACGCA--TAACAAACAAACAAAAAAAGATCAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTT-CTGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTTGTTTC</Hsp_qseq>
+      <Hsp_hseq>AAAATTTCTTAGGTAGCTTTATTGAAGAGCTTTAAAGACTTGTATGCCTAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGCATATATTTTAATCG--GTGTATGCATTGATATTTTTCATGATACTTTGGTGTGATATTTTGTATATTTACAAATGTAAAAATGTAA-AAAAAGAGATCAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTACT--TATTCACAAAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTGTGATTTTTC</Hsp_hseq>
+      <Hsp_midline>|||||| ||| ||||||||||| ||||||||||||||| ||||||||| |||| |||||||||||||| ||   || ||  ||  |||||||||||   || |  |||  | | |||||||||| ||| ||| |||||||||| |||||| |  | | || |||  |  ||| ||   || ||||| |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||  |||||||| ||||||||||||||||||||||||||||||||||||||||||||||||||||||| || | ||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>139.619</Hsp_bit-score>
+      <Hsp_score>75</Hsp_score>
+      <Hsp_evalue>1.30748e-35</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>170</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>173</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>148</Hsp_identity>
+      <Hsp_positive>148</Hsp_positive>
+      <Hsp_gaps>17</Hsp_gaps>
+      <Hsp_align-len>180</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTATAAAAAAATATAATGATGTAT--T-CT---AGTGTATGGTTGTT-TCGTTG-G-CATTGCAACTGCTCGCTCGAGGGCAGCTCACTATAAAGATGTAGTTTATTATGTCTTAAGTGAGTGTTG-TGATACAACAAAAA</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAT-AAAAAATATAATGATGTATCATTCTATAAGTGTATGGTGGTTGTTGTTTCGACA--GCTAAAGTTTACTTTAG--CAGCCTACTATAAAGATGTAGTTTATTATGTCTTAAGT-A-TGGTGTTGATTCAACAAAAA</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||||||| |||||||||||||||||||  | ||   |||||||||| ||| | |||  | ||  || |  | |  ||  ||  ||||  |||||||||||||||||||||||||||||||| | || || |||| |||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>16</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|3</Hit_id>
+  <Hit_def>AB462266.1 Culicoides japonicus genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Ngs24_1</Hit_def>
+  <Hit_accession>3</Hit_accession>
+  <Hit_len>925</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>457.243</Hsp_bit-score>
+      <Hsp_score>247</Hsp_score>
+      <Hsp_evalue>3.17806e-131</Hsp_evalue>
+      <Hsp_query-from>167</Hsp_query-from>
+      <Hsp_query-to>597</Hsp_query-to>
+      <Hsp_hit-from>316</Hsp_hit-from>
+      <Hsp_hit-to>745</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>380</Hsp_identity>
+      <Hsp_positive>380</Hsp_positive>
+      <Hsp_gaps>21</Hsp_gaps>
+      <Hsp_align-len>441</Hsp_align-len>
+      <Hsp_qseq>AAAATTACTTGGGTAGCTTTATCGAAGAGCTTTAAAGATTTGTATGCCCAAGG-CCCGTAAAACTAGTGAC---TT-CG-TGTCACTAGTATGCATGTTCTCTCGCAGAGCATGCATTGATTTTTATCAAGATACTTTGGAGTGAT-AGTACGAATGTACGCATAACAAACAAACAAAAAAAGATC-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATAT-TT-CTGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTTGTTTCACAGCATCATAAGTGCATGATGTGATTATAT</Hsp_qseq>
+      <Hsp_hseq>AAAATTACTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGTATATACT-TAGTTGTATATGCATTGATATTTTTCATGATACTTTGGTGTGATTTTTGTAAAACAAAATATAATAAAATAA-AAAAATTGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATATTACT--TATTCACAAAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTTTGTT----G---CATAAGTGCATGATGTGATCATAT</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||| ||||||||||||||| |||| ||||||||| |||||||||||||| ||   || ||  ||  |||||||| || | || | |  |   |||||||||| ||| ||| |||||||||| |||||   |   ||   |   |||| |||  || |||||  |||| ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| || ||  |||||||| ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  ||    |   ||||||||||||||||||| ||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>104.533</Hsp_bit-score>
+      <Hsp_score>56</Hsp_score>
+      <Hsp_evalue>4.76955e-25</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>63</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>61</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>61</Hsp_identity>
+      <Hsp_positive>61</Hsp_positive>
+      <Hsp_gaps>2</Hsp_gaps>
+      <Hsp_align-len>63</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTATAAAAAAATATAATGATGTAT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATAT--TAAAAAAATATAATGATGTAT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||||  |||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>17</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|6</Hit_id>
+  <Hit_def>AB462269.1 Culicoides cylindratus genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Kag08, long type</Hit_def>
+  <Hit_accession>6</Hit_accession>
+  <Hit_len>820</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>449.856</Hsp_bit-score>
+      <Hsp_score>243</Hsp_score>
+      <Hsp_evalue>5.31802e-129</Hsp_evalue>
+      <Hsp_query-from>167</Hsp_query-from>
+      <Hsp_query-to>596</Hsp_query-to>
+      <Hsp_hit-from>234</Hsp_hit-from>
+      <Hsp_hit-to>652</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>377</Hsp_identity>
+      <Hsp_positive>377</Hsp_positive>
+      <Hsp_gaps>27</Hsp_gaps>
+      <Hsp_align-len>438</Hsp_align-len>
+      <Hsp_qseq>AAAATTACTTGGGTAGCTTTATCGAAGAGCTTTAAAGATTTGTATGCCCAAGG-CCCGTAAAACTAGTGACTTCGTGTCACTAGTATGCATGTTCTCTCGCAGAGCATGCATTGATTTTTATCAAGATACTTTGGAGTGA---TAGTAC--GAA-TGTACGCATAACAAACAAACAAAAAAAGATC-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCTGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTTGTTTCACAGCATCATAAGTGCATGATGTGATTATA</Hsp_qseq>
+      <Hsp_hseq>AAAATTTCTTAGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCTAAGGCCCCGTAAAACTAGTAAC-CCAT-T-GCGAGGTGGC---TAGTAT-GC--A-TATGCATTGATATTTTTCATGATACTTTGGAGTGAGTATAATACAAAAATTGTA--CAT-A-AAACAAA-TAAAAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTATAATATTTTTGATATTCATAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGT-GTKTWA-AW-A-CRTAAGTGCATGATGTGATCATA</Hsp_hseq>
+      <Hsp_midline>|||||| ||| ||||||||||| ||||||||||||||| |||| |||| |||| |||||||||||||| ||  | | |  | ||   ||   |  | | ||  |  |||||||||| ||| ||| |||||||||||||||   || |||   || ||||  ||| | |||||||  |||||||||| |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| |||||||| ||||||||| |  |||||||||||||||||||||||||||||||||||||||||||||||||||||||||| || | | |  | | ||||||||||||||||| |||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>93.4528</Hsp_bit-score>
+      <Hsp_score>50</Hsp_score>
+      <Hsp_evalue>1.03243e-21</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>61</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>58</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>58</Hsp_identity>
+      <Hsp_positive>58</Hsp_positive>
+      <Hsp_gaps>3</Hsp_gaps>
+      <Hsp_align-len>61</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTATAAAAAAATATAATGATGT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTA-AAAAA--TATAATGATGT</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||||||| |||||  |||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>3</Hsp_num>
+      <Hsp_bit-score>52.8265</Hsp_bit-score>
+      <Hsp_score>28</Hsp_score>
+      <Hsp_evalue>1.75223e-09</Hsp_evalue>
+      <Hsp_query-from>753</Hsp_query-from>
+      <Hsp_query-to>780</Hsp_query-to>
+      <Hsp_hit-from>793</Hsp_hit-from>
+      <Hsp_hit-to>820</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>28</Hsp_identity>
+      <Hsp_positive>28</Hsp_positive>
+      <Hsp_gaps>0</Hsp_gaps>
+      <Hsp_align-len>28</Hsp_align-len>
+      <Hsp_qseq>TTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>TTATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>18</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|16</Hit_id>
+  <Hit_def>AB462279.1 Culicoides oxystoma genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Naha16_1</Hit_def>
+  <Hit_accession>16</Hit_accession>
+  <Hit_len>796</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>448.01</Hsp_bit-score>
+      <Hsp_score>242</Hsp_score>
+      <Hsp_evalue>1.9127e-128</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>555</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>572</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>479</Hsp_identity>
+      <Hsp_positive>479</Hsp_positive>
+      <Hsp_gaps>45</Hsp_gaps>
+      <Hsp_align-len>586</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTATAAAAAAATATAATGATGTATTC-TAGTGTATGGTTGTTTCGTTGGCAT-TGCAACTGCTCG-CTCG--AGGGCAGCTCACTATAAAGATGTAGTTTATTATGTCTTAAGTGAGT-GTTGTGATA-CAAC-AAAAATTA-CTTGGGTAGC-TTTATCGAAGAGCTTTAAAGATTTGTATGCCCAAGG-CCCGTAAAACTAGTGAC---TT-CG-TGTCACTAGTATGCATGT--T-CTCT-CGCAGAGCATGCATTGATTTTTATCAAGATACTTTGGAGTGATAGTACGAATGTACGCATAACAA-ACA-AACAAAAAAA--GATC-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTG-T-AATATT-TC--TGAT-ATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTA-ATTAAAAAAACATATAATGATGT-TTCATAAGGTATGG-TG-TT-GTT--AATATGGTAGTG-TCGTCTTGTCACGACAGCTTGTTATAAAGATGTAGTTTATTATGTCTTAAACAAGTCAATATCATATTAACGCAAAATAATCTTAGGTAGCTTTTATGTAAGAGCTTTAAAGACTTTTTTGCCTAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGTATATAATACCTTGCGTATTGTATGCATTGATTTTT--CATGATATTAATGTGTGAT-GT-TG--TTTATGCAAAACAATTAATAATAAAAAAATTGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCTAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATACGATTAGATTTTGATTAATAATCTCAATGATAATTGACAAAATCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||| |||| ||||| |||||||||||| ||| ||  |||||| || || |||   || ||  | || ||| || |  | | |||||   ||||||||||||||||||||||||||||   |||   | | |||  |||  ||||| | ||| |||||| |||||  |||||||||||||| || | |||| |||| |||||||||||||| ||   || ||  ||  |||||||| || |  | |  | || |  | ||||||||||||||  || |||| |   | ||||| ||  |  | || ||| |||||   | || |||||||  |||| ||||||||||||||||||||||||||||||||||||||||||||||||||| ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||||||||||||| | |||| | ||  |||| ||| ||| | ||||||||||||||||||||||||||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>19</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|11</Hit_id>
+  <Hit_def>AB462274.1 Culicoides peregrinus genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Yng26</Hit_def>
+  <Hit_accession>11</Hit_accession>
+  <Hit_len>794</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>440.623</Hsp_bit-score>
+      <Hsp_score>238</Hsp_score>
+      <Hsp_evalue>3.20062e-126</Hsp_evalue>
+      <Hsp_query-from>169</Hsp_query-from>
+      <Hsp_query-to>598</Hsp_query-to>
+      <Hsp_hit-from>190</Hsp_hit-from>
+      <Hsp_hit-to>636</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>383</Hsp_identity>
+      <Hsp_positive>383</Hsp_positive>
+      <Hsp_gaps>23</Hsp_gaps>
+      <Hsp_align-len>450</Hsp_align-len>
+      <Hsp_qseq>AATTACTTGGGTAGCTTTA--TCGAAGAGCTTTAAAGATTTGTATGCCCAAGG-CCCGTAAAACTAGTGAC---TT-CG-TGTCACTAGTATGCATGTTCTCTCGCAGAGCATGCATTGAT-TT-TTATCAAGATACTTTGGAGTGA--T--AGTACGAATGTACGCA--T-AACA-AACAAACAAAAAAAGATC-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCTGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTTGTTTCAC-AGCATCATAAGTGCATGATGTGATTATATG</Hsp_qseq>
+      <Hsp_hseq>AATTTCTTGGGTAGCTTTAATTTTAAGAGCTTTAAAGACTTTTTTGCCCAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGTATATACT-TAATTGTATATACATTGATATTATTTTCATGATACTTTGGTGTGAAATAAAGTTATAA-GTACTATTTTGTACATATAAAAAAAAAAAAGATCTAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCMTGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTTGATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATATTTTTTTAATAAAAT-ATAAGTGCATGATGTGATTATATG</Hsp_hseq>
+      <Hsp_midline>|||| ||||||||||||||  |  |||||||||||||| || | ||||||||| |||||||||||||| ||   || ||  ||  |||||||| || | || |    |   || ||||||| || || ||| |||||||||| ||||  |  |||   || ||||     |  ||| |  ||| ||||||||||| |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| |||||||||||  |||||||||||||||||||||||||||||||||||||||||||||||||||||||| || ||| |  |  || ||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>106.379</Hsp_bit-score>
+      <Hsp_score>57</Hsp_score>
+      <Hsp_evalue>1.32611e-25</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>61</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>60</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>60</Hsp_identity>
+      <Hsp_positive>60</Hsp_positive>
+      <Hsp_gaps>1</Hsp_gaps>
+      <Hsp_align-len>61</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTATAAAAAAATATAATGATGT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATA-TATAAAAAAATATAATGATGT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||| |||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>3</Hsp_num>
+      <Hsp_bit-score>63.9064</Hsp_bit-score>
+      <Hsp_score>34</Hsp_score>
+      <Hsp_evalue>8.09487e-13</Hsp_evalue>
+      <Hsp_query-from>665</Hsp_query-from>
+      <Hsp_query-to>780</Hsp_query-to>
+      <Hsp_hit-from>687</Hsp_hit-from>
+      <Hsp_hit-to>794</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>91</Hsp_identity>
+      <Hsp_positive>91</Hsp_positive>
+      <Hsp_gaps>10</Hsp_gaps>
+      <Hsp_align-len>117</Hsp_align-len>
+      <Hsp_qseq>ATGTTTGACCATTA-TTTTTATTTAATGCAAATAACAAATTTTGGTATAAAATCAAGCGTGCCTCTGCGACAAAACTGTAACATTTAAATTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>ATATTTGACCATTATTTTTTATTTAATTAAAATAA-TAATATTGGT-TTAAATCAAATATATAT-TGAGA-AATATTGT----TTT-ATTTATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>|| ||||||||||| ||||||||||||  ||||||  ||| ||||| | |||||||   |   | || || || | |||    ||| | ||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>20</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|10</Hit_id>
+  <Hit_def>AB462273.1 Culicoides ohmorii genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Kag05</Hit_def>
+  <Hit_accession>10</Hit_accession>
+  <Hit_len>825</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>420.31</Hsp_bit-score>
+      <Hsp_score>227</Hsp_score>
+      <Hsp_evalue>4.16966e-120</Hsp_evalue>
+      <Hsp_query-from>168</Hsp_query-from>
+      <Hsp_query-to>597</Hsp_query-to>
+      <Hsp_hit-from>202</Hsp_hit-from>
+      <Hsp_hit-to>658</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>386</Hsp_identity>
+      <Hsp_positive>386</Hsp_positive>
+      <Hsp_gaps>29</Hsp_gaps>
+      <Hsp_align-len>458</Hsp_align-len>
+      <Hsp_qseq>AAATTACTTGGGTAGCTTTATCGAAGAGCTTTAAAGATTTGTATGCCCAAGG-CCCGTAAAACTAGTGAC---TT-CG-TGTCACTAGTATGCATGTTCTCTCGCAGAGCATGCATTGATTTTTATCAAGATACTTTGG--AGTGAT-A-GT-ACGAATGTA-C-GCATA---ACA-A-ACA-AACAAAAAAAGAT---CAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCTGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTTGTTTC-AC-----AGCATCATAAGTGCATGATGTGATTATAT</Hsp_qseq>
+      <Hsp_hseq>AAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGTATATACT-TAATTGTATATGCATTGATATTTTTCATGATACTTTGGTGTGTGATAATATAAAAAAAAAATCTTTATATTTATATAGAGAGAAAAAAAAAAAATAAGAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTTGATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTTATTTGTAAAAAAAAGAAGCATAAGTGCATGATGTGATTATAT</Hsp_hseq>
+      <Hsp_midline>||||| ||||||||||||||| ||||||||||||||| |||| ||||||||| |||||||||||||| ||   || ||  ||  |||||||| || | || |    |   |||||||||| ||| ||| ||||||||||   ||||| |  | |  ||   | |   |||   | | | | | || ||||||| ||    ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| |||||||||||  ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| |||  |      || | ||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>89.7595</Hsp_bit-score>
+      <Hsp_score>48</Hsp_score>
+      <Hsp_evalue>1.33553e-20</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>61</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>60</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>57</Hsp_identity>
+      <Hsp_positive>57</Hsp_positive>
+      <Hsp_gaps>1</Hsp_gaps>
+      <Hsp_align-len>61</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTATAAAAAAATATAATGATGT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTAT-TAACATAAAAATATAATGATGT</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||| | | | ||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>3</Hsp_num>
+      <Hsp_bit-score>52.8265</Hsp_bit-score>
+      <Hsp_score>28</Hsp_score>
+      <Hsp_evalue>1.75223e-09</Hsp_evalue>
+      <Hsp_query-from>753</Hsp_query-from>
+      <Hsp_query-to>780</Hsp_query-to>
+      <Hsp_hit-from>798</Hsp_hit-from>
+      <Hsp_hit-to>825</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>28</Hsp_identity>
+      <Hsp_positive>28</Hsp_positive>
+      <Hsp_gaps>0</Hsp_gaps>
+      <Hsp_align-len>28</Hsp_align-len>
+      <Hsp_qseq>TTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>TTATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>21</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|14</Hit_id>
+  <Hit_def>AB462277.1 Culicoides charadraeus genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: KC05_14</Hit_def>
+  <Hit_accession>14</Hit_accession>
+  <Hit_len>913</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>414.77</Hsp_bit-score>
+      <Hsp_score>224</Hsp_score>
+      <Hsp_evalue>1.93996e-118</Hsp_evalue>
+      <Hsp_query-from>168</Hsp_query-from>
+      <Hsp_query-to>600</Hsp_query-to>
+      <Hsp_hit-from>296</Hsp_hit-from>
+      <Hsp_hit-to>700</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>376</Hsp_identity>
+      <Hsp_positive>376</Hsp_positive>
+      <Hsp_gaps>44</Hsp_gaps>
+      <Hsp_align-len>441</Hsp_align-len>
+      <Hsp_qseq>AAATTACTTGGGTAGCTTTATCGAAGAGCTTTAAAGATTTGTATGCCCAAGG-CCCGTAAAACTAGTGAC---TT-CG-TGTCACTAGTATGCATGTTCTCTCGCAGAGCATGCATTGATTTTTATCAAGATACTTTGGAGTGATAGTACGAATGTACGCATAACAAACAAACAAAAAAAGATCAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAAT--ATTTCTGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTTGTTTCACAGCATCATAAGTGCATGATGTGATTATATGGG</Hsp_qseq>
+      <Hsp_hseq>AAATTTCTTAGGTAGCTTTATCGAAGAGCTTTAAAGACTTGTTTGCCTAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGCAT----T-T------G--TGCATTGATATTTTTCATGATACTTTGG--TG-T-GTTTG--TGTA---ATAA-AAA-AAA-ATAAAAA-ATCAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATTGATATTTGTTAT--A-A-AGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATAT-GTAT-AT-G--T-ATAAGTGCATGATGTGATTATATGGG</Hsp_hseq>
+      <Hsp_midline>||||| ||| ||||||||||||||||||||||||||| |||| |||| |||| |||||||||||||| ||   || ||  ||  |||||||||||    | |      |  ||||||||| ||| ||| ||||||||||  || | ||  |  ||||   |||| ||| ||| | ||||| ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  || | || |||  | | ||||||||||||||||||||||||||||||||||||||||||||||||||||||||| | || | |  |  | ||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>100.839</Hsp_bit-score>
+      <Hsp_score>54</Hsp_score>
+      <Hsp_evalue>6.1698e-24</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>80</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>83</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>74</Hsp_identity>
+      <Hsp_positive>74</Hsp_positive>
+      <Hsp_gaps>3</Hsp_gaps>
+      <Hsp_align-len>83</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTA-TATTATAAAAAAA-TATAATGATGTATTCT-AGTGTATGGTTGTT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTAATATAAAACAAAAATTATAATGATGTATTCTCATTGGTTGGTTGTT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||| ||| | | ||||| |||||||||||||||| | ||  ||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>22</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|7</Hit_id>
+  <Hit_def>AB462270.1 Culicoides dubius genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Isg23</Hit_def>
+  <Hit_accession>7</Hit_accession>
+  <Hit_len>1096</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>364.91</Hsp_bit-score>
+      <Hsp_score>197</Hsp_score>
+      <Hsp_evalue>1.98157e-103</Hsp_evalue>
+      <Hsp_query-from>322</Hsp_query-from>
+      <Hsp_query-to>558</Hsp_query-to>
+      <Hsp_hit-from>597</Hsp_hit-from>
+      <Hsp_hit-to>831</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>227</Hsp_identity>
+      <Hsp_positive>227</Hsp_positive>
+      <Hsp_gaps>8</Hsp_gaps>
+      <Hsp_align-len>240</Hsp_align-len>
+      <Hsp_qseq>ATAACAAACAAACAAAAAAAGATCAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATAT-TTC--TGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTAT</Hsp_qseq>
+      <Hsp_hseq>ATAA-AAA-AAA-AAATTAA-AT-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATCTTAGTTGTTATTCACAGAATCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTAT</Hsp_hseq>
+      <Hsp_midline>|||| ||| ||| |||  || || ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||   || |||||||||| |||||||||||||||||||||||||||||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>73.1396</Hsp_bit-score>
+      <Hsp_score>39</Hsp_score>
+      <Hsp_evalue>1.34501e-15</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>39</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>39</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>39</Hsp_identity>
+      <Hsp_positive>39</Hsp_positive>
+      <Hsp_gaps>0</Hsp_gaps>
+      <Hsp_align-len>39</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATA</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATA</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+</Iteration_hits>
+  <Iteration_stat>
+    <Statistics>
+      <Statistics_db-num>22</Statistics_db-num>
+      <Statistics_db-len>18669</Statistics_db-len>
+      <Statistics_hsp-len>16</Statistics_hsp-len>
+      <Statistics_eff-space>13994188</Statistics_eff-space>
+      <Statistics_kappa>0.46</Statistics_kappa>
+      <Statistics_lambda>1.28</Statistics_lambda>
+      <Statistics_entropy>0.85</Statistics_entropy>
+    </Statistics>
+  </Iteration_stat>
+</Iteration>
+  </BlastOutput_iterations>
+</BlastOutput>

--- a/tools/merge_blastxml/test-data/q1.blastxml
+++ b/tools/merge_blastxml/test-data/q1.blastxml
@@ -1,0 +1,1845 @@
+<?xml version="1.0"?>
+<!DOCTYPE BlastOutput PUBLIC "-//NCBI//NCBI BlastOutput/EN" "http://www.ncbi.nlm.nih.gov/dtd/NCBI_BlastOutput.dtd">
+<BlastOutput>
+  <BlastOutput_program>blastn</BlastOutput_program>
+  <BlastOutput_version>BLASTN 2.5.0+</BlastOutput_version>
+  <BlastOutput_reference>Zheng Zhang, Scott Schwartz, Lukas Wagner, and Webb Miller (2000), &quot;A greedy algorithm for aligning DNA sequences&quot;, J Comput Biol 2000; 7(1-2):203-14.</BlastOutput_reference>
+  <BlastOutput_db>/usr/people/galaxyuser/galaxy/galaxysrv/galaxy/database/files/000/dataset_421_files/blastdb</BlastOutput_db>
+  <BlastOutput_query-ID>Query_1</BlastOutput_query-ID>
+  <BlastOutput_query-def>AB462261.1 Culicoides brevitarsis genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Naha17_1</BlastOutput_query-def>
+  <BlastOutput_query-len>796</BlastOutput_query-len>
+  <BlastOutput_param>
+    <Parameters>
+      <Parameters_expect>0.001</Parameters_expect>
+      <Parameters_sc-match>1</Parameters_sc-match>
+      <Parameters_sc-mismatch>-2</Parameters_sc-mismatch>
+      <Parameters_gap-open>0</Parameters_gap-open>
+      <Parameters_gap-extend>0</Parameters_gap-extend>
+      <Parameters_filter>L;m;</Parameters_filter>
+    </Parameters>
+  </BlastOutput_param>
+<BlastOutput_iterations>
+<Iteration>
+  <Iteration_iter-num>1</Iteration_iter-num>
+  <Iteration_query-ID>Query_1</Iteration_query-ID>
+  <Iteration_query-def>AB462261.1 Culicoides brevitarsis genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Naha17_1</Iteration_query-def>
+  <Iteration_query-len>796</Iteration_query-len>
+<Iteration_hits>
+<Hit>
+  <Hit_num>1</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|1</Hit_id>
+  <Hit_def>AB462264.1 Culicoides wadai genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Isg18_1</Hit_def>
+  <Hit_accession>1</Hit_accession>
+  <Hit_len>834</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>684.381</Hsp_bit-score>
+      <Hsp_score>370</Hsp_score>
+      <Hsp_evalue>0</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>728</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>762</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>660</Hsp_identity>
+      <Hsp_positive>660</Hsp_positive>
+      <Hsp_gaps>80</Hsp_gaps>
+      <Hsp_align-len>785</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAAATATAATGATGTATTCTTTATAAG-GTATGGTTG-T-TAT-CGTTGTTA-T-TA-CAG-T-G--G-------CTTCGGCAAGCTCGTTATAAAGATGTAGTTTATTATGTCTTAAGCGAGTGCTGTAATACAACAAAACTAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCC--GTAAAACTAGTGA-CTTCGTGTCGCTAGTATGCATATT---G--------CT-TT---A----CGC---GATATGCATTGATATTTTTATCAAGATACTTTGGAGTGAGTAC-TTTGTAC-GTAAAATAAAATAAAAAAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCATGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGCGTCGTTTGCTTCCTCGGAGGCTGCGCGCATAAGTGCTTGATGTGATCATATGAATTGCTTCAGATTCATATATCATTAATAAAGTA-A-TATGAGTGGTTG-CTT---TGC-AGATA-CG--TGCATTTGACCATTACTTTTATTTAATTAAATA--AAATATTGGTATAAAATCAAA</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTA-ATCTAAAACATTCAATGATGTATTCT-CACAAGTGTATGGTTGTTGTTTCCGTTGTTATTGTAGCAGCTCGTCGTAATTATCGTCGGGCAGCTTGCTATAAAGATGTAGTTTATTATGTCTTAAGCGAGTGCTGCAATACAACAATACAAAATTTCTTAGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCTAAGGCCCCCAGTAAAACTAGTGATCTTTGTGTCACTAGTATGCATATTAATGCATAACATCTCTTCGGAGGTGCGCTTTGATATGCATTG--ATTTATATCAAGATACTTTGGAGTGAGTACATTCGTACAATAAAA-CAAA-CAAAAAAAGATC-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTT-TGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGACTCGTTTGAA-CGTC------T-----CATAAGTGCATGATGTGATCATATGGATTTCG-C-GATTCATATATCATTAATAAAGGAGAATATG-GTTGTTAACGTGCGTGTTACATTGCGTTTGCATTTGACCATTATTTTTATTTAATAAAATAATAAATTTTGGTATAAAATCAAA</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||| ||  |||| ||  |||||||||||||  | ||| ||||||||| | | | |||||||| | || ||| | |  |       | ||||  |||| | |||||||||||||||||||||||||||||||||||||| |||||||||| || ||||||||| ||||||||||||||||||||||||||||||||||||| ||||||||  ||||||||||||| ||| ||||| ||||||||||||||   |        || ||   |    |||   |||||||||||  |||| ||||||||||||||||||||||||| || ||||  |||||  |||  ||||||||||| |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  |||||||   | ||      |     ||||||||| ||||||||||||||| ||| |  | |||||||||||||||||||||| | | |||| || |||  | |   ||  | ||  ||  ||||||||||||||| ||||||||||| |||||  |||| ||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>54.6731</Hsp_bit-score>
+      <Hsp_score>29</Hsp_score>
+      <Hsp_evalue>4.97388e-10</Hsp_evalue>
+      <Hsp_query-from>768</Hsp_query-from>
+      <Hsp_query-to>796</Hsp_query-to>
+      <Hsp_hit-from>806</Hsp_hit-from>
+      <Hsp_hit-to>834</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>29</Hsp_identity>
+      <Hsp_positive>29</Hsp_positive>
+      <Hsp_gaps>0</Hsp_gaps>
+      <Hsp_align-len>29</Hsp_align-len>
+      <Hsp_qseq>ACTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>ACTATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>2</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|0</Hit_id>
+  <Hit_def>AB462263.1 Culicoides maculatus genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Kag12_1</Hit_def>
+  <Hit_accession>0</Hit_accession>
+  <Hit_len>764</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>682.534</Hsp_bit-score>
+      <Hsp_score>369</Hsp_score>
+      <Hsp_evalue>0</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>727</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>701</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>623</Hsp_identity>
+      <Hsp_positive>623</Hsp_positive>
+      <Hsp_gaps>48</Hsp_gaps>
+      <Hsp_align-len>738</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAAATATAATGATGTATTCTTTATAAGGTATGGTTGTTATCGTTGTTATTACAG-TGGCT-T--CGGCAAGCTCGTTATAAAGATGTAGTTTATTATGTCTTAAGCGAGTGCTGTAATACAACAAAACTAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGC-CCCGTAAAACTAGTGA-CTTCGTGTCGCTAGTATGCATATT-GCTTTACGCGATATGCATTGATATTTTTATCAAGATACTTTGGAGTGAGTACTTTGTACGTA-AAATAAAATAAAAAAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCATGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGCGTCGTTTGCTTCCTCGGAGGCTGCGCGCATAAGTGCTTGATGTGATCATATGAATTGCTTCAGATTCATATATCATTAATAAAGTAATATGAGTGGTTGCTTTGCAGATACGTGCAT--TTGACCATTACTTTTATTTAATTAAATAAA-ATATTGGTATAAAATCAA</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTA-ACT--AAACATTCAATGATGTATTCTTTA--AGGTATGGTTG---TCGTTGTTATTGCAGCAGCCTCTCGCGGGCAGCTTGCTATAAAGATGTAGTTTATTATGTCTTAAGCAAGTGTTGTGGTTCAACAAA---AAATTACTTGGGTAGCTTTATTTAAGAGCTTTAAAGACTTGTTTGCCCAAGGCTCCCGTAAAACTAGTGATCTT-GTTTCATTAGTATGCA-ATTATATTTA-TATATTTGCATTGAT-TTTATATCAAGATACTTTGGTGTGAGTAC---GTATGTACATATAAAA-CAAAAAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTTCGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATG--TA-TT-G-T-C-TGAAAAGATAAATG--TAAGTGCATGATGTGATCATATGGATTWACT----TTCATATATCATTAATGGAGGA-TATG-GTTATCGCT--GCT-ATGTTTGCACACTTGGCCATTATTTTTATTTAGTTAAAAATATATATTGGTATAAAATCAA</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||| | |  ||| ||  ||||||||||||||||  |||||||||||   ||||||||||| |||  | || |  |||  |||| | |||||||||||||||||||||||||||||| |||| |||  | |||||||   ||||| |||||||||||||||  |||||||||||||||||||||||||||||| |||||||||||||||| ||| || ||  ||||||||| |||   ||||    || ||||||||| ||| |||||||||||||||| ||||||||   ||| ||| | ||||||  |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||   |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  |  || | | | |   | | |    |  ||||||| ||||||||||||||| |||   |    ||||||||||||||||  || | |||| ||  | |||  ||  ||   ||||   ||| |||||| ||||||||| ||||| | | ||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>52.8265</Hsp_bit-score>
+      <Hsp_score>28</Hsp_score>
+      <Hsp_evalue>1.78893e-09</Hsp_evalue>
+      <Hsp_query-from>766</Hsp_query-from>
+      <Hsp_query-to>796</Hsp_query-to>
+      <Hsp_hit-from>734</Hsp_hit-from>
+      <Hsp_hit-to>764</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>30</Hsp_identity>
+      <Hsp_positive>30</Hsp_positive>
+      <Hsp_gaps>0</Hsp_gaps>
+      <Hsp_align-len>31</Hsp_align-len>
+      <Hsp_qseq>TAACTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>TATCTATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>|| ||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>3</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|17</Hit_id>
+  <Hit_def>AB462280.1 Culicoides kibunensis genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: AM05_6</Hit_def>
+  <Hit_accession>17</Hit_accession>
+  <Hit_len>817</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>621.595</Hsp_bit-score>
+      <Hsp_score>336</Hsp_score>
+      <Hsp_evalue>1.08727e-180</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>796</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>817</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>678</Hsp_identity>
+      <Hsp_positive>678</Hsp_positive>
+      <Hsp_gaps>59</Hsp_gaps>
+      <Hsp_align-len>836</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAAATATAATGATGTATTCTTTATAAGGTATGGTTGTTATCGT-TGTTATTA-C-AGTGGCTTCGGCAAGCTCGTTA-T-AAAGATGTAGTTTATTATGTCTTAAGCGAGTGCTGTAATACAA-CA---AAACT-AAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGAC---TT-CG-TGTCGCTAGTATGCATATTGC--TTTACGCG-ATATGCATTGATATTTTTATCAAGATACTTTGGAGTGAGTA----CTT--T-GTACGTA-AAATA-AAATAAAAAAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCA-TGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGCGTCGTTTGCTTCCTCGGAGGCTGC-GC-GCATAAGTGCTTGATGTGATCATATGAATTGCTTCAGATT-C--ATATATCATTAATAAAGTAATATGAGTGGTTGCTT-TGCAGATACGTGCATTTGACCATTACTTTTATTTAAT-TAAATA-A-AATATTGGTATAAAATCAA-AGGCACTTGCAAAT-GTAGACCGTTATATGTA-AAAACTTTAACTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAAATATAATGATGTA-TCATTCTAAGGTATGGTTGTT-TTGTCTCTCAACAGCTATTAACTT-GGC-AG--C-TTACTCAAAGATGTAGCTTATTATGTTTTAAGTAAGTGTTGTTAGACAATCAGGTATGGTGAAATTWCTTAGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCTAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGCATATACAAGTAAAATTGTATATGCATTGATATTTT--TCATGATACTTTGGTGTGAGTATAAAATTAATAATTTGTACAWAAACAAACAAAAAAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTCAAACTATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTGT--TTTGTTGTCTAACAA-CAGCAGAAGCATAAGTGCATGATGTGATCATAT-AA--GCTTTTAATYGCYTATATATCATTAATAAAGGTATAAGTATGGTAACAAGTGCTTTTGCACATATTTAACCATAATTTTTATTTAATATAAATATATAATTTTGGTATAAAATGAATATGTG-TTGYACGTTGTA-AGC-T-ATACAAAGAAAACTTTAAAATTGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| || || ||||||||||||||| | || | | |  | | | |  ||| ||| ||  | ||| | |||||||||| ||||||||| |||||  |||| ||| | |||| ||   |   | ||||| ||| ||||||||||||||||||||||||||||||||||||| ||||||||||||||||||| ||   || ||  || ||||||||||||||     |  |   | |||||||||||||||||  ||| |||||||||| |||||||     ||  |  |  ||| | | | ||| |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  |   |||||||||  ||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||  |||| |  ||   |  | || |  |||||||||| |||||||||||||| ||  ||||   ||  |  |||||||||||||||||  ||| |  ||||  |   |||   | |    |||| ||||| | ||||||||||| |||||| | ||| |||||||||||| || | |   ||| |  | ||| | | | |||   | ||||||||||   |||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>4</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|12</Hit_id>
+  <Hit_def>AB462275.1 Culicoides punctatus genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Kag13_1</Hit_def>
+  <Hit_accession>12</Hit_accession>
+  <Hit_len>787</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>590.202</Hsp_bit-score>
+      <Hsp_score>319</Hsp_score>
+      <Hsp_evalue>3.06608e-171</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>561</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>575</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>503</Hsp_identity>
+      <Hsp_positive>503</Hsp_positive>
+      <Hsp_gaps>36</Hsp_gaps>
+      <Hsp_align-len>586</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAAATATAATGATGTATTCTT-TATAAGGTATGGTTGTTATCGTTGTTA-T-T-ACAGT-GGCT--TCGGCAAGCTCGTTATAAAGATGTAGTTTATTATGTCTTAAGCGAGT-GC-TGTAATACAACAAAACTAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGAC---TT-CG-TGTCGCTAGTATGCATATTGCTTTACGCGATATGCATTGATATTTTTATC-AAGATACTTTGGAGTGAGTACT-TTGT-ACGTAA----A-AT-AA-AATA-AAAAAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCATGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATG</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTAT-TATAAAACATATAATGATGT-TCATTCTAT-AGGTATGGTTGTTGT-GTTGTCATTGTAAGAGTCATTTAGTTGGC-AGCTCTCTATAAAGACATAGTTTATTATGTTTTAAGGGAGTACCTTGCAGTGCGACAAAA--AAATTACTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGCATAT-ACTTAATTGTATATGCATTGAT-TTATT-TCAAAGATACATTGGAGAGAGTATAATTGTAATGAAATTGTACATAAACAAAACAAAAAAAG-TAAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTTCGATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATG</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||| |  |||| |||||||||||| |  || ||| ||||||||||||| | ||||| | | | | |||    |  | ||| |||||  ||||||||  ||||||||||||| ||||| ||||  | || | | | ||||||  ||||| ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||   || ||  || ||||||||||||||  ||| |    |||||||||||| || || || ||||||| |||||| |||||   |||| | | ||    | || || || | |||||||| | ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||   ||||||||||  |||||||||||||||||||||||||||||||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>5</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|18</Hit_id>
+  <Hit_def>AB462281.1 Culicoides verbosus genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: OKYN05_18</Hit_def>
+  <Hit_accession>18</Hit_accession>
+  <Hit_len>805</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>586.508</Hsp_bit-score>
+      <Hsp_score>317</Hsp_score>
+      <Hsp_evalue>3.96623e-170</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>796</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>805</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>681</Hsp_identity>
+      <Hsp_positive>681</Hsp_positive>
+      <Hsp_gaps>83</Hsp_gaps>
+      <Hsp_align-len>842</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAAATATAATGATGT--ATTCTTTATAAGGTAT---GGTTGTTATCGTTGTTATTAC-AGTGGCTTCGGCAAGCTCGTTATAAAGATGTAGTTTATTATGTCTTAAGCGAGTGCTGTAATACAACAA---------AACTAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGAC---TT-CG-TGTCGCTAGTATGCATATTGCTTTACGCGATATGCATTGATATTTTTATCAAGATACTTTGGAGTG--AG--------T--ACTTTGTACGTAAAATAAAATAAAAAAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCATGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGCGTCGTTTGCTTCCTCGGAGGCTGCGCGCATAAGTGCTTGATGTGATCATATGAATTGCTTCAGATT-C--ATATATCATTAATAAAG-TA-ATATGAGTGGTTGCT-TTGCAGATACGTGCATTTGACCATTACTTTTATTTAAT-TAAATAAAATA---TTGGTATAAAATCAA-AGG-CACTT-GCAAATGT-AGACCGTTATATGTAAAAACTTTAACTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAAATATAATGATGTTCATTC-ATAAAAGGTATAACGGTTGTTGTC-TTTCAATGGCTATTCACTT-AGCAAGCTTGCTATAAAAATGTAGTTTATTATGTTTTAAGCAAGTGTTGTTAGACAA-AAGGTTGGTTGTTCAAAATTACTTAGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCTAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGTATAT-ACTTAATTGTATATGCATTGATATTTT--TCATGATACTTTGGAGTGTGAGTATAAAATTAAAATTTGTAC-AAAAACAAAA-ACAAAAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATAAACTAATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATG--TCTTTAAAAT--T-G-AGA-T------ATAAGTGCATGATGTGATCATAT-AA--GCTT-A-ATTGCCTATATATCATTAATAAAGGTGGAGGT-A-TGGT-GCTATTGT-G-TACAT--ATTTAACCATCATTTTTATTTAATATAAATAATATAATTTTGGTATAAAATGAATATGTCATATAGCACATATCATACAGCAAAA---AAAAACTTTAAAATTGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  ||||  || |||||||   ||||||| || ||   ||  | | |  |||  ||||||| | |||||| |||||||||||||||| |||||| |||| ||| | |||| ||           | ||||| ||| ||||||||||||||||||||||||||||||||||||| ||||||||||||||||||| ||   || ||  || ||||||||| ||||  ||| |    |||||||||||||||||  ||| ||||||||||||||  ||        |  | |||||||  |||| |||| | ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||    | |||||||||  |||||||||||||||||||||||||||||||||||||||||||||||||||||||||  || ||    |  | | ||  |      |||||||| |||||||||||||| ||  |||| | ||| |  ||||||||||||||||| |  |  | | |||| ||| |||  | ||| |  |||| ||||| | ||||||||||| ||||||| |||   |||||||||||| || | | ||  | ||| || | | || |  | |   |||||||||||   |||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>6</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|5</Hit_id>
+  <Hit_def>AB462268.1 Culicoides cylindratus genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Kag08, short type</Hit_def>
+  <Hit_accession>5</Hit_accession>
+  <Hit_len>748</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>582.815</Hsp_bit-score>
+      <Hsp_score>315</Hsp_score>
+      <Hsp_evalue>5.13064e-169</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>561</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>547</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>490</Hsp_identity>
+      <Hsp_positive>490</Hsp_positive>
+      <Hsp_gaps>36</Hsp_gaps>
+      <Hsp_align-len>572</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAAATATAATGATGTATTCTT-TATAAGGTATGGTTGTTATCGTTGTTATTAC-AGTGGCTTCGGCAAGCTCGTTATAAAGATGTAGTTTATTATGTCTTAAGCGAGTGCTGTAATACAACAAAACTAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGACTTCGTGTCGCTAGTATGCATATTGCTTTACGCGATATGCATTGATATTTTTATCAAGATACTTTGGAGTGAGTA-----C----TTTGTACGTAAAATAAAATAAAAAAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCATGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATG</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTAT----AAAATATATAATGATGT-TCATTCAATAAGGT-TGGTGGTTGT-ATTGTAACAGCTATTTACTT-AGC-AGCTTGCTATAAAGATGTRGTTTATYATGTCTTAAGYAAGTGTTGYGATACARCAAA---AAATTTCTTAGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCTAAGGCCCCGTAAAACTAGTAAC-CCAT-T-GCGAGGTGGC-TA--G---TATGC-ATATGCATTGATATTTT--TCATGATACTTTGGAGTGAGTATAATACAAAAATTGTACATAAAACAAAAYAAAAAAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTATAATATTTT-TGATATTCATAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATAYATTAAACTATCTTATG</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||    |||| |||||||||||| |  ||  ||||||| |||| ||| |  |||| |   | | |  |||  || |||| | ||||||||||| |||||| ||||||||||  |||| ||  ||||| ||||   ||||||||| ||||||||||||||||||||||||||||||||||||| ||||||||||||||||||| ||  | | | || ||   || ||  |   || || |||||||||||||||||  ||| ||||||||||||||||||     |     |||||| ||||| |||| ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||||||||  ||||||||| |  |||||||||||||||||||||||||||||||||||||||| ||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>7</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|21</Hit_id>
+  <Hit_def>AB462284.1 Culicoides paraflavescens genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: OKYN05_13</Hit_def>
+  <Hit_accession>21</Hit_accession>
+  <Hit_len>842</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>564.348</Hsp_bit-score>
+      <Hsp_score>305</Hsp_score>
+      <Hsp_evalue>1.85841e-163</Hsp_evalue>
+      <Hsp_query-from>170</Hsp_query-from>
+      <Hsp_query-to>724</Hsp_query-to>
+      <Hsp_hit-from>249</Hsp_hit-from>
+      <Hsp_hit-to>783</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>484</Hsp_identity>
+      <Hsp_positive>484</Hsp_positive>
+      <Hsp_gaps>38</Hsp_gaps>
+      <Hsp_align-len>564</Hsp_align-len>
+      <Hsp_qseq>AAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGAC---TT-CG-TGTCGCTAGTATGCATATTGCTTTACGCGATATGCATTGATATTTTTATCAAGATACTTTGGAGTGAGTACT--TTGTACGTAAAATAAAATAAAAAAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCATGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGCGTCGTTTGCTTCCTCGGAGGCTGCGCGCATAAGTGCTTGATGTGATCATATGAATTGCTTCAGATTCATATATCATTAATAAAGTAATATGAGTGGTTGCTTTGCAGATACGTGCATTTGACCATTACTTTTATTTAATTAAATA--AAATATTGGTATAAAAT</Hsp_qseq>
+      <Hsp_hseq>AAATTTCTTGGGTAGCTTTATTGAAGAGCTTTAAAGACTTATTTGCCCAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGCATA-CCCTTTATTGGGTATGCATTGATATTTT--TCATGATACTTTGGTGTGAGTACTTATTGTACATATGAT-AAATAAAAAAACGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTTTGATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGCGTCTCTAGCGA--TAGAAG-C-GCT----TAAGTGCATGATGTGATTATAT-AA--G-TAAA-ATT-ATATATCATTAATAAAGGAATAAAA-TGGTA--T--G-A-AT-CAT--ATTTAACCATTATTTTTATTTAAA-AAATAACAAATTTTGGTATAAAAT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||| |||||||||||||||||| |||||||||||||||||||||||||| ||   || ||  || |||||||||||||   |||||   | ||||||||||||||||  ||| |||||||||| |||||||||  |||||| ||  || ||||||||||| ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  |||||||||||  |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  | ||    | | || | ||     ||||||| ||||||||| |||| ||  | |  | ||| ||||||||||||||||| ||||  | ||||   |  | | || | |  |||| ||||||| ||||||||||  |||||  |||| ||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>145.159</Hsp_bit-score>
+      <Hsp_score>78</Hsp_score>
+      <Hsp_evalue>2.8691e-37</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>145</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>143</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>126</Hsp_identity>
+      <Hsp_positive>126</Hsp_positive>
+      <Hsp_gaps>8</Hsp_gaps>
+      <Hsp_align-len>148</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAAATATAATGATGTATTCTTTATAAGGTATGGTTGTT-ATCGTTGTTATTA-C-AGTGGCTTCGGCAAGCTCGTTATAAAGATGTAGTTTATTATGTCTTAAG</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATT-AAAACATATAATGATGT-TTC-TT-TAAGGTATGGTGTTTGATATTTGTTGATAGCTATTTGATT-AGCAAGCTTACTATAAAGATGTAGTTTATTATGTCTTAAG</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||||| |||| |||||||||||| ||| || |||||||||||  || ||  |||||  || | | | | ||  |||||||   |||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>8</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|20</Hit_id>
+  <Hit_def>AB462283.1 Culicoides matsuzawai genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: IS05_6</Hit_def>
+  <Hit_accession>20</Hit_accession>
+  <Hit_len>908</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>545.882</Hsp_bit-score>
+      <Hsp_score>295</Hsp_score>
+      <Hsp_evalue>6.73148e-158</Hsp_evalue>
+      <Hsp_query-from>170</Hsp_query-from>
+      <Hsp_query-to>565</Hsp_query-to>
+      <Hsp_hit-from>300</Hsp_hit-from>
+      <Hsp_hit-to>698</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>372</Hsp_identity>
+      <Hsp_positive>372</Hsp_positive>
+      <Hsp_gaps>17</Hsp_gaps>
+      <Hsp_align-len>406</Hsp_align-len>
+      <Hsp_qseq>AAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGAC---TT-CG-TGTCGCTAGTATGCATATTGCTTTACGCGA-TATGCATTGATATTTTTATCAAGATACTTTGGAGTGA-GTAC-T-TTGTACGTAAAATAAAATAAAAAAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCAT-GATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGCGTC</Hsp_qseq>
+      <Hsp_hseq>AAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGCATA-CAC-TTARTTGAGTATGCATTGATATTTT--TCATGATACTTTGGTGTGAAGTACATATTGTACCG-ATAT-AAACAAAAAAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTT-ATCGATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTGTC</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||   || ||  || |||||||||||||   | |||   || ||||||||||||||||  ||| |||||||||| |||| |||| | ||||||   | || ||| |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| || ||||||||||  ||||||||||||||||||||||||||||||||||||||||||||||||||||||||| |||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>148.852</Hsp_bit-score>
+      <Hsp_score>80</Hsp_score>
+      <Hsp_evalue>2.21795e-38</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>145</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>154</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>134</Hsp_identity>
+      <Hsp_positive>134</Hsp_positive>
+      <Hsp_gaps>15</Hsp_gaps>
+      <Hsp_align-len>157</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAAATATAATGATGTATTCTTTATA-A-GGTAT--GGTTGTTATCGTTGTTAT-T-A-CAG-TG---GCTTCGGCAAGCTCGTTATAAAGATGTAGTTTATTAT-GTCTTAAG</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAAATATAATGATGT-TTCTTTATATAAGGTATATGGTTGTTAT-GTTGTCTTGTCAACAGCTATTTGATTA-GCAAGCTTGCTATAAAGATGTAGTTTATTACGGTCTTAAG</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||||||||| | |||||  ||||||||| |||||  | | | ||| |    | ||  ||||||| | ||||||||||||||||||||  ||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>9</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|19</Hit_id>
+  <Hit_def>AB462282.1 Culicoides humeralis genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Kag15_1</Hit_def>
+  <Hit_accession>19</Hit_accession>
+  <Hit_len>912</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>532.955</Hsp_bit-score>
+      <Hsp_score>288</Hsp_score>
+      <Hsp_evalue>5.2407e-154</Hsp_evalue>
+      <Hsp_query-from>170</Hsp_query-from>
+      <Hsp_query-to>796</Hsp_query-to>
+      <Hsp_hit-from>297</Hsp_hit-from>
+      <Hsp_hit-to>912</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>535</Hsp_identity>
+      <Hsp_positive>535</Hsp_positive>
+      <Hsp_gaps>49</Hsp_gaps>
+      <Hsp_align-len>646</Hsp_align-len>
+      <Hsp_qseq>AAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGAC---TT-CG-TGTCGCTAGTATGCATATTGCTTTACGCGA-TATGCATTGATATTTTTATCAAGATACTTTGGAGTGAGTA--CTTTGTA-CGTAAAATAA-AA-TAAAAAAAA-GATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCAT-GATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGCGTCGTTTGCTTCCTCGGAGGCTGCGCGCATAAGTGCTTGATGTGATCATATGAATTGCTTCAGATTCATATATCATTAATAAAG--TAATATGAGTGGTTGCTTTGCAGATACGTGCAT--TTGACCATTACTTTTATTTAATTAAATAAAATATTGGTATAAAATCAA-AGGCACTT-GCAAATGTAGACCGTTATATGTAAAAACTTTAACTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>AAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGCATA-CAC-TTAATTGAGTATGCATTGATATTTT--TCATGATACTTTGGTGTGAGTATAATTTGTATTGTACATAAACAAGAAAAAAAAACGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTT-ATCGATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTGT-GT---CTTGAAAA-AGACAT----CATAAGTGCATGATGTGATTATAT-AA--GCGCAAGCTT-ATATATCATTAATAAAGGATAATATG-GACGTATC---GCT-AT-CTTGCATACTTAACCATAATTTTTATTTGATTATAAATAATTTTGGTATAAAATGAGTATGT-CTAAGCTC-T-TAG-CTTTCGCCTCTAAAA-CTTTAT-TATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||   || ||  || |||||||||||||   | |||   || ||||||||||||||||  ||| |||||||||| |||||||   ||||||  ||| |  || ||  |||||||| |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| || ||||||||||  ||||||||||||||||||||||||||||||||||||||||||||||||||||||||| || ||   |||      || |      ||||||||| ||||||||| |||| ||  ||   || || |||||||||||||||||  ||||||| |  ||  |   ||  || | |||||  || ||||| | |||||||| |||| | | ||| |||||||||||| |  | |  ||  ||   | ||| |  |    | ||||| |||||  |||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>145.159</Hsp_bit-score>
+      <Hsp_score>78</Hsp_score>
+      <Hsp_evalue>2.8691e-37</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>145</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>152</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>131</Hsp_identity>
+      <Hsp_positive>131</Hsp_positive>
+      <Hsp_gaps>13</Hsp_gaps>
+      <Hsp_align-len>155</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAAATATAATGATGTATTCTTTATA-A---GGTAT--GGTT--GTTATCGTTGTTATTA-C-AGTGGCTTCGGCAAGCTCGTTATAAAGATGTAGTTTATTATGTCTTAAG</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAAATATAATGATGT-TTCTTTATATATAAGGTATATGGTTATGTTGTC-TTGTCAAYRGCTATTYGATTA-GCAAGCTTGCTATAAAGATGTAGTTTATTATGTCTTAAG</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||||||||| |   |||||  ||||  ||| || |||| |    | | | | ||  ||||||| | |||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>10</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|13</Hit_id>
+  <Hit_def>AB462276.1 Culicoides sumatrae genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: ONYK05_17</Hit_def>
+  <Hit_accession>13</Hit_accession>
+  <Hit_len>784</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>525.569</Hsp_bit-score>
+      <Hsp_score>284</Hsp_score>
+      <Hsp_evalue>8.76954e-152</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>561</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>583</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>499</Hsp_identity>
+      <Hsp_positive>499</Hsp_positive>
+      <Hsp_gaps>46</Hsp_gaps>
+      <Hsp_align-len>595</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTAT-ATT-AAAAAAATATAATGATGTATTCTTTATAAGGTATGGTTGTTA-TC-GTTGTTATTACAGTGGCTTCGGCAAGC-T----CGTTATAAAGATGTAGTTTATTATGTCTTAAGCGAGTGCTGTA-ATACAACAAAACTAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGAC---TT-CG-TGTCGCTAGTATGCATATTGCTTTACGCGATATGCATTGATATTTTTATCAAGATACTTTGGAGTGA---------GT--A-CTTTGTACGTAAAATA-AAATA--AAAAAAAGA-T-CA-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATT-TCATGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATG</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATTATTAAAAAAAATATAATGATGT-TTCATT-CAAGGTATGGTTGTTAATCTATTGCAATGGCTATTAATTTAGC-AGCTTACACCGCTATAAAGATGTGGTTTATCATATCTTAAGC-A-TTC-GTAGGTGTTGTGATAGAAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGTATAT-ACTTAATTGTATATGCATTGATATTTT--TCATGATACTTTGGTGTGATAATAAAAAGTAAATCTTTATA-TTTATATAGAGATAGGAAAAAAAAAGTAAAGAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTATC--GATATTCACGAAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATG</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||| ||| |||||||||||||||||| ||| ||  ||||||||||||||| ||  |||  ||  |  |   ||  || ||| |    || ||||||||||| |||||| || |||||||| | | | |||  |      | |  ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||   || ||  || ||||||||| ||||  ||| |    |||||||||||||||||  ||| |||||||||| ||||         ||  | |||| ||  | | ||| | |||  ||||||| | |  | |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||  |||||||||  ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>11</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|9</Hit_id>
+  <Hit_def>AB462272.1 Culicoides nipponensis genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Isg22</Hit_def>
+  <Hit_accession>9</Hit_accession>
+  <Hit_len>794</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>518.182</Hsp_bit-score>
+      <Hsp_score>280</Hsp_score>
+      <Hsp_evalue>1.46745e-149</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>558</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>567</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>491</Hsp_identity>
+      <Hsp_positive>491</Hsp_positive>
+      <Hsp_gaps>45</Hsp_gaps>
+      <Hsp_align-len>585</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAAATATAATGATGTATTCTT-TATAAG-GT-ATGGTTGTTATCGTTGTT---ATTACAGTGGCTTCGGCAAGC-TCGTTATAAAGATGTAGTTTATTATGTC-T-TA--AGCGAG--TGCTGTAATACAACAA-A----ACTAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGAC---TT-CG-TGTCGCTAGTATGCATATTGCTTTACGCGATATGCATTGATATTTTTATCAAGATACTTTGGAGTGAGTACTTTGTACGTAAAATAAAATAAAAAAAAG-ATCA-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATAT-TTCATGATATTCACA-GAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTAT-TATAAAAAATATAATGATGT-TCATTCTATTAGTGTAATGG-TGTTATTATTATTACAATTGCAATATATTTTGCA-GCTTACACA-AAAGATGTAGTTTATTATATCATATATGTGCAAGTATATTGTAATAATAAAAGAGTTGGTTAAATTTCTTGGGTAGCTTTATTGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGTATAT--ATTCA-TTTATATACATTGATATTTT--TCATGATACTTTGGATTGA-TA---TG-A--TAAAACAAACAAAAAAAAAGTGTAAGAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATATTTTTGATATTCACAAGA-TCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTT</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||| |  ||||||||||||||||| |  || ||| || || |||| ||||||  || ||   ||| || |   ||  ||| || |    | |||||||||||||||||| || | ||   || ||  |  |||||||  | || |      |||||||||||||||||||||| ||||||||||||||||||||||||||||||||||||||||||||| ||   || ||  || ||||||||| ||||   || |    |||| ||||||||||||  ||| ||||||||||| ||| ||   || |  ||||| |||  |||||||||  | | ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||  ||||||||||| || |||||||||||||||||||||||||||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>12</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|15</Hit_id>
+  <Hit_def>AB462278.1 Culicoides erairai genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: IS05_2</Hit_def>
+  <Hit_accession>15</Hit_accession>
+  <Hit_len>931</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>516.336</Hsp_bit-score>
+      <Hsp_score>279</Hsp_score>
+      <Hsp_evalue>5.2779e-149</Hsp_evalue>
+      <Hsp_query-from>170</Hsp_query-from>
+      <Hsp_query-to>796</Hsp_query-to>
+      <Hsp_hit-from>310</Hsp_hit-from>
+      <Hsp_hit-to>931</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>533</Hsp_identity>
+      <Hsp_positive>533</Hsp_positive>
+      <Hsp_gaps>47</Hsp_gaps>
+      <Hsp_align-len>648</Hsp_align-len>
+      <Hsp_qseq>AAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGAC---TT-CG-TGTCGCTAGTATGCATATTGCTTTA-CGCGATATGCATTGATATTTTTATCAAGATACTTTGGAGTGAGTACTTTG--TACGTA-AAA--T-AAAA--TAAAAAAA-AGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCATGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGCGTCGTTTGCTTCCTCGGAGGCTGC-GCGCATAAGTGCTTGATGTGATCATATGAATTGCTTCAGATTCATATATCATTAATAAAGTAATATGAG-TGGTTGCTTTGCAGATACGT-GCAT-TTG-ACCATTACTTTTATTTAATTAAATAAAATATTGGTATAAAATCAA-AGGCACTTGCAAATGTAGACCGTTATATGTAAAAACTTTAACTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>AAATTTCTTAGGTAGCTTTATTGAAGAGCTTTAAAGACTTGTATGCCTAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGCATATATTTTAATCGGTGTATGCATTGATATTTT--TCATGATACTTTGGTGTGA-TATTTTGTATATTTACAAATGTAAAAATGTAAAAAAAGAGATC-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTACT--TATTCACAAAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTGTGATT--TTT-CTGG-T-GAAA-CAGAAGCTTACAAGTGCATGATGTGATCATATAGATGATTTCTGTCT-ATATATCATTAATAAAGTGGTATGATATGTGTACTAA--AGTTGTGTTGCATATTTAACCATAATTTTTATTTAATAATATTAATT-TTGGTATAAAATAAATAAGCACA--CAC-T-TAG----TTGTATC-AAAAACTTTAAAT-TGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>||||||||| ||||||||||| |||||||||||||||||||| |||| ||||||||||||||||||| ||   || ||  || ||||||||||||||   || | ||   ||||||||||||||||  ||| |||||||||| |||| || ||||  ||  || |||  | ||||  |||||||| ||||| |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  |  |||||||| ||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||  |  ||| ||   | | |  | |  ||  | |||||| ||||||||||||||  ||   ||| |  | ||||||||||||||||||  |||||  ||  | ||    || |  || |||| ||  ||||| | ||||||||||| | || || | |||||||||||| || | ||||   ||  | |||    || |||  ||||||||||| | |||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>135.926</Hsp_bit-score>
+      <Hsp_score>73</Hsp_score>
+      <Hsp_evalue>1.72675e-34</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>167</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>172</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>143</Hsp_identity>
+      <Hsp_positive>143</Hsp_positive>
+      <Hsp_gaps>11</Hsp_gaps>
+      <Hsp_align-len>175</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTA-AAAAAATATAATGATGTATTCTT-TATAAG-GTATGGTTGTTATCGTT--GTTAT-TACAGTGG-CTTCGGCAAGCTCGTTATAAAGATGTAGTTTATTATGTCTTAAGCGAGTGCTGTA-ATACAACAAAA</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTATAAAAAATATAATGATGTATCATTCTATAAGTGTATGGTGGTTGTTGTTTCGACAGCTAAAGTTTACTTTAGCAGCCTAC-TATAAAGATGTAGTTTATTATGTCTTAAGT-A-TGGTGTTGATTCAACAAAA</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||||||| |||||||||||||||||||  || |||||| ||||||| ||| | |||  |  |  || |||   |||  |||  ||   |||||||||||||||||||||||||||||  | || |||  || ||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>13</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|8</Hit_id>
+  <Hit_def>AB462271.1 Culicoides lungchiensis genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: AM05_8</Hit_def>
+  <Hit_accession>8</Hit_accession>
+  <Hit_len>776</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>510.796</Hsp_bit-score>
+      <Hsp_score>276</Hsp_score>
+      <Hsp_evalue>2.45557e-147</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>561</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>585</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>496</Hsp_identity>
+      <Hsp_positive>496</Hsp_positive>
+      <Hsp_gaps>44</Hsp_gaps>
+      <Hsp_align-len>595</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTA-TATTAAAAAAATATAATGATGTATTCT-TTATAAG-G-TATGGTTGTTAT-CGTTGTTATTAC-AGTGGCTTCGGCAAGCTCGTTATAAAGATGTAGTTTATTA--TGTC-T-TAAGCGAGTGCTGTAATACA--ACAA----AACTAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGAC---TT-CG-TGTCGCTAGTATGCATATTGCTTTACGCG-ATATGCATTGATATTTTTATCAAGATACTTTGG-----AG------TGAGTAC-TTTGTACGTAAAATAAAATAAAAAAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCATGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATG</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATTAAAAAAAAAATATAATGATGT--TCTATCATAAGTGTTATGG-TGTTATATATTACAATAACTATTTAATT-AGTAAGCTTATTATAAAGATGTGGTTTATCACTTATCTTATAAATAAGTATTGTAATATATTTTAAGTGTATGGAAATTACTTGGGTAGCTTTATTGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGTATATACATTTATTTGTATATACATTGATATTTTT-TCATGATACTTTGGTATAAAGAAAAAAAAAGTACAATTTT--GT-ACATATAA-AAAAAAAAGATCTAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTT-TGATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATG</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||| ||  ||||||||||||||||||  ||| | ||||| | ||||| ||||||   ||   || || | |   ||  | |||||  |||||||||||| |||||| |  | || | |||   |||  ||||||| |    ||    |   ||||| ||||||||||||||| ||||||||||||||||||||||||||||||||||||||||||||| ||   || ||  || ||||||||| ||||   ||||   | |||| ||||||||||||| ||| ||||||||||     ||        |||||  || |  || | ||| || |||||||||||| |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  |||||||||||  |||||||||||||||||||||||||||||||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>14</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|3</Hit_id>
+  <Hit_def>AB462266.1 Culicoides japonicus genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Ngs24_1</Hit_def>
+  <Hit_accession>3</Hit_accession>
+  <Hit_len>925</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>508.949</Hsp_bit-score>
+      <Hsp_score>275</Hsp_score>
+      <Hsp_evalue>8.8318e-147</Hsp_evalue>
+      <Hsp_query-from>170</Hsp_query-from>
+      <Hsp_query-to>561</Hsp_query-to>
+      <Hsp_hit-from>317</Hsp_hit-from>
+      <Hsp_hit-to>714</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>366</Hsp_identity>
+      <Hsp_positive>366</Hsp_positive>
+      <Hsp_gaps>22</Hsp_gaps>
+      <Hsp_align-len>406</Hsp_align-len>
+      <Hsp_qseq>AAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGAC---TT-CG-TGTCGCTAGTATGCATATTGCTTTACGCG-ATATGCATTGATATTTTTATCAAGATACTTTGGAGTGAGTACTTTGT---AC---GTAAAATAAAATAAAAAAA-AGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATAT-TTCATGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATG</Hsp_qseq>
+      <Hsp_hseq>AAATTACTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGTATAT-AC-TTAGTTGTATATGCATTGATATTTT--TCATGATACTTTGGTGTGA-T-TTTTGTAAAACAAAATATAATAAAATAAAAAAATTGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATATTACT--TATTCACAAAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATG</Hsp_hseq>
+      <Hsp_midline>||||| ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||   || ||  || ||||||||| ||||  | |||   | |||||||||||||||||  ||| |||||||||| |||| |  |||||   ||    || |||||||||||||||  |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||  |  |||||||| ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>130.386</Hsp_bit-score>
+      <Hsp_score>70</Hsp_score>
+      <Hsp_evalue>8.0338e-33</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>91</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>97</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>89</Hsp_identity>
+      <Hsp_positive>89</Hsp_positive>
+      <Hsp_gaps>6</Hsp_gaps>
+      <Hsp_align-len>97</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAAATATAATGATGTATT-CTT-TAT-AAGGTAT-GGTTGTT-ATCGT-TGTT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAAATATAATGATGTATCACTTATATTAAGGTATTGGTTGTTTATTGTGTGTT</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  ||| ||| ||||||| ||||||| || || ||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>15</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|11</Hit_id>
+  <Hit_def>AB462274.1 Culicoides peregrinus genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Yng26</Hit_def>
+  <Hit_accession>11</Hit_accession>
+  <Hit_len>794</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>499.716</Hsp_bit-score>
+      <Hsp_score>270</Hsp_score>
+      <Hsp_evalue>5.31537e-144</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>560</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>596</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>498</Hsp_identity>
+      <Hsp_positive>498</Hsp_positive>
+      <Hsp_gaps>46</Hsp_gaps>
+      <Hsp_align-len>601</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATAT-TAAAAAAATATAATGATGT-AT-TC-TTTATAAG-G-TATGGTTGTTATCGTTGTT---ATTAC-AGTGGCTTCGGCAAGCTCGTTATAAAGATGTAGTTTATTAT-GTC-T-TAAGCGAGTGCTGTAATACAA--CA------AAACTAAATTTCTTGGGTAGCTTTA--TAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGAC---TT-CG-TGTCGCTAGTATGCATATTGCTTTACGCGATATGCATTGATATTTTTATCAAGATACTTTGGAGTGA-GT--ACTT-T--GTAC------GTA-AAATAAAATAAAAAAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCATGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTAT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATATAAAAAAATATAATGATGTTCTCTCATTAAAAAGTGTTATGG-TGTTATATATATTACAATAACTATTAAATT-AGTAAGCTTATTATAAAGATGTGGTTTATCATTATCTTATAAATAAGTATTGTAATATAAGGTATTGGTGGTGTTTAATTTCTTGGGTAGCTTTAATTTTAAGAGCTTTAAAGACTTTTTTGCCCAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGTATAT-ACTTAATTGTATATACATTGATATTATTTTCATGATACTTTGGTGTGAAATAAAGTTATAAGTACTATTTTGTACATATAAAA-AAAAAAAAGATCTAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCMTGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTT-TGATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTAT</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||||| |||||||||||||||||||  | || || | ||| | ||||| ||||||   | ||   || || | |   ||  | |||||  |||||||||||| |||||| ||  || | |||   |||  ||||||| ||   |          | |||||||||||||||||||  |  ||||||||||||||||| |||||||||||||||||||||||||| ||   || ||  || ||||||||| ||||  ||| |    |||| |||||||||| || ||| |||||||||| ||||  |  | || |  ||||      ||| | |||||| |||||||||||| |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  |||||||||||  ||||||||||||||||||||||||||||||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>16</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|16</Hit_id>
+  <Hit_def>AB462279.1 Culicoides oxystoma genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Naha16_1</Hit_def>
+  <Hit_accession>16</Hit_accession>
+  <Hit_len>796</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>494.176</Hsp_bit-score>
+      <Hsp_score>267</Hsp_score>
+      <Hsp_evalue>2.473e-142</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>557</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>572</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>492</Hsp_identity>
+      <Hsp_positive>492</Hsp_positive>
+      <Hsp_gaps>53</Hsp_gaps>
+      <Hsp_align-len>591</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATT-AAAAAA-ATATAATGATGTATTCTTTATAAGGTAT-G-GTTG-T--TATCGTTGT-TATTACAGTGGCTTCGGCAAGCTCGTTATAAAGATGTAGTTTATTATGTCTTAAGCGAGTGCTGTAATA-CA-A-CAAAACTAAAT-TTCTTGGGTAGCTTT-ATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGAC---TT-CG-TGTCGCTAGTATGCATAT--TGCTTTACGCG-A---TATGCATTGATATTTTTATCAAGATACTTTGGAGTGA-GTACTTTGTACGTAA-AA-TAA-AATAAAAAAA-AGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTG-T-AATATT-TCA-TGAT-ATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTA-ATTAAAAAAACATATAATGATGT-TTC---ATAAGGTATGGTGTTGTTAATATGGTAGTGTCGT-C-TTGTC-ACGAC-AGCTTGTTATAAAGATGTAGTTTATTATGTCTTAAACAAGT-C---AATATCATATTAACGCAAAATAATCTTAGGTAGCTTTTATGTAAGAGCTTTAAAGACTTTTTTGCCTAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGTATATAATACCTT--GCGTATTGTATGCATTG--A-TTTT-TCATGATATTAATGTGTGATGTTGTTTATGCAAAACAATTAATAATAAAAAAATTGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCTAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATACGATTAGATTTTGATTAATAATCTCAATGATAATTGACAAAATCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||| ||| |||||| |||||||||||| |||   ||||||||| | |||| |  ||| || || |  | |  || |  || | |||| |||||||||||||||||||||||||||||| | ||| |   |||| || |  ||  | ||||  |||| ||||||||| ||  ||||||||||||||||| |||||| ||||||||||||||||||| ||   || ||  || ||||||||| ||||  | | ||  ||| |   |||||||||  | |||| ||| |||| |   | |||| ||  ||| | |  || || ||| ||||||||||  |||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||||||||||||| | |||| | ||| |||| ||| ||| | ||||||||||||||||||||||||||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>17</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|4</Hit_id>
+  <Hit_def>AB462267.1 Culicoides aterinervis genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: AM05_5</Hit_def>
+  <Hit_accession>4</Hit_accession>
+  <Hit_len>891</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>492.329</Hsp_bit-score>
+      <Hsp_score>266</Hsp_score>
+      <Hsp_evalue>8.8945e-142</Hsp_evalue>
+      <Hsp_query-from>170</Hsp_query-from>
+      <Hsp_query-to>561</Hsp_query-to>
+      <Hsp_hit-from>277</Hsp_hit-from>
+      <Hsp_hit-to>680</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>366</Hsp_identity>
+      <Hsp_positive>366</Hsp_positive>
+      <Hsp_gaps>24</Hsp_gaps>
+      <Hsp_align-len>410</Hsp_align-len>
+      <Hsp_qseq>AAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGAC---TT-CG-TGTCGCTAGTATGCATATTGCTTTACGCG-ATATGCATTGATATTTTTATCAAGATACTTTGGAGTGAGTA-----C----TTTGTACGTAAAATAA-AAT--AAAAAAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCATGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATG</Hsp_qseq>
+      <Hsp_hseq>AAATTTCTTAGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCTAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGCATA-CAC-TTAGTTGTGTATGCATTGATATTTT--TCATGATACTTTGGAGTGAGTATAATACAAAAATTGTACAT-AAATAATAATAAAAAAAAAAGATGAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTATAATATTTT-TGATATTCATAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATG</Hsp_hseq>
+      <Hsp_midline>||||||||| ||||||||||||||||||||||||||||||||||||| ||||||||||||||||||| ||   || ||  || |||||||||||||   | |||   |  ||||||||||||||||  ||| ||||||||||||||||||     |     |||||| | |||||| |||  ||||||||||| ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||||||||  ||||||||| |  |||||||||||||||||||||||||||||||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>119.306</Hsp_bit-score>
+      <Hsp_score>64</Hsp_score>
+      <Hsp_evalue>1.73901e-29</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>161</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>160</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>136</Hsp_identity>
+      <Hsp_positive>136</Hsp_positive>
+      <Hsp_gaps>15</Hsp_gaps>
+      <Hsp_align-len>168</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAAATATAATGATGTATTCTTTATAAGGTA-TGGTTGTTATCGTTGTTATT--A-CAGTGGCTTCG---GCAAGCTCGTTATAAAGATGTAGTTTATTATGTCTTAAGCGAGTGCTGTAATACA</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATA--AAAATA-TATAATGATG--TTCATTCTAAGGTTGTGGATGT-AT-GTTGTTATTGTAACAGCTATTTAGTTAGC-AGCTTGCTATAAAGATGTAGTTTATTATGTCTTAAGTAAGTGTTATGATACA</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||||  |||| | ||||||||||  ||| || ||||||  ||| ||| || |||||||||  | |||    || |   || |||| | |||||||||||||||||||||||||||||  |||| | | |||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>18</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|2</Hit_id>
+  <Hit_def>AB462265.1 Culicoides arakawae genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Kag02</Hit_def>
+  <Hit_accession>2</Hit_accession>
+  <Hit_len>907</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>475.709</Hsp_bit-score>
+      <Hsp_score>257</Hsp_score>
+      <Hsp_evalue>8.95765e-137</Hsp_evalue>
+      <Hsp_query-from>170</Hsp_query-from>
+      <Hsp_query-to>560</Hsp_query-to>
+      <Hsp_hit-from>304</Hsp_hit-from>
+      <Hsp_hit-to>702</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>357</Hsp_identity>
+      <Hsp_positive>357</Hsp_positive>
+      <Hsp_gaps>16</Hsp_gaps>
+      <Hsp_align-len>403</Hsp_align-len>
+      <Hsp_qseq>AAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGAC---TT-CG-TGTCGCTAGTATGCATATTGCTTTACGCGATATGCATTGATATTTTTATCAAGATACTTTGGAGTGA-GTACT----TTGTAC-GTAAAATA-AAATAAAAAAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCATGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTAT</Hsp_qseq>
+      <Hsp_hseq>AAATTACTTAGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCTAAGGCCCTGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGTATAT-ACTTAATTGTATATGCATTGATATTTT--TCATGATACTTTGGTGTGATATAATAAAAATGTACAATTTTGTACTAATAAAAAAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATAA-ATAATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTAT</Hsp_hseq>
+      <Hsp_midline>||||| ||| ||||||||||||||||||||||||||||||||||||| ||||||| ||||||||||| ||   || ||  || ||||||||| ||||  ||| |    |||||||||||||||||  ||| |||||||||| ||||  || |     |||||  |    ||  |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||   || |||||||||  ||||||||||||||||||||||||||||||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>128.539</Hsp_bit-score>
+      <Hsp_score>69</Hsp_score>
+      <Hsp_evalue>2.88947e-32</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>82</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>81</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>78</Hsp_identity>
+      <Hsp_positive>78</Hsp_positive>
+      <Hsp_gaps>1</Hsp_gaps>
+      <Hsp_align-len>82</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAAATATAATGATGTATTCTTTATAAGGTATGGTTGTT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAAATATAATGATGT-TCATTCATAAGGTATGGTTGTT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| |  || ||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>19</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|6</Hit_id>
+  <Hit_def>AB462269.1 Culicoides cylindratus genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Kag08, long type</Hit_def>
+  <Hit_accession>6</Hit_accession>
+  <Hit_len>820</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>473.863</Hsp_bit-score>
+      <Hsp_score>256</Hsp_score>
+      <Hsp_evalue>3.22174e-136</Hsp_evalue>
+      <Hsp_query-from>170</Hsp_query-from>
+      <Hsp_query-to>561</Hsp_query-to>
+      <Hsp_hit-from>235</Hsp_hit-from>
+      <Hsp_hit-to>619</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>357</Hsp_identity>
+      <Hsp_positive>357</Hsp_positive>
+      <Hsp_gaps>25</Hsp_gaps>
+      <Hsp_align-len>401</Hsp_align-len>
+      <Hsp_qseq>AAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGACTTCGTGTCGCTAGTATGCATATTGCTTTACGCGATATGCATTGATATTTTTATCAAGATACTTTGGAGTGAGTA-----C----TTTGTACGTAAAATAAAATAAAAAAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCATGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATG</Hsp_qseq>
+      <Hsp_hseq>AAATTTCTTAGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCTAAGGCCCCGTAAAACTAGTAAC-CCAT-T-GCGAGGTGGC-TA--G---TATGC-ATATGCATTGATATTTT--TCATGATACTTTGGAGTGAGTATAATACAAAAATTGTACATAAAA-CAAAT--AAAAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTATAATATTTT-TGATATTCATAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATG</Hsp_hseq>
+      <Hsp_midline>||||||||| ||||||||||||||||||||||||||||||||||||| ||||||||||||||||||| ||  | | | || ||   || ||  |   || || |||||||||||||||||  ||| ||||||||||||||||||     |     |||||| |||||  ||||  ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||||||||  ||||||||| |  |||||||||||||||||||||||||||||||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>102.686</Hsp_bit-score>
+      <Hsp_score>55</Hsp_score>
+      <Hsp_evalue>1.75136e-24</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>59</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>58</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>58</Hsp_identity>
+      <Hsp_positive>58</Hsp_positive>
+      <Hsp_gaps>1</Hsp_gaps>
+      <Hsp_align-len>59</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAAATATAATGATGT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAA-TATAATGATGT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||||||||||| |||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>20</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|10</Hit_id>
+  <Hit_def>AB462273.1 Culicoides ohmorii genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Kag05</Hit_def>
+  <Hit_accession>10</Hit_accession>
+  <Hit_len>825</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>451.703</Hsp_bit-score>
+      <Hsp_score>244</Hsp_score>
+      <Hsp_evalue>1.50957e-129</Hsp_evalue>
+      <Hsp_query-from>169</Hsp_query-from>
+      <Hsp_query-to>561</Hsp_query-to>
+      <Hsp_hit-from>201</Hsp_hit-from>
+      <Hsp_hit-to>614</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>365</Hsp_identity>
+      <Hsp_positive>365</Hsp_positive>
+      <Hsp_gaps>29</Hsp_gaps>
+      <Hsp_align-len>418</Hsp_align-len>
+      <Hsp_qseq>TAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGAC---TT-CG-TGTCGCTAGTATGCATATTGCTTTACGCGATATGCATTGATATTTTTATCAAGATACTTT-G-GAGTG---A-GT---------A-CTTTGTACGTA-A-A-ATA-AAATAAAAAAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCATGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATG</Hsp_qseq>
+      <Hsp_hseq>TAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGTATAT-ACTTAATTGTATATGCATTGATATTTTT--CATGATACTTTGGTGTGTGATAATATAAAAAAAAAATCTTTATATTTATATAGAGAGAAAAAAAAAAAATAAGAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTT-TGATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATG</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||   || ||  || ||||||||| ||||  ||| |    ||||||||||||||||||  || |||||||| | | |||   |  |         | |||| ||  || | | | | ||| |||||||| |  ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  |||||||||||  |||||||||||||||||||||||||||||||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>87.9128</Hsp_bit-score>
+      <Hsp_score>47</Hsp_score>
+      <Hsp_evalue>4.904e-20</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>59</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>60</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>57</Hsp_identity>
+      <Hsp_positive>57</Hsp_positive>
+      <Hsp_gaps>3</Hsp_gaps>
+      <Hsp_align-len>61</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTA-A-AAAAATATAATGATGT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTAT-TAACATAAAAATATAATGATGT</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||| | | | ||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>21</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|14</Hit_id>
+  <Hit_def>AB462277.1 Culicoides charadraeus genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: KC05_14</Hit_def>
+  <Hit_accession>14</Hit_accession>
+  <Hit_len>913</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>422.156</Hsp_bit-score>
+      <Hsp_score>228</Hsp_score>
+      <Hsp_evalue>1.1836e-120</Hsp_evalue>
+      <Hsp_query-from>169</Hsp_query-from>
+      <Hsp_query-to>560</Hsp_query-to>
+      <Hsp_hit-from>295</Hsp_hit-from>
+      <Hsp_hit-to>664</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>349</Hsp_identity>
+      <Hsp_positive>349</Hsp_positive>
+      <Hsp_gaps>38</Hsp_gaps>
+      <Hsp_align-len>400</Hsp_align-len>
+      <Hsp_qseq>TAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGAC---TT-CG-TGTCGCTAGTATGCATATTGCTTTACGCGATATGCATTGATATTTTTATCAAGATACTTTGGAGTGAGTACTTTGTACGTAAAATAAAATAAAA-AAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAAT--ATTTCATGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTAT</Hsp_qseq>
+      <Hsp_hseq>TAAATTTCTTAGGTAGCTTTATCGAAGAGCTTTAAAGACTTGTTTGCCTAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGCAT------TT----G---TGCATTGATA-TTTT-TCATGATACTTTGG--T--GT-GTTTGT--GT--AATAAAAAAAAATAAAAAATC-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATTGATATT-TGTTAT--A-A-AGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTAT</Hsp_hseq>
+      <Hsp_midline>|||||||||| ||||||||||| ||||||||||||||||||||||||| ||||||||||||||||||| ||   || ||  || ||||||||||||      ||    |   |||||||||| |||| ||| ||||||||||  |  ||  |||||  ||  ||||||| |||| |||| ||| |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  || |  || |||  | | |||||||||||||||||||||||||||||||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>97.1461</Hsp_bit-score>
+      <Hsp_score>52</Hsp_score>
+      <Hsp_evalue>8.14828e-23</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>82</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>83</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>76</Hsp_identity>
+      <Hsp_positive>76</Hsp_positive>
+      <Hsp_gaps>7</Hsp_gaps>
+      <Hsp_align-len>86</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTA-TATTAAA-AAAA--TATAATGATGTATTCTTTATAAGGTATGGTTGTT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTAATATAAAACAAAAATTATAATGATGTATTCTC-ATT-GGT-TGGTTGTT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||| ||| ||| ||||  ||||||||||||||||  ||  ||| ||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>22</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|7</Hit_id>
+  <Hit_def>AB462270.1 Culicoides dubius genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Isg23</Hit_def>
+  <Hit_accession>7</Hit_accession>
+  <Hit_len>1096</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>388.917</Hsp_bit-score>
+      <Hsp_score>210</Hsp_score>
+      <Hsp_evalue>1.20047e-110</Hsp_evalue>
+      <Hsp_query-from>170</Hsp_query-from>
+      <Hsp_query-to>560</Hsp_query-to>
+      <Hsp_hit-from>395</Hsp_hit-from>
+      <Hsp_hit-to>831</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>369</Hsp_identity>
+      <Hsp_positive>369</Hsp_positive>
+      <Hsp_gaps>46</Hsp_gaps>
+      <Hsp_align-len>437</Hsp_align-len>
+      <Hsp_qseq>AAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGAC---T-TCGT--G---TCGCTAGTA-TGCATAT---T-GCT-TTA-C-G-CGATATGCATT-GATATT--T-T-TAT-CAAGAT-AC-T-T---TG-GAGT-G--AGTACTT-TGTA-C-GT-AA-AATAAAA-TAAAAAAAAGA-TCA---AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCA--TGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTAT</Hsp_qseq>
+      <Hsp_hseq>AAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTAACCCATATAATATGAGGTAGCTAGTAATGCATATAAATAGTTGTTAACTGTCTTTATGCATTTGATATACATATATATTCATGATTATATATGAGTGTGTGTTGTCATTAGTTATTTAACTGGCAACAACAAAAATAAAAAAAAAAATTAAATAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATCTTAGTTGTTATTCACAGAATCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTAT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||   | |  |  |   | ||||||| |||||||   | | | ||| | | |  |||||||| |||||   | | ||| || ||| |  | |   || | || |  | || || | || | |  || || |||| ||||||||| | | |   ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| | |  || |||||||||| |||||||||||||||||||||||||||||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>73.1396</Hsp_bit-score>
+      <Hsp_score>39</Hsp_score>
+      <Hsp_evalue>1.37318e-15</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>52</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>51</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>48</Hsp_identity>
+      <Hsp_positive>48</Hsp_positive>
+      <Hsp_gaps>1</Hsp_gaps>
+      <Hsp_align-len>52</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAAATATA</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATA-AAAATATATATA</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||||  ||| | |||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+</Iteration_hits>
+  <Iteration_stat>
+    <Statistics>
+      <Statistics_db-num>22</Statistics_db-num>
+      <Statistics_db-len>18669</Statistics_db-len>
+      <Statistics_hsp-len>16</Statistics_hsp-len>
+      <Statistics_eff-space>14287260</Statistics_eff-space>
+      <Statistics_kappa>0.46</Statistics_kappa>
+      <Statistics_lambda>1.28</Statistics_lambda>
+      <Statistics_entropy>0.85</Statistics_entropy>
+    </Statistics>
+  </Iteration_stat>
+</Iteration>
+<Iteration>
+  <Iteration_iter-num>2</Iteration_iter-num>
+  <Iteration_query-ID>Query_2</Iteration_query-ID>
+  <Iteration_query-def>AB462262.1 Culicoides jacobsoni genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Kag14_1</Iteration_query-def>
+  <Iteration_query-len>774</Iteration_query-len>
+<Iteration_hits>
+<Hit>
+  <Hit_num>1</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|0</Hit_id>
+  <Hit_def>AB462263.1 Culicoides maculatus genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Kag12_1</Hit_def>
+  <Hit_accession>0</Hit_accession>
+  <Hit_len>764</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>780.406</Hsp_bit-score>
+      <Hsp_score>422</Hsp_score>
+      <Hsp_evalue>0</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>774</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>764</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>683</Hsp_identity>
+      <Hsp_positive>683</Hsp_positive>
+      <Hsp_gaps>60</Hsp_gaps>
+      <Hsp_align-len>799</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATACTAAAAAAATATAATGATGTATTCTTATATAAGGTTGGAGTGTTTGGTGGGTTGTTATTGCAGCGGCTTTGCCTTAACCGGCTTAGCAGCTCGCTATAAAGATGTAGTTTATTATGTCTTAAGCGAGTGCTGTGATACAACAAAAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGC-CCCGTAAAACTAGTGGCTCTTTTGACATTAGTATGCA--TATACTTTTGTATATGCATTGATTTT-TATCAAGATACTTTGGAGTGAGTACGAATGTACATA-AAAATAAAAAAAGATCTAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTT-GATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTGTGCCATCTCCTAACGGTGATGTGTCTCAAGTGCATGATGTGATCATATGGATGTAACAGTTCATATATCATTAATAAAGAGATATGGTTGTTGACGTGC-ATGTTTG-A-------CCATTATTTTTATCTAATAAATAAATA-ATTTTGGTATAAAATCAAGCG-TGTA-CTGTTTGACACAAAA---AT-CT-TTA-A-CTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTA-ACT--AAACATTCAATGATGTATTCTT---TAAGG-T--A-TGGTT-GT-CGTTGTTATTGCAGCAGC-CT--C-T---C-GC-GGGCAGCTTGCTATAAAGATGTAGTTTATTATGTCTTAAGCAAGTGTTGTGGTTCAACAAAAAATTACTTGGGTAGCTTTATTTAAGAGCTTTAAAGACTTGTTTGCCCAAGGCTCCCGTAAAACTAGTG-ATCTTGTTTCATTAGTATGCAATTATATTTATATATTTGCATTGATTTTATATCAAGATACTTTGGTGTGAGTACGTATGTACATATAAAACAAAAAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTTCGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTATTGTCTGAAAAGATAAATGT---AAGTGCATGATGTGATCATATGGAT-TWACT-TTCATATATCATTAATGGAG-GATATGGTTATCG-C-TGCTATGTTTGCACACTTGGCCATTATTTTTATTTAGTTAA-AAATATATATTGGTATAAAATCAAGTGGTGTAGCTG---G-CGCTAAAGCGATTCTATTCTATCTATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||| |||  ||| ||  ||||||||||||||   ||||| |  | || || ||  |||||||||||||| ||  |  | |   | ||   |||||| |||||||||||||||||||||||||||||||| |||| |||| | |||||||||||| |||||||||||||||  |||||||||||||||||||||||||||||| |||||||||||||||  |||| |  ||||||||||||  |||| || | ||| |||||||||||| |||||||||||||||| ||||||||| ||||||||| |||| ||||||||||| ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||   | ||  ||  |  |  |||   ||||||||||||||||||||||||| | ||  ||||||||||||||||  || ||||||||| | | | ||| ||||||| |       ||||||||||||| || | || ||||| || |||||||||||||||| | |||| |||   | | | |||   || || ||  | ||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>2</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|1</Hit_id>
+  <Hit_def>AB462264.1 Culicoides wadai genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Isg18_1</Hit_def>
+  <Hit_accession>1</Hit_accession>
+  <Hit_len>834</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>667.761</Hsp_bit-score>
+      <Hsp_score>361</Hsp_score>
+      <Hsp_evalue>0</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>668</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>696</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>605</Hsp_identity>
+      <Hsp_positive>605</Hsp_positive>
+      <Hsp_gaps>60</Hsp_gaps>
+      <Hsp_align-len>712</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATACTAAAAAAATATAATGATGTATTCTTATATAAG-GT-TGGAGTGTTTGGTGGGTTGTTATTGCAGCGGCTTTGCCT--TAACCGGCTTAGCAGCTCGCTATAAAGATGTAGTTTATTATGTCTTAAGCGAGTGCTGTGATACAACAA---AAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCC--GTAAAACTAGTGGCTCTTT-TG--AC----AT---TAGT-ATGCAT-ATA-CT-TT------T--G---T-ATATGCATTGATTTTTATCAAGATACTTTGGAGTGAGTACGAAT-GTAC-AT--AA-AAATAAAAAAAGATCTAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTTGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTGTGCCATCTCCTAACGGTGATGTGTCTC--AAGTGCATGATGTGATCATATGGATGTAACAGTTCATATATCATTAATAAAG-AG-ATATGGTTGTTGACGTGCATGTT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTAATCT-AAAACATTCAATGATGTATTCT--CACAAGTGTATGG-TTGTTGTTTCCGTTGTTATTGTAGCAGCTCGTCGTAATTATCGTC-GGGCAGCTTGCTATAAAGATGTAGTTTATTATGTCTTAAGCGAGTGCTGCAATACAACAATACAAAATTTCTTAGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCTAAGGCCCCCAGTAAAACTAGT-GATCTTTGTGTCACTAGTATGCATATTAATGCATAACATCTCTTCGGAGGTGCGCTTTGATATGCATTGATTTATATCAAGATACTTTGGAGTGAGTAC-ATTCGTACAATAAAACAAACAAAAAAAGATC-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTTGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATG--A-CTCGTT----TGAAC-GTCTCATAAGTGCATGATGTGATCATATGGATTTCGCGATTCATATATCATTAATAAAGGAGAATATGGTTGTTAACGTGCGTGTT</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||  || |||| ||  |||||||||||||   | ||| || |||  ||||   |  |||||||||| ||| |||   | |  | | || |   |||||| ||||||||||||||||||||||||||||||||||||||||  |||||||||   |||||||||| ||||||||||||||||||||||||||||||||||||| ||||||||  ||||||||||| | ||||| ||  ||    ||   || | |||||| | | || ||      |  |   | |||||||||||||| ||||||||||||||||||||||||| | | |||| ||  || ||| ||||||||||| ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||  | ||| |     |||   |||||  ||||||||||||||||||||||||| |  |  |||||||||||||||||||| || ||||||||||| |||||| ||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>71.293</Hsp_bit-score>
+      <Hsp_score>38</Hsp_score>
+      <Hsp_evalue>4.79952e-15</Hsp_evalue>
+      <Hsp_query-from>667</Hsp_query-from>
+      <Hsp_query-to>716</Hsp_query-to>
+      <Hsp_hit-from>711</Hsp_hit-from>
+      <Hsp_hit-to>761</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>47</Hsp_identity>
+      <Hsp_positive>47</Hsp_positive>
+      <Hsp_gaps>1</Hsp_gaps>
+      <Hsp_align-len>51</Hsp_align-len>
+      <Hsp_qseq>TTTGACCATTATTTTTATCTAATAAATAAAT-AATTTTGGTATAAAATCAA</Hsp_qseq>
+      <Hsp_hseq>TTTGACCATTATTTTTATTTAATAAAATAATAAATTTTGGTATAAAATCAA</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||| |||||||  ||| |||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>3</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|21</Hit_id>
+  <Hit_def>AB462284.1 Culicoides paraflavescens genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: OKYN05_13</Hit_def>
+  <Hit_accession>21</Hit_accession>
+  <Hit_len>842</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>641.908</Hsp_bit-score>
+      <Hsp_score>347</Hsp_score>
+      <Hsp_evalue>0</Hsp_evalue>
+      <Hsp_query-from>183</Hsp_query-from>
+      <Hsp_query-to>774</Hsp_query-to>
+      <Hsp_hit-from>248</Hsp_hit-from>
+      <Hsp_hit-to>842</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>526</Hsp_identity>
+      <Hsp_positive>526</Hsp_positive>
+      <Hsp_gaps>29</Hsp_gaps>
+      <Hsp_align-len>608</Hsp_align-len>
+      <Hsp_qseq>AAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGGCTC-TTTTGACAT---TAGTATGCATATACTT--TTGTATATGCATTGATTTTTATCAAGATACTTTGGAGTGAGTAC-GAATGTACATA--A-AAATAAAAAAA-GATCTAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTT-GATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTGTGCCATCTCCTAACGGT-GATGTGTCTCAAGTGCATGATGTGATCATATGGATGTAACAGTTCATATATCATTAATAAAGAGATATGGTTGT-TGACGTGCATGTTTGACCATTATTTTTATCTAATAAATAAATAATTTTGGTATAAAATCAAGCGTGTACTGTTTGACAC-AAAAAT-CTTTAACTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>AAAATTTCTTGGGTAGCTTTATTGAAGAGCTTTAAAGACTTATTTGCCCAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGCATACCCTTTATTGGGTATGCATTGATATTTTTCATGATACTTTGGTGTGAGTACTTATTGTACATATGATAAATAAAAAAACGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTTTGATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGCG-TCTC-TAGCGATAGAAGCG-CTTAAGTGCATGATGTGATTATATA-A-GTAAAA-TT-ATATATCATTAATAAAGGAATAAAATGGTATGAA-T-CATATTTAACCATTATTTTTATTTAAAAAATAACAAATTTTGGTATAAAATAGATA-TGTA-TGATT-ACCTTAAAAATTCTTTAT-TATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||| |||||||||||||||||| ||||||||||||||||||||||||||  | | ||  ||  |   |||||||||||  |||  |||  ||||||||||| ||| ||| |||||||||| ||||||||  | ||||||||  | ||||||||||| |||| ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||||||||||  |||||||||||||||||||||||||||||||||||||||||||||||||||||| |||  |||| || || | || | | || |||||||||||||||| ||||  | |||| | || |||||||||||||||||  |||   | || |||  | ||| ||| |||||||||||||| ||| ||||||  ||||||||||||||||  |   |||| || || ||   |||||| |||||  |||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>98.9927</Hsp_bit-score>
+      <Hsp_score>53</Hsp_score>
+      <Hsp_evalue>2.20163e-23</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>162</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>143</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>130</Hsp_identity>
+      <Hsp_positive>130</Hsp_positive>
+      <Hsp_gaps>21</Hsp_gaps>
+      <Hsp_align-len>163</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATACTAAAAAAATATAATGATGTATTCTTATATAAGGT-TGGAGTGTTTGGTGGGTTGTTATTGCAGCGGCTTTGCCTTAACCGGCTTAGCAGCTCGCTATAAAGATGTAGTTTATTATGTCTTAAG</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAACA-TATAATGATGT-TTCTT-TA-A-GGTATGG--TGTTTGATAT-TTGTTGAT--AGCTA-TTTGA-TTA---G-C--A--AGCTTACTATAAAGATGTAGTTTATTATGTCTTAAG</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||| ||||| | ||||||||||| ||||| || | ||| |||  |||||| |   |||||  |  |||   ||||  |||   | |  |  ||||  ||||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>4</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|12</Hit_id>
+  <Hit_def>AB462275.1 Culicoides punctatus genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Kag13_1</Hit_def>
+  <Hit_accession>12</Hit_accession>
+  <Hit_len>787</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>638.214</Hsp_bit-score>
+      <Hsp_score>345</Hsp_score>
+      <Hsp_evalue>0</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>774</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>787</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>668</Hsp_identity>
+      <Hsp_positive>668</Hsp_positive>
+      <Hsp_gaps>65</Hsp_gaps>
+      <Hsp_align-len>813</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATACTAAAAAAATATAATGATGTATTCTTATATAAGGTTGGAGTGTTTGGTGGGTTGTTATTGCAGCGGCTTTGCCTTAACCGGCTTAGCAGCTCGCTATAAAGATGTAGTTTATTATGTCTTAAGCGAGTGCTGTG-A-TACAAC-AAAAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGGCTC-TTTTGACAT---TAGTATGCATATACTT--TTGTATATGCATTGATTTTTATC-AAGATAC-TT--TG-GAG--TGA--GT-ACG-AA-TGTACAT--A-AAAATAAAAAAAGATCTAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTT-GATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTGTGCCATCTCCTAACGGTGATGTGTCTCAAGTGCATGATGTGATCATATGGATG-TAACAGTTCATATATCATTAATAAAGAGATATGGTTG----TTGACGT---GC-ATGTTTGACCATTATTTTTATCTAATAAATAAATAATTTTGGTATAAAATCAAGCGT-GTACT-GTTTG--ACACAAAA-ATCTTTAACTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATTAT-AAAACATATAATGATGT-TCATTCTAT-AGG-T--A-TGGTTGTTGTGTTGTCATTGTAAGAG---T-CATTTA---G-TTGGCAGCTCTCTATAAAGACATAGTTTATTATGTTTTAAGGGAGTACCTTGCAGTGCGACAAAAAAATTACTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGCATATACTTAATTGTATATGCATTGATTTATTTCAAAGATACATTGGAGAGAGTATAATTGTAATGAAATTGTACATAAACAAAACAAAAAAAG-TAAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTTCGATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTCTT-TC--A-C--TGAAA-GCAT-AAGTGCATGATGTGATTATATAGGTGATATCAACTTATATATCATTAATAAAGTGTGGTGGTAACAAATATACTTTAAGCTATGTTTGACCATTATTTTTATCTAAAAAATAATAAATTTTGGTATAAAATCAAATGTAGTGTTTGTTTGTTACTCATAACATCCATT--TATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||  | |||| |||||||||||| |  || ||| ||| |  | || ||| || ||||| |||| |   |   | | || |   | || ||||||| |||||||||  ||||||||||||| ||||| |||| |  || | | | || |||||||| |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  | | ||  ||  |   ||||||||||||||||  |||||||||||||||||| | || ||||||| ||   | |||  | |  || | | || |||||||  | |||| |||||||| |  ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||||||||||  |||||||||||||||||||||||||||||||||||||||||||||||||||||| || | | ||  | |  |||   |  | |||||||||||||||| |||| | || || ||  | ||||||||||||||||| |   ||||      |  || |   || ||||||||||||||||||||||||| ||||||  |||||||||||||||||||  || ||  | |||||  || || || |||  |   |||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>5</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|18</Hit_id>
+  <Hit_def>AB462281.1 Culicoides verbosus genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: OKYN05_18</Hit_def>
+  <Hit_accession>18</Hit_accession>
+  <Hit_len>805</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>564.348</Hsp_bit-score>
+      <Hsp_score>305</Hsp_score>
+      <Hsp_evalue>1.80599e-163</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>713</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>732</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>619</Hsp_identity>
+      <Hsp_positive>619</Hsp_positive>
+      <Hsp_gaps>71</Hsp_gaps>
+      <Hsp_align-len>758</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATACTAAAAAAATATAATGATGTATTCTT-ATATAAGGTTGGAGTGTTTGGTGGGTTGTTATTGCAGCGGCTTTGCCTTAACCGGCTTAGC-AGCTCGCTATAAAGATGTAGTTTATTATGTCTTAAGCGAGTGCTGTGATACAACAA------------AAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGGCTC-TTTTGACAT---TAGTATGCATATACTT--TTGTATATGCATTGATTTTTATCAAGATACTTTGGAGTG--AG--T---A--CGAA--TGTAC-ATAA-AAATA-AAAAAAGATCTAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTT-TGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTGTGCCATCTCCTAACGGTGATGTGTCTCAAGTGCATGATGTGATCATATG-GATGTAACAGTTCATATATCATTAATAAAGA-G-A--TATGGT--TGTTGACGTGCATGTTTGACCATTATTTTTATCTAATA-AA-TAA-ATAATTTTGGTATAAAAT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAAATATAATGATGT-TCATTCATAAAAGG-T--A-T-AACGGT-TGTTG-TCTTTCAATGGCT----ATT---C-ACTTAGCAAGCTTGCTATAAAAATGTAGTTTATTATGTTTTAAGCAAGTGTTGTTAGACAA-AAGGTTGGTTGTTCAAAATTACTTAGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCTAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGTATATACTTAATTGTATATGCATTGATATTTTTCATGATACTTTGGAGTGTGAGTATAAAATTAAAATTTGTACAAAAACAAAAACAAAAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATAAACTAATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTC-T-T--TAAAATTGA-GA-TAT-AAGTGCATGATGTGATCATATAAGCT-TAATTGCCTATATATCATTAATAAAGGTGGAGGTATGGTGCTATTGT-GTACATATTTAACCATCATTTTTATTTAATATAAATAATATAATTTTGGTATAAAAT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||| ||||||||||||||||||| |  || ||| |||| |  | |    |||  |||| | || ||  ||||     ||   |  |||||| |||| |||||||| |||||||||||||||| |||||| |||| ||| | |||| ||            |||||| ||| ||||||||||||||||||||||||||||||||||||| |||||||||||||||||||  | | ||  ||  |   ||||||| ||||||||  |||||||||||||||| ||| ||| ||||||||||||||  ||  |   |    ||  ||||| | || ||| | |||||||||| |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||    | |||||||||  |||||||||||||||||||||||||||||||||||||||||||||||||||||| || | | |  |||   ||| |  | | |||||||||||||||||||||  | | |||  |   |||||||||||||||||  | |  ||||||  | |||  || ||| ||| ||||| |||||||| ||||| || ||| ||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>6</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|5</Hit_id>
+  <Hit_def>AB462268.1 Culicoides cylindratus genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Kag08, short type</Hit_def>
+  <Hit_accession>5</Hit_accession>
+  <Hit_len>748</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>562.502</Hsp_bit-score>
+      <Hsp_score>304</Hsp_score>
+      <Hsp_evalue>6.4955e-163</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>563</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>544</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>491</Hsp_identity>
+      <Hsp_positive>491</Hsp_positive>
+      <Hsp_gaps>45</Hsp_gaps>
+      <Hsp_align-len>576</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATACTAAAAAAATATAATGATGTATTCTTATATAAGGTTGGAGTGTTTGGTGGGTTGTTATTGCAGCGGCTTTGCCTTAACCGGCTTAGCAGCTCGCTATAAAGATGTAGTTTATTATGTCTTAAGCGAGTGCTGTGATACAACAAAAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGGCTCTTTTGACATTAGTATGCATATACTTTTGTATATGCATTGATTTTTATCAAGATACTTTGGAGTGAGTA-----C--GAA-TGTACAT---A-AAAA-TAAAAAAAGATCTAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTTGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTAT----AAAATATATAATGATGT--TC--ATTCAA---T-AAG-G-TTGGT-GGTTG-TATTGTAACAGCTAT---TT-A----CTTAGCAGCTTGCTATAAAGATGTRGTTTATYATGTCTTAAGYAAGTGTTGYGATACARCAAAAAATTTCTTAGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCTAAGGCCCCGTAAAACTAGTAAC-CCATTG-C-GAGGT-GGC---TA-GTATGCATATGCATTGATATTTTTCATGATACTTTGGAGTGAGTATAATACAAAAATTGTACATAAAACAAAAYAAAAAAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTATAATATTTTTGATATTCATAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATAYATTAAACTATCTT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||    |||| ||||||||||||  ||  ||  ||   |  || | ||||| ||||| ||||| | | ||| |   || |    |||||||||| ||||||||||||| |||||| ||||||||||  |||| || |||||| ||||||||||||| ||||||||||||||||||||||||||||||||||||| |||||||||||||||||||  | |  ||| |    ||  ||   ||  | || |||||||||||| ||| ||| ||||||||||||||||||     |   || |||||||   | ||||  ||||||||||| |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| |||||||||||||||||| |  |||||||||||||||||||||||||||||||||||||||| |||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>7</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|19</Hit_id>
+  <Hit_def>AB462282.1 Culicoides humeralis genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Kag15_1</Hit_def>
+  <Hit_accession>19</Hit_accession>
+  <Hit_len>912</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>540.342</Hsp_bit-score>
+      <Hsp_score>292</Hsp_score>
+      <Hsp_evalue>3.04352e-156</Hsp_evalue>
+      <Hsp_query-from>183</Hsp_query-from>
+      <Hsp_query-to>774</Hsp_query-to>
+      <Hsp_hit-from>296</Hsp_hit-from>
+      <Hsp_hit-to>912</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>522</Hsp_identity>
+      <Hsp_positive>522</Hsp_positive>
+      <Hsp_gaps>43</Hsp_gaps>
+      <Hsp_align-len>626</Hsp_align-len>
+      <Hsp_qseq>AAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGGCTC-TTTTGACAT---TAGTATGCATATACTT--TTGTATATGCATTGATTTTTATCAAGATACTTTGGAGTGAGTA-----CG-AATGTACAT-AA-AA-ATAAAAAAA-GATCTAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTT-GATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTGTGCCATCTCCTAACGGTGATGTGTCTCAAGTGCATGATGTGATCATATGGATGTAACAGTTCATATATCATTAATAAAG-AGA-TATGGTTGT-T-G--A-CGTGCATGTTTGACCATTATTTTTATCTAATAAATAAATAATTTTGGTATAAAATCAAGCGTGT--A--CT----G-TTT-GACACAAAAATCTTTAACTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>AAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGCATACACTTAATTGAGTATGCATTGATATTTTTCATGATACTTTGGTGTGAGTATAATTTGTATTGTACATAAACAAGAAAAAAAAACGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTATCGATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTG-TGTCTTGAAAAAGACATCA-T-AAGTGCATGATGTGATTATATAAGCGCAAGC-TT-ATATATCATTAATAAAGGATAATATGGACGTATCGCTATCTTGCATACTTAACCATAATTTTTATTTGATT-ATAAATAATTTTGGTATAAAATGA-GTATGTCTAAGCTCTTAGCTTTCGCCTCTAAAA-CTTTAT-TATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  | | ||  ||  |   ||||||||||| ||||  |||  ||||||||||| ||| ||| |||||||||| |||||||      | | ||||||| || || | ||||||| |||| ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| | ||||||||||  |||||||||||||||||||||||||||||||||||||||||||||||||||||| ||   | || | |    ||  |   | |||||||||||||||| ||||    | ||   || ||||||||||||||||| | | |||||  || | |  | | |||||  || ||||| |||||||| | ||  |||||||||||||||||||||| | |  |||  |  ||    | ||| | | | |||| |||||  |||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>113.766</Hsp_bit-score>
+      <Hsp_score>61</Hsp_score>
+      <Hsp_evalue>7.86264e-28</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>70</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>70</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>68</Hsp_identity>
+      <Hsp_positive>68</Hsp_positive>
+      <Hsp_gaps>2</Hsp_gaps>
+      <Hsp_align-len>71</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATACTAAAAAAATATAATGATGTATTCTT-ATATA</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAAATATAATGATGT-TTCTTTATATA</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||| ||||||||||||||||||| ||||| |||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>3</Hsp_num>
+      <Hsp_bit-score>65.753</Hsp_bit-score>
+      <Hsp_score>35</Hsp_score>
+      <Hsp_evalue>2.233e-13</Hsp_evalue>
+      <Hsp_query-from>122</Hsp_query-from>
+      <Hsp_query-to>162</Hsp_query-to>
+      <Hsp_hit-from>111</Hsp_hit-from>
+      <Hsp_hit-to>152</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>40</Hsp_identity>
+      <Hsp_positive>40</Hsp_positive>
+      <Hsp_gaps>1</Hsp_gaps>
+      <Hsp_align-len>42</Hsp_align-len>
+      <Hsp_qseq>TTAGC-AGCTCGCTATAAAGATGTAGTTTATTATGTCTTAAG</Hsp_qseq>
+      <Hsp_hseq>TTAGCAAGCTTGCTATAAAGATGTAGTTTATTATGTCTTAAG</Hsp_hseq>
+      <Hsp_midline>||||| |||| |||||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>8</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|13</Hit_id>
+  <Hit_def>AB462276.1 Culicoides sumatrae genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: ONYK05_17</Hit_def>
+  <Hit_accession>13</Hit_accession>
+  <Hit_len>784</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>531.109</Hsp_bit-score>
+      <Hsp_score>287</Hsp_score>
+      <Hsp_evalue>1.83173e-153</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>774</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>784</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>653</Hsp_identity>
+      <Hsp_positive>653</Hsp_positive>
+      <Hsp_gaps>76</Hsp_gaps>
+      <Hsp_align-len>817</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTAT-ACT-AAAAAAATATAATGATGTATTCTTATATAAGGTTGGAGTGTTTGGTGGGTTGT-TATTGCAGCGGCTTTGCCTTAACCGGCTTAGCAGCTCGCTATAAAGATGTAGTTTATTATGTCTTAAGCGAGTGCT--GTGATACAACAAAAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGGCTC-TTTTGACAT---TAGTATGCATATACTT--TTGTATATGCATTGATTTTTATCAAGATACTTTGGAGTGA---------GT--A-C--GA-ATGTACATA-A-A-A--ATAAAAAAAG-ATCTAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTTGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTGTGCCATCTCCTAACGGTGATGTGTCTCAAGTGCATGATGTGATCATATGGATGTAACAGTTCATATATCATTAATAAAGAGATATG-GTTGTTGA-CG--TGC-A-TG--TTTGACCATTATTTTTATCTAATAAATAAAT-AATTTTGGTATAAAATCAAG--CGTGTACTGTTTGACACAAAAATCTTTAACTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATTATTAAAAAAAATATAATGATGT-TTC--ATTCAAGG-T--A-TGGTT-GT---TAATCTATTGCAATGGCTATTAATTTAGCAGCTTA-CA-C-CGCTATAAAGATGTGGTTTATCATATCTTAAGC-ATTCGTAGGTGTTGTGATAGAAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGTATATACTTAATTGTATATGCATTGATATTTTTCATGATACTTTGGTGTGATAATAAAAAGTAAATCTTTATATTTATATAGAGATAGGAAAAAAAAAGTAAAGAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTATCGATATTCACGAAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTTAT-T--TAATGGTAACGT-----AAGGGCATGTTGTGATTATATA-A-GTAAAA-TT-ATATATCACTAATAAAGT-ATATGAGATATGGAACAAATTTTAATGTATTTGACCATTATTTTTATTTAA-AATGATATGAATATTGGTTTAAA-TCAAATACAACTTTTGTTT-ATATATTATTATT-AT-TATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||| | | |||||||||||||||||| |||  ||  |||| |  | || || ||   |  | |||||||  |||| |   || | | ||||| || | |||||||||||||| |||||| || |||||||| | |  |  ||| |   | | ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  | | ||  ||  |   ||||||| ||||||||  |||||||||||||||| ||| ||| |||||||||| ||||         ||  | |   | || || ||| | | |  | |||||||| |   |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| | |||||||||  ||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||  || |  ||| ||| | ||     ||| ||||| |||||| ||||  | |||| | || |||||||| ||||||||  ||||| | | | || |   |   | ||  |||||||||||||||||| ||| ||  | || ||| ||||| |||| ||||   |   |  ||||| | | |  | | || |  |||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>9</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|20</Hit_id>
+  <Hit_def>AB462283.1 Culicoides matsuzawai genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: IS05_6</Hit_def>
+  <Hit_accession>20</Hit_accession>
+  <Hit_len>908</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>529.262</Hsp_bit-score>
+      <Hsp_score>286</Hsp_score>
+      <Hsp_evalue>6.58806e-153</Hsp_evalue>
+      <Hsp_query-from>183</Hsp_query-from>
+      <Hsp_query-to>774</Hsp_query-to>
+      <Hsp_hit-from>299</Hsp_hit-from>
+      <Hsp_hit-to>908</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>516</Hsp_identity>
+      <Hsp_positive>516</Hsp_positive>
+      <Hsp_gaps>40</Hsp_gaps>
+      <Hsp_align-len>621</Hsp_align-len>
+      <Hsp_qseq>AAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGGCTC-TTTTGACAT---TAGTATGCATATACTT--TTGTATATGCATTGATTTTTATCAAGATACTTTGGAGTGA-GTACGAA-TGTA-C-ATA-AAAATAAAAAAAGATCTAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTT-GATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTGTGCCATCTCCTAACGGTGATGTGTCTCAAGTGCATGATGTGATCATATGGATGTAACAGTTCATATATCATTAATAAAGAGATA---TGGT-TGTTGAC--G-T---GCATGTTTGACCATTATTTTTATCTAATA-AATAAATAATTTTGGTATAAAATCAAGC-GTGTA-CT-GT--TT-GACACAAAAATCTTTAACTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>AAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGCATACACTTARTTGAGTATGCATTGATATTTTTCATGATACTTTGGTGTGAAGTACATATTGTACCGATATAAACAAAAAAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTATCGATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTG-TCTTGAAAAAGA-ACAT-----AAGCGCATGATGTGATTATAAAAGTGTAAAAGCTTTTATATCACTAATAAAGGAATAAWATGGTGTTTTGCTTTGCTAAGGCATATTTAACCATAATTTTTATTTAATATAATATG-AATTTTGGTATAAAATGAATATGTCTAGCTTGGAATTCGCCTAAAAAACCATT---TATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  | | ||  ||  |   ||||||||||| ||||  |||  ||||||||||| ||| ||| |||||||||| |||| ||||  | |||| | ||| |||  ||||||||||| ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| | ||||||||||  |||||||||||||||||||||||||||||||||||||||||||||||||||||| ||   |||   ||  |  |  |     ||| |||||||||||| |||    ||||| || |  ||||||| ||||||||  |||   |||| | |||    | |   |||| ||| ||||| |||||||| ||||| ||||   |||||||||||||||| ||   || || || |   || | |  ||||| | ||   |||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>126.692</Hsp_bit-score>
+      <Hsp_score>68</Hsp_score>
+      <Hsp_evalue>1.00993e-31</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>181</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>172</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>150</Hsp_identity>
+      <Hsp_positive>150</Hsp_positive>
+      <Hsp_gaps>19</Hsp_gaps>
+      <Hsp_align-len>186</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATACTAAAAAAATATAATGATGTATTCTT-ATATAAGGTTGGAGTGTTTGGTGGGTTGTTATTG-CAGCGGCTTTGCCTTAACCGGCTTAGC-AGCTCGCTATAAAGATGTAGTTTATTAT-GTCTTAAGCGAGTGCTGTGATA-CAACA</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAAATATAATGATGT-TTCTTTATATAAGGTAT-A-TGGTTGTTATGTTGTC-TTGTCAACAGCTAT---TTGA-----TTAGCAAGCTTGCTATAAAGATGTAGTTTATTACGGTCTTAAGTAAGTG-T-TGACAGCAACA</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||| ||||||||||||||||||| ||||| |||||||||   | || ||| |  |||||  ||| || | ||| |   || |     ||||| |||| ||||||||||||||||||||||  ||||||||  |||| | ||| | |||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>10</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|15</Hit_id>
+  <Hit_def>AB462278.1 Culicoides erairai genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: IS05_2</Hit_def>
+  <Hit_accession>15</Hit_accession>
+  <Hit_len>931</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>518.182</Hsp_bit-score>
+      <Hsp_score>280</Hsp_score>
+      <Hsp_evalue>1.42606e-149</Hsp_evalue>
+      <Hsp_query-from>183</Hsp_query-from>
+      <Hsp_query-to>774</Hsp_query-to>
+      <Hsp_hit-from>309</Hsp_hit-from>
+      <Hsp_hit-to>931</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>524</Hsp_identity>
+      <Hsp_positive>524</Hsp_positive>
+      <Hsp_gaps>51</Hsp_gaps>
+      <Hsp_align-len>633</Hsp_align-len>
+      <Hsp_qseq>AAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGGCTC-TTTTGACAT---TAGTATGCATATACTTT--T--GTATATGCATTGATTTTTATCAAGATACTTTGGAGTGA--GTACG-A-ATGTAC--A--TAAAAA--T-AAAAAA-AGATCTAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTTGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTGTGCCATCTCC--T-AA-CGGTGATGTGTCTCAAGTGCATGATGTGATCATATGGATG-TAACAGTTCATATATCATTAATAAAG----A-GATATG-GT--T---GTTGACGTGCATGTTTGACCATTATTTTTATCTAATAAATAAATAATTTTGGTATAAAATCAA---GCGTGTACT--GTTTGACACAAAAATCTTTAACTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>AAAATTTCTTAGGTAGCTTTATTGAAGAGCTTTAAAGACTTGTATGCCTAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGCATATATTTTAATCGGTGTATGCATTGATATTTTTCATGATACTTTGGTGTGATATTTTGTATATTTACAAATGTAAAAATGTAAAAAAAGAGATC-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTACT-TATTCACAAAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTGTGATTTTTCTGGTGAAACAGA-AGCT-TA-CAAGTGCATGATGTGATCATATAGATGATTTCTGTCTATATATCATTAATAAAGTGGTATGATATGTGTACTAAAGTTGTGTTGCATATTTAACCATAATTTTTATTTAATAA-TAT-TAATTTTGGTATAAAATAAATAAGCACACACTTAGTTGTAT-CAAAAA-CTTTAAAT-TGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>|||||||||| ||||||||||| |||||||||||||||||||| |||| |||||||||||||||||||  | | ||  ||  |   ||||||||||||| |||  |  || ||||||||||| ||| ||| |||||||||| ||||   |  | | || |||  |  ||||||  | |||||| ||||| |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||    |||||||| ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||   | ||   | || | |  |  | |  |||||||||||||||||||||| |||| |  | ||  |||||||||||||||||    | |||||| ||  |   ||||   ||||| ||| ||||| |||||||| |||||| ||  ||||||||||||||||| ||   ||    |||  |||  |  |||||| |||||| | |||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>130.386</Hsp_bit-score>
+      <Hsp_score>70</Hsp_score>
+      <Hsp_evalue>7.80721e-33</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>187</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>175</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>152</Hsp_identity>
+      <Hsp_positive>152</Hsp_positive>
+      <Hsp_gaps>16</Hsp_gaps>
+      <Hsp_align-len>189</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATACTA-AAAAAATATAATGATGTATTCTTATATAAGGTTGGAGTGTTTGGTGGGTTGTTATTGCAGCGGCTTTGCCTTAACCGGCTTAGCAGCTCGCTATAAAGATGTAGTTTATTATGTCTTAAGCGAGTGCTG-TGATACAACAAAAAAT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTATAAAAAATATAATGATGTATCATTCTATAAG-T-GTA-TGGT-GGTTG-TTGTT-TCG-A-CAGCTAAAGTTTA-CT---TTAGCAGCCTACTATAAAGATGTAGTTTATTATGTCTTAAGT-A-TGGTGTTGATTCAACAAAAAAT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||| || |||||||||||||||||||  || |||||| | | | || | ||| | ||||| | | | | |||     ||| |    ||||||||   ||||||||||||||||||||||||||||||  | || || |||| |||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>11</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|2</Hit_id>
+  <Hit_def>AB462265.1 Culicoides arakawae genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Kag02</Hit_def>
+  <Hit_accession>2</Hit_accession>
+  <Hit_len>907</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>512.642</Hsp_bit-score>
+      <Hsp_score>277</Hsp_score>
+      <Hsp_evalue>6.63483e-148</Hsp_evalue>
+      <Hsp_query-from>183</Hsp_query-from>
+      <Hsp_query-to>774</Hsp_query-to>
+      <Hsp_hit-from>303</Hsp_hit-from>
+      <Hsp_hit-to>907</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>513</Hsp_identity>
+      <Hsp_positive>513</Hsp_positive>
+      <Hsp_gaps>43</Hsp_gaps>
+      <Hsp_align-len>620</Hsp_align-len>
+      <Hsp_qseq>AAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGGCTC-TTTTGACAT---TAGTATGCATATACTT--TTGTATATGCATTGATTTTTATCAAGATACTTTGGAGTG----AGTACGAATGTACA------TAAAAAT-AAAAAAAGATCTAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTTGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTGTGCCATCTCCTAACGGTGATGTGTCTCAAGTGCATGATGTGATCATAT--GGATGTAACAGTTCA--TATATCATTAATAAAG---AGATATGGTTGTTGACGTGCATGTTTGACCATTATTTTTATCTAATA-AATAAATAATTTTGGTATAAAATCAAGC-GTGTACT-GTTTGAC-ACAAAAATCTTTAACTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>AAAATTACTTAGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCTAAGGCCCTGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGTATATACTTAATTGTATATGCATTGATATTTTTCATGATACTTTGGTGTGATATAATAAAAATGTACAATTTTGTACTAATAAAAAAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATAAATAATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATATTATTTGAAAAAG-TAATAT-----AAGTGCATGATGTGATTATACAAGGCTTTAACAGG-CATGTATATCATTAATAAAGGATAGATATGGTAAATGA---GCATATTTAACCATTATTTTTATTTAAAATAATAAAGTATATTGGTATAAAATAAATATGTG-ACTTGCCTTATTACTTA---CTTTAATT-TGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>|||||| ||| ||||||||||||||||||||||||||||||||||||| ||||||| |||||||||||  | | ||  ||  |   ||||||| ||||||||  |||||||||||||||| ||| ||| |||||||||| |||    | ||  ||||||||      ||  ||| ||||||||||| |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||   | |||||||||  |||||||||||||||||||||||||||||||||||||||||||||||||||||| |   || |   || | | || |     |||||||||||||||| |||   || | ||||||  ||  ||||||||||||||||   |||||||||   |||   |||| ||| |||||||||||||| ||| | ||||||  || |||||||||||| ||   ||| ||| |  | |  ||  |   |||||| | |||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>104.533</Hsp_bit-score>
+      <Hsp_score>56</Hsp_score>
+      <Hsp_evalue>4.73209e-25</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>59</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>59</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>58</Hsp_identity>
+      <Hsp_positive>58</Hsp_positive>
+      <Hsp_gaps>0</Hsp_gaps>
+      <Hsp_align-len>59</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATACTAAAAAAATATAATGATGT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAAATATAATGATGT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||| |||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>12</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|11</Hit_id>
+  <Hit_def>AB462274.1 Culicoides peregrinus genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Yng26</Hit_def>
+  <Hit_accession>11</Hit_accession>
+  <Hit_len>794</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>507.102</Hsp_bit-score>
+      <Hsp_score>274</Hsp_score>
+      <Hsp_evalue>3.08689e-146</Hsp_evalue>
+      <Hsp_query-from>185</Hsp_query-from>
+      <Hsp_query-to>774</Hsp_query-to>
+      <Hsp_hit-from>190</Hsp_hit-from>
+      <Hsp_hit-to>794</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>516</Hsp_identity>
+      <Hsp_positive>516</Hsp_positive>
+      <Hsp_gaps>53</Hsp_gaps>
+      <Hsp_align-len>624</Hsp_align-len>
+      <Hsp_qseq>AATTTCTTGGGTAGCTTTA--TAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGGCTC-TTTTGACAT---TAGTATGCATATACTT--TTGTATATGCATTGAT-TT-TTATCAAGATACTTTGGAGTGA------G---TACG-A--A---TGTACATA-AAAATAAAAAAAGATCTAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTTGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTGTGCCATCTCCTAACGGTGATGTGTCTCAAGTGCATGATGTGATCATATGGA--TGTAACAG---TTCATATATCATTAATAAAGAGATATGGTTGTTGACGTGCATGTTTGACCATTATTTTT-ATCTAAT-AAATAAATAATTTTGGTATAAAATCAAGCGTGTACTGTTTGACACAAAAATCTTTAAC-TATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>AATTTCTTGGGTAGCTTTAATTTTAAGAGCTTTAAAGACTTTTTTGCCCAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGTATATACTTAATTGTATATACATTGATATTATTTTCATGATACTTTGGTGTGAAATAAAGTTATAAGTACTATTTTGTACATATAAAAAAAAAAAAGATCTAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCMTGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTTGATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTAT--ATTTTTTTAA---TAAAATAT---AAGTGCATGATGTGATTATATGAAAATGTAATATTTTTTCATATATCATTAATAAATATATAAAATTGGTG---T--ATATTTGACCATTATTTTTTATTTAATTAAAATAATAATATTGGTTTAAA-TCAAA--TATA-TATT-GAGA-AATATTGTTTTATTTATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||  |  ||||||||||||||||| ||||||||||||||||||||||||||  | | ||  ||  |   ||||||| ||||||||  |||||||| ||||||| || || ||| |||||||||| ||||      |   || | |  |   |||||||| |||| |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  |||||||||||||||||||||||||||||||||||||||||||||||||||||| |    | |  |||   | |  | |   |||||||||||||||| ||||| |  ||||| |    ||||||||||||||||||| | |||   ||| ||   |  || |||||||||||||||| || |||| |||  |||||| ||||| |||| ||||   | || | || || | || | | ||| |  |||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>98.9927</Hsp_bit-score>
+      <Hsp_score>53</Hsp_score>
+      <Hsp_evalue>2.20163e-23</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>59</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>60</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>58</Hsp_identity>
+      <Hsp_positive>58</Hsp_positive>
+      <Hsp_gaps>1</Hsp_gaps>
+      <Hsp_align-len>60</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATAC-TAAAAAAATATAATGATGT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATATAAAAAAATATAATGATGT</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||||  |||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>13</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|17</Hit_id>
+  <Hit_def>AB462280.1 Culicoides kibunensis genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: AM05_6</Hit_def>
+  <Hit_accession>17</Hit_accession>
+  <Hit_len>817</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>503.409</Hsp_bit-score>
+      <Hsp_score>272</Hsp_score>
+      <Hsp_evalue>3.99314e-145</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>774</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>817</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>662</Hsp_identity>
+      <Hsp_positive>662</Hsp_positive>
+      <Hsp_gaps>83</Hsp_gaps>
+      <Hsp_align-len>837</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATACTAAAAAAATATAATGATGTATTCTTATATAAGGTTGGAGTGTTTGGTGGGTTGTTATTGCAGCGGCTTTGCCTTAACCGGCTTAGCAGCTCGCTATAAAGATGTAGTTTATTATGTCTTAAGCGAGTGCTGTGATACAA-CA---A----AAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGGCTC-TTTTGACAT---TAGTATGCATATAC---T---TTTGTATATGCATTGATTTTTATCAAGATACTTTGGAGTGAGTA--------CGAA--TGTACA-TAA-AAA-TAAAAAAAGATCTAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTT--TGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTT--GTGCCATCTC--CTAACGGT-GATGTGTCTCAAGTGCATGATGTGATCATATG-GATGT-AACAGTTCATATATCATTAATAAAGAGATATGGTTGTTGAC--GTGCAT--G----T-TTG-ACCATTATTTTTATCTA--ATAAATAAATAATTTTGGTATAAAATCAAGC-GTGT---ACTGTT-TGA-C-A--CAAA-AAT-CTTTAACTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAAATATAATGATGTAT-CAT-TCTAAGG-T--A-TGGTT-GT--TTTGTCTCT-CAACAGC--T--ATTAA----CTTGGCAGCTTACT-CAAAGATGTAGCTTATTATGTTTTAAGTAAGTGTTGTTAGACAATCAGGTATGGTGAAATTWCTTAGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCTAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGCATATACAAGTAAAATTGTATATGCATTGATATTTTTCATGATACTTTGGTGTGAGTATAAAATTAATAATTTGTACAWAAACAAACAAAAAAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTCAAACTATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTGTTTTGTTGTCTAACAACAGCAGAAGCATAAGTGCATGATGTGATCATATAAGCTTTTAATYGCYTATATATCATTAATAAAGGTATAAGTATGGTAACAAGTGCTTTTGCACATATTTAACCATAATTTTTATTTAATATAAATATATAATTTTGGTATAAAATGAATATGTGTTGYAC-GTTGTAAGCTATACAAAGAAAACTTTAAAATTGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||| ||||||||||||||||||||| | | | ||||| |  | || || ||   ||||   | || | ||  |   ||||    ||| ||||||  ||  |||||||||| ||||||||| |||||  |||| ||| | |||| ||   |     ||||| ||| ||||||||||||||||||||||||||||||||||||| |||||||||||||||||||  | | ||  ||  |   ||||||||||||||   |    |||||||||||||||| ||| ||| |||||||||| |||||||          ||  ||||||  || |||  ||||||||||| ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||      |||||||||  ||||||||||||||||||||||||||||||||||||||||||||||||||||||  |||   | |   |||||    |  |   |  |||||||||||||||||||||  | | | ||  |   |||||||||||||||||  ||| |  || | ||  |||| |  |    | ||  ||||| |||||||| ||  ||||||| |||||||||||||||||| ||   ||||   || ||| | | | |  |||| ||  ||||||   |||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>14</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|3</Hit_id>
+  <Hit_def>AB462266.1 Culicoides japonicus genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Ngs24_1</Hit_def>
+  <Hit_accession>3</Hit_accession>
+  <Hit_len>925</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>501.562</Hsp_bit-score>
+      <Hsp_score>271</Hsp_score>
+      <Hsp_evalue>1.43619e-144</Hsp_evalue>
+      <Hsp_query-from>183</Hsp_query-from>
+      <Hsp_query-to>774</Hsp_query-to>
+      <Hsp_hit-from>316</Hsp_hit-from>
+      <Hsp_hit-to>925</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>518</Hsp_identity>
+      <Hsp_positive>518</Hsp_positive>
+      <Hsp_gaps>54</Hsp_gaps>
+      <Hsp_align-len>628</Hsp_align-len>
+      <Hsp_qseq>AAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGGCTC-TTTTGACAT---TAGTATGCATATACTT--TTGTATATGCATTGATTTTTATCAAGATACTTTGGAGTGA-----GT---AC-GAATGTACATAAAAATAAAAAAA--GATCTAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTTGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTGTGCCATCTCCTAACGGTGATGTGTCTCAAGTGCATGATGTGATCATATG-GATGTAACAGTTCATATATCATTAATAAAGA-G--ATA--TGGTTGTTGA--CG-TGCATGTTTGACCATTATTTTTATCTAATAAATAAATAATTTTGGTATAAAATCAAGC-GTGTAC---TGTTT-G--AC-AC-AAAAATCTTTAACTA-TGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>AAAATTACTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGTATATACTTAGTTGTATATGCATTGATATTTTTCATGATACTTTGGTGTGATTTTTGTAAAACAAAATATA-AT-AAAATAAAAAAATTGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATATTACTTATTCACAAAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATG---T-T--T---G-T--TGCAT---AAGTGCATGATGTGATCATATAAGCTTTATTGCTT-ATATATCATTAATAAAGGTGTGATAAATGGTACAAAATACTTTGCATATTTAACCATTATTTTTATTTAACATGAAAATAATTTTGGTATAAAATAAATATGTCTAAGAGTGTTTAGTTACTATTAAAAAAATTTTAAAATTGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>|||||| |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  | | ||  ||  |   ||||||| ||||||||  |||||||||||||||| ||| ||| |||||||||| ||||     ||   ||  ||| || || ||||||||||||  |||| ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||   |||||||| ||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||   | |  |   | |  ||  |   |||||||||||||||||||||  | | ||    || |||||||||||||||||  |  |||  ||||     |  |  ||||| ||| |||||||||||||| ||| |   |||||||||||||||||||| ||   || ||    ||||| |  || |  |||||  ||| |  | |||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>130.386</Hsp_bit-score>
+      <Hsp_score>70</Hsp_score>
+      <Hsp_evalue>7.80721e-33</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>174</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>170</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>143</Hsp_identity>
+      <Hsp_positive>143</Hsp_positive>
+      <Hsp_gaps>10</Hsp_gaps>
+      <Hsp_align-len>177</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATACTAAAAAAATATAATGATGTATT-CTTATAT-AAGGT-TGGAGTGTTTGGTGGGTTGTTATTGCAGCGGCTTTGCCTTAACCGGCTTAGCAGCTCGCTATAAAGATGTAGTTTATTATGTCTTAAGCGAGTGCTGTGA</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAAATATAATGATGTATCACTTATATTAAGGTATTGGTTGTTTATTGTGT-GTTGAAGCAGCAGCTATT--TTAATA----TAGCAGCTTACTATAAAAATATAGTTTATTATATTTTAAGTAAGTGCTGTGA</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||| |||||||||||||||||||||  ||||||| ||||| | |  |||||  || || |||   ||||| ||| |   ||||      ||||||||  ||||||| || ||||||||||| | |||||  ||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>15</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|9</Hit_id>
+  <Hit_def>AB462272.1 Culicoides nipponensis genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Isg22</Hit_def>
+  <Hit_accession>9</Hit_accession>
+  <Hit_len>794</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>490.482</Hsp_bit-score>
+      <Hsp_score>265</Hsp_score>
+      <Hsp_evalue>3.1088e-141</Hsp_evalue>
+      <Hsp_query-from>184</Hsp_query-from>
+      <Hsp_query-to>566</Hsp_query-to>
+      <Hsp_hit-from>183</Hsp_hit-from>
+      <Hsp_hit-to>570</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>353</Hsp_identity>
+      <Hsp_positive>353</Hsp_positive>
+      <Hsp_gaps>15</Hsp_gaps>
+      <Hsp_align-len>393</Hsp_align-len>
+      <Hsp_qseq>AAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGGCTC-TTTTGACAT---TAGTATGCATATACTTTTGTATATGCATTGATTTTTATCAAGATACTTTGGAGTGAGTACGAATGTACATAAAAATAAAAAAAGATCT---AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATAT-TTTT-GATATTCACA-GAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTGTG</Hsp_qseq>
+      <Hsp_hseq>AAATTTCTTGGGTAGCTTTATTGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGTATATATTCATTTATATACATTGATATTTTTCATGATACTTTGGATTGA-TATG-AT-AAAACAAACAAAAAAAAAG-TGTAAGAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATATTTTTGATATTCACAAGA-TCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTGTG</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||| |||||||||||||||||||||||||||||||||||||||||||||  | | ||  ||  |   ||||||| ||||| |  | ||||| ||||||| ||| ||| ||||||||||| ||| || | ||  | | ||| | |||||||| | |   ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| |||| |||||||||| || ||||||||||||||||||||||||||||||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>91.6061</Hsp_bit-score>
+      <Hsp_score>49</Hsp_score>
+      <Hsp_evalue>3.6841e-21</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>59</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>58</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>56</Hsp_identity>
+      <Hsp_positive>56</Hsp_positive>
+      <Hsp_gaps>1</Hsp_gaps>
+      <Hsp_align-len>59</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATACTAAAAAAATATAATGATGT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATTATAAAAAA-TATAATGATGT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||  ||||||| |||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>16</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|4</Hit_id>
+  <Hit_def>AB462267.1 Culicoides aterinervis genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: AM05_5</Hit_def>
+  <Hit_accession>4</Hit_accession>
+  <Hit_len>891</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>490.482</Hsp_bit-score>
+      <Hsp_score>265</Hsp_score>
+      <Hsp_evalue>3.1088e-141</Hsp_evalue>
+      <Hsp_query-from>183</Hsp_query-from>
+      <Hsp_query-to>563</Hsp_query-to>
+      <Hsp_hit-from>276</Hsp_hit-from>
+      <Hsp_hit-to>677</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>360</Hsp_identity>
+      <Hsp_positive>360</Hsp_positive>
+      <Hsp_gaps>21</Hsp_gaps>
+      <Hsp_align-len>402</Hsp_align-len>
+      <Hsp_qseq>AAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGGCTC-TTTTGACAT---TAGTATGCATATACTT--TTGTATATGCATTGATTTTTATCAAGATACTTTGGAGTGAGTA-----C--GAA-TGTACAT--A-AA-AAT---AAAAAAAGATCTAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTTGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTT</Hsp_qseq>
+      <Hsp_hseq>AAAATTTCTTAGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCTAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGCATACACTTAGTTGTGTATGCATTGATATTTTTCATGATACTTTGGAGTGAGTATAATACAAAAATTGTACATAAATAATAATAAAAAAAAAAGATGAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTATAATATTTTTGATATTCATAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTT</Hsp_hseq>
+      <Hsp_midline>|||||||||| ||||||||||||||||||||||||||||||||||||| |||||||||||||||||||  | | ||  ||  |   ||||||||||| ||||  |||| ||||||||||| ||| ||| ||||||||||||||||||     |   || |||||||  | || |||   ||||||||||  |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| |||||||||||||||||| |  ||||||||||||||||||||||||||||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>124.846</Hsp_bit-score>
+      <Hsp_score>67</Hsp_score>
+      <Hsp_evalue>3.63234e-31</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>178</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>160</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>144</Hsp_identity>
+      <Hsp_positive>144</Hsp_positive>
+      <Hsp_gaps>18</Hsp_gaps>
+      <Hsp_align-len>178</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATACTAAAAAAATATAATGATGTATTCTTATATAAGGTTGGAGTGTTTGGTGGGTTGTTATTGCAGCGGCTTTGCCTTAACCGGCTTAGCAGCTCGCTATAAAGATGTAGTTTATTATGTCTTAAGCGAGTGCTGTGATACA</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATA--AAAATA-TATAATGATGT-T-CAT-TCTAAGGTTGT-G-GAT--GTATGTTGTTATTGTAACAGCTAT---TTA---G--TTAGCAGCTTGCTATAAAGATGTAGTTTATTATGTCTTAAGTAAGTGTTATGATACA</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||||  |||| | ||||||||||| | | | | ||||||||  | | |  ||  |||||||||| | | ||| |   |||   |  ||||||||| |||||||||||||||||||||||||||||||  |||| | |||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>17</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|8</Hit_id>
+  <Hit_def>AB462271.1 Culicoides lungchiensis genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: AM05_8</Hit_def>
+  <Hit_accession>8</Hit_accession>
+  <Hit_len>776</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>483.096</Hsp_bit-score>
+      <Hsp_score>261</Hsp_score>
+      <Hsp_evalue>5.20213e-139</Hsp_evalue>
+      <Hsp_query-from>184</Hsp_query-from>
+      <Hsp_query-to>563</Hsp_query-to>
+      <Hsp_hit-from>182</Hsp_hit-from>
+      <Hsp_hit-to>582</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>359</Hsp_identity>
+      <Hsp_positive>359</Hsp_positive>
+      <Hsp_gaps>23</Hsp_gaps>
+      <Hsp_align-len>402</Hsp_align-len>
+      <Hsp_qseq>AAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGGCTC-TTTTGACAT---TAGTATGCATATAC---T-TTTGTATATGCATTGAT-TTTTATCAAGATACTTTGG-----AG------TGAGTACGAA--TGTACATAAAAATAAAAAAAGATCTAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTTGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTT</Hsp_qseq>
+      <Hsp_hseq>AAATTACTTGGGTAGCTTTATTGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGTATATACATTTATTTGTATATACATTGATATTTTTTCATGATACTTTGGTATAAAGAAAAAAAAAGTACAATTTTGTACATATAAA-AAAAAAAGATCTAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTTGATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTT</Hsp_hseq>
+      <Hsp_midline>||||| ||||||||||||||| |||||||||||||||||||||||||||||||||||||||||||||  | | ||  ||  |   ||||||| ||||||   | ||||||||| ||||||| |||| ||| ||||||||||     ||        ||||| |   |||||||| ||| |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  ||||||||||||||||||||||||||||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>95.2994</Hsp_bit-score>
+      <Hsp_score>51</Hsp_score>
+      <Hsp_evalue>2.84798e-22</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>75</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>75</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>70</Hsp_identity>
+      <Hsp_positive>70</Hsp_positive>
+      <Hsp_gaps>6</Hsp_gaps>
+      <Hsp_align-len>78</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTA-TACTAAAAAAATATAATGATGTATTCTTAT-ATAAG-GTT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATTAAAAAAAAAATATAATGATGT-T-CT-ATCATAAGTGTT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||| ||  |||||||||||||||||| | || || ||||| |||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>18</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|6</Hit_id>
+  <Hit_def>AB462269.1 Culicoides cylindratus genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Kag08, long type</Hit_def>
+  <Hit_accession>6</Hit_accession>
+  <Hit_len>820</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>479.403</Hsp_bit-score>
+      <Hsp_score>259</Hsp_score>
+      <Hsp_evalue>6.72938e-138</Hsp_evalue>
+      <Hsp_query-from>183</Hsp_query-from>
+      <Hsp_query-to>563</Hsp_query-to>
+      <Hsp_hit-from>234</Hsp_hit-from>
+      <Hsp_hit-to>616</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>350</Hsp_identity>
+      <Hsp_positive>350</Hsp_positive>
+      <Hsp_gaps>18</Hsp_gaps>
+      <Hsp_align-len>391</Hsp_align-len>
+      <Hsp_qseq>AAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGGCTCTTTTGACATTAGTATGCATATACTTTTGTATATGCATTGATTTTTATCAAGATACTTTGGAGTGAGTA-----C--GAA-TGTACATAAAA-ATA-AAAAAAGATCTAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTTGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTT</Hsp_qseq>
+      <Hsp_hseq>AAAATTTCTTAGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCTAAGGCCCCGTAAAACTAGTAAC-CCATTG-C-GAGGT-GGC---TA-GTATGCATATGCATTGATATTTTTCATGATACTTTGGAGTGAGTATAATACAAAAATTGTACATAAAACAAATAAAAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTATAATATTTTTGATATTCATAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTT</Hsp_hseq>
+      <Hsp_midline>|||||||||| ||||||||||||||||||||||||||||||||||||| |||||||||||||||||||  | |  ||| |    ||  ||   ||  | || |||||||||||| ||| ||| ||||||||||||||||||     |   || ||||||||||| | | |||||||||| |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| |||||||||||||||||| |  ||||||||||||||||||||||||||||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>97.1461</Hsp_bit-score>
+      <Hsp_score>52</Hsp_score>
+      <Hsp_evalue>7.91846e-23</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>59</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>58</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>57</Hsp_identity>
+      <Hsp_positive>57</Hsp_positive>
+      <Hsp_gaps>1</Hsp_gaps>
+      <Hsp_align-len>59</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATACTAAAAAAATATAATGATGT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAA-TATAATGATGT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||| ||||||| |||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>19</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|10</Hit_id>
+  <Hit_def>AB462273.1 Culicoides ohmorii genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Kag05</Hit_def>
+  <Hit_accession>10</Hit_accession>
+  <Hit_len>825</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>466.476</Hsp_bit-score>
+      <Hsp_score>252</Hsp_score>
+      <Hsp_evalue>5.23906e-134</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>651</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>697</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>562</Hsp_identity>
+      <Hsp_positive>562</Hsp_positive>
+      <Hsp_gaps>58</Hsp_gaps>
+      <Hsp_align-len>703</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTAT-ACTAAAAAAATATAATGATGT--ATTCTTATATAAGGTTGGAGTGTTTGGTG-GGTTGTTATTGCAGCGGCTTTGCCTTAACCGGCTTAGCAGCTC-GC-TATAAAGATGTAGTTTAT--TA---T---GT---C-TTA--AGCGAGTGCTGTGATA-CAA-CAAAAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGGCTC-TTTTGACAT---TAGTATGCATATACTT--TTGTATATGCATTGATTTTTATCAAGATACTTTGG--AGTG---A-GT---------A-C--GA-ATGTACATA-A-A-AATAAAAAAAGAT--CTAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTTGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTGTGCCATCTCCTAACGGTGATGTGTCTCAAGTGCATGATGTGATCATATGGATGTAACAGTTCATATATCATTAATAAAGAGATATGG</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATTAACATAAAAATATAATGATGTTCATTCATATATATGAAAAAAG-GTATGGTGTTGTTGCTATTACAAYAGCTATTAATTTAGCAGCTT-GCA--TCAACTTATAAAGATGTGGTTTATCATATCTTAAAGTACACATTATTAGTAAGTGTTGTAATAGAAAGGTKTAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGTATATACTTAATTGTATATGCATTGATATTTTTCATGATACTTTGGTGTGTGATAATATAAAAAAAAAATCTTTATATTTATATAGAGAGAAAAAAAAAAAATAAGAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTTGATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTTATTTG-TAAAAAAAAGAAGCAT-AAGTGCATGATGTGATTATATAAATACATCAATTTATATATCACTAATAAAAAGGTATGG</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||| |  | ||||||||||||||||  |||| |||||| |     || || |||||  |||| |||| ||   ||| |   || | | |||| |||  ||  | ||||||||||| ||||||  ||   |   ||   | |||  ||  |||| ||| |||  ||     |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  | | ||  ||  |   ||||||| ||||||||  |||||||||||||||| ||| ||| ||||||||||   |||   |  |         | |   | || || ||| | | || ||||||| ||    |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  |||||||||||||||||||||||||||||||||||||||||||||||||||||| ||  || |  |||     |   |  | |||||||||||||||| ||||  ||  | || || |||||||| ||||||| || |||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>20</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|14</Hit_id>
+  <Hit_def>AB462277.1 Culicoides charadraeus genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: KC05_14</Hit_def>
+  <Hit_accession>14</Hit_accession>
+  <Hit_len>913</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>435.083</Hsp_bit-score>
+      <Hsp_score>235</Hsp_score>
+      <Hsp_evalue>1.47741e-124</Hsp_evalue>
+      <Hsp_query-from>184</Hsp_query-from>
+      <Hsp_query-to>563</Hsp_query-to>
+      <Hsp_hit-from>296</Hsp_hit-from>
+      <Hsp_hit-to>662</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>339</Hsp_identity>
+      <Hsp_positive>339</Hsp_positive>
+      <Hsp_gaps>23</Hsp_gaps>
+      <Hsp_align-len>385</Hsp_align-len>
+      <Hsp_qseq>AAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGGCTCTTTTGACATTAGTATGC-A-TATACTTTTGTATATGCATTGATTTTTATCAAGATACTTTGGAGTGAGTACGAATGTACATAAAAATAAA-AAAAGATCTAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAAT--ATTTTTGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTT</Hsp_qseq>
+      <Hsp_hseq>AAATTTCTTAGGTAGCTTTATCGAAGAGCTTTAAAGACTTGTTTGCCTAAGGCCCCGTAAAACTAGTAAC-CCATTG-C-GAGGT-GGCTAGTATGCATTTG----TGCATTGATATTTTTCATGATACTTTGG--TGTGTTTG--TGTA-ATAAAAAAAAATAAAAAATC-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATTGATATTTGTTAT--A-A-AGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTT</Hsp_hseq>
+      <Hsp_midline>||||||||| ||||||||||| ||||||||||||||||||||||||| |||||||||||||||||||  | |  ||| |    ||  || | ||| | ||||    ||||||||| ||| ||| ||||||||||  || ||  |  |||| ||||||| ||| |||| ||| |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  || |||| |||  | | |||||||||||||||||||||||||||||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>89.7595</Hsp_bit-score>
+      <Hsp_score>48</Hsp_score>
+      <Hsp_evalue>1.32504e-20</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>64</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>68</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>63</Hsp_identity>
+      <Hsp_positive>63</Hsp_positive>
+      <Hsp_gaps>6</Hsp_gaps>
+      <Hsp_align-len>69</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTA-TACTAAAA-AAA---TATAATGATGTATTCT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTAATA-TAAAACAAAAATTATAATGATGTATTCT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||| || ||||| |||   ||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>21</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|16</Hit_id>
+  <Hit_def>AB462279.1 Culicoides oxystoma genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Naha16_1</Hit_def>
+  <Hit_accession>16</Hit_accession>
+  <Hit_len>796</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>422.156</Hsp_bit-score>
+      <Hsp_score>228</Hsp_score>
+      <Hsp_evalue>1.15022e-120</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>562</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>572</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>482</Hsp_identity>
+      <Hsp_positive>482</Hsp_positive>
+      <Hsp_gaps>56</Hsp_gaps>
+      <Hsp_align-len>595</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATACT-AAAAAA-ATATAATGATGTATTCTTATATAAGGTTGGAGTGTTTGGTGGGTTGTTATTGCAGCGGCTTTGCCTTAACCGGCTTAGCAGCTCGCTATAAAGATGTAGTTTATTATGTCTTAAGCGAGTGC-TGTGATA-CAACAAAAAAT-TTCTTGGGTAGCTTT-ATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTGGCTC-TTTTGACAT---TAGTATG--CAT-ATA-CTTTTGTA---TATGCATTGATTTTTATCAAGATACT--T-TG-GA-G-TGAGTACGAATGTAC-A-TAAAAATAAAAAAA--GATCTAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTG-T-AATATTTT---TGAT-ATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTA-ATTAAAAAAACATATAATGATGT-TTC----ATAAGGTATG-GTG-TTGTTAATATGGTAGTG--TCGTC-TTG---TCA-C-G---A-CAGCTTGTTATAAAGATGTAGTTTATTATGTCTTAAACAAGTCAATATCATATTAACGCAAAATAATCTTAGGTAGCTTTTATGTAAGAGCTTTAAAGACTTTTTTGCCTAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGTATATAATACCTTGCGTATTGTATGCATTGA-TTTT-TCATGATATTAATGTGTGATGTTGTTTATGCAA-AACAATTAATAATAAAAAAATTGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCTAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATACGATTAGATTTTGATTAATAATCTCAATGATAATTGACAAAATCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||| | | |||||| |||||||||||| |||    |||||||  | ||| ||| |    || || ||   || | |||   | | | |   | ||||| | |||||||||||||||||||||||||||| | |||   | | |||  |||  |||||  |||| ||||||||| ||  ||||||||||||||||| |||||| |||||||||||||||||||  | | ||  ||  |   |||||||   || ||| |||  |||   |||||||||| |||| ||| |||| |  | || || | ||  || | |   || | ||| ||||||||||  |||| ||||||||||||||||||||||||||||||||||||||||||||||||||| ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||||||||||||| | |||| | |   |||| ||| ||| | ||||||||||||||||||||||||||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>22</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|7</Hit_id>
+  <Hit_def>AB462270.1 Culicoides dubius genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Isg23</Hit_def>
+  <Hit_accession>7</Hit_accession>
+  <Hit_len>1096</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>374.144</Hsp_bit-score>
+      <Hsp_score>202</Hsp_score>
+      <Hsp_evalue>3.26663e-106</Hsp_evalue>
+      <Hsp_query-from>333</Hsp_query-from>
+      <Hsp_query-to>563</Hsp_query-to>
+      <Hsp_hit-from>597</Hsp_hit-from>
+      <Hsp_hit-to>829</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>224</Hsp_identity>
+      <Hsp_positive>224</Hsp_positive>
+      <Hsp_gaps>4</Hsp_gaps>
+      <Hsp_align-len>234</Hsp_align-len>
+      <Hsp_qseq>ATAAAAATAAAAAAAGATCTAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATAT-TT--TTGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTT</Hsp_qseq>
+      <Hsp_hseq>ATAAAAA-AAAAAATTAAATAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATCTTAGTTGTTATTCACAGAATCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTT</Hsp_hseq>
+      <Hsp_midline>||||||| ||||||  |  |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||  ||| |||||||||| |||||||||||||||||||||||||||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>128.539</Hsp_bit-score>
+      <Hsp_score>69</Hsp_score>
+      <Hsp_evalue>2.80797e-32</Hsp_evalue>
+      <Hsp_query-from>182</Hsp_query-from>
+      <Hsp_query-to>250</Hsp_query-to>
+      <Hsp_hit-from>393</Hsp_hit-from>
+      <Hsp_hit-to>461</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>69</Hsp_identity>
+      <Hsp_positive>69</Hsp_positive>
+      <Hsp_gaps>0</Hsp_gaps>
+      <Hsp_align-len>69</Hsp_align-len>
+      <Hsp_qseq>AAAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGT</Hsp_qseq>
+      <Hsp_hseq>AAAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGT</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>3</Hsp_num>
+      <Hsp_bit-score>73.1396</Hsp_bit-score>
+      <Hsp_score>39</Hsp_score>
+      <Hsp_evalue>1.33445e-15</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>52</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>51</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>48</Hsp_identity>
+      <Hsp_positive>48</Hsp_positive>
+      <Hsp_gaps>1</Hsp_gaps>
+      <Hsp_align-len>52</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATACTAAAAAAATATA</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATA-AAAATATATATA</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||||  ||| | |||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+</Iteration_hits>
+  <Iteration_stat>
+    <Statistics>
+      <Statistics_db-num>22</Statistics_db-num>
+      <Statistics_db-len>18669</Statistics_db-len>
+      <Statistics_hsp-len>16</Statistics_hsp-len>
+      <Statistics_eff-space>13884286</Statistics_eff-space>
+      <Statistics_kappa>0.46</Statistics_kappa>
+      <Statistics_lambda>1.28</Statistics_lambda>
+      <Statistics_entropy>0.85</Statistics_entropy>
+    </Statistics>
+  </Iteration_stat>
+</Iteration>
+</BlastOutput_iterations>
+</BlastOutput>
+

--- a/tools/merge_blastxml/test-data/q2.blastxml
+++ b/tools/merge_blastxml/test-data/q2.blastxml
@@ -1,0 +1,2111 @@
+<?xml version="1.0"?>
+<!DOCTYPE BlastOutput PUBLIC "-//NCBI//NCBI BlastOutput/EN" "http://www.ncbi.nlm.nih.gov/dtd/NCBI_BlastOutput.dtd">
+<BlastOutput>
+  <BlastOutput_program>blastn</BlastOutput_program>
+  <BlastOutput_version>BLASTN 2.5.0+</BlastOutput_version>
+  <BlastOutput_reference>Zheng Zhang, Scott Schwartz, Lukas Wagner, and Webb Miller (2000), &quot;A greedy algorithm for aligning DNA sequences&quot;, J Comput Biol 2000; 7(1-2):203-14.</BlastOutput_reference>
+  <BlastOutput_db>/usr/people/galaxyuser/galaxy/galaxysrv/galaxy/database/files/000/dataset_421_files/blastdb</BlastOutput_db>
+  <BlastOutput_query-ID>Query_1</BlastOutput_query-ID>
+  <BlastOutput_query-def>AB462259.1 Culicoides actoni genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Kag01</BlastOutput_query-def>
+  <BlastOutput_query-len>776</BlastOutput_query-len>
+  <BlastOutput_param>
+    <Parameters>
+      <Parameters_expect>0.001</Parameters_expect>
+      <Parameters_sc-match>1</Parameters_sc-match>
+      <Parameters_sc-mismatch>-2</Parameters_sc-mismatch>
+      <Parameters_gap-open>0</Parameters_gap-open>
+      <Parameters_gap-extend>0</Parameters_gap-extend>
+      <Parameters_filter>L;m;</Parameters_filter>
+    </Parameters>
+  </BlastOutput_param>
+<BlastOutput_iterations>
+<Iteration>
+  <Iteration_iter-num>1</Iteration_iter-num>
+  <Iteration_query-ID>Query_1</Iteration_query-ID>
+  <Iteration_query-def>AB462259.1 Culicoides actoni genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Kag01</Iteration_query-def>
+  <Iteration_query-len>776</Iteration_query-len>
+<Iteration_hits>
+<Hit>
+  <Hit_num>1</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|0</Hit_id>
+  <Hit_def>AB462263.1 Culicoides maculatus genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Kag12_1</Hit_def>
+  <Hit_accession>0</Hit_accession>
+  <Hit_len>764</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>800.72</Hsp_bit-score>
+      <Hsp_score>433</Hsp_score>
+      <Hsp_evalue>0</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>776</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>764</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>678</Hsp_identity>
+      <Hsp_positive>678</Hsp_positive>
+      <Hsp_gaps>42</Hsp_gaps>
+      <Hsp_align-len>791</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAATATAATGATGTATTCTTATAAAGTGTATGGTTGTTGGTTGTT-TTGCAGCGGCC-CTTG-TGGCAGCTCRCTATAAAGATGTAGTTTATTATGTCTTAAGCGAGTGCTGTGAAACAACAAAAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCAGTAAAACTAGTGATTTCGTGTCGCTAGTATGCATACATCTCTTTCGGGAGGGTATGCATTGATTTTATATCAAGATACTTTGGTGTGATAGTACGAATAGTACATATAAAA-TAAAAAATATAAGAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCATGATATTCACGAAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTCATGC-TTGT-TGAAAGACATAGTT-TGAGTGCATGATGTGATCATATGAATTT--TTTCATATATCATTAATAGAGTATATGGTTTATA-CTACT-TGCTTACGCGGCATGTTTGACCATTATTTTTATTTAACAAAATAACAAATTTTGGTATAAAATCAAGCGTGTTGTAGGCTGACG-TAGATAAAACTCT-TTCT-T-TATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTA-ACT-AAACATTCAATGATGTATTCTT-T-AAG-GTATGGTTG-TCGTTGTTATTGCAGCAGCCTCTCGCGGGCAGCTTGCTATAAAGATGTAGTTTATTATGTCTTAAGCAAGTGTTGTGGTTCAACAAAAAATTACTTGGGTAGCTTTATTTAAGAGCTTTAAAGACTTGTTTGCCCAAGGCTCCCGTAAAACTAGTGATCTTGTTTCATTAGTATGCA-A-TTATATTT--ATA-TATTTGCATTGATTTTATATCAAGATACTTTGGTGTGA--GTACGTAT-GTACATATAAAACAAAAAAAGATCA-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTTCGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTATTGTCTGAAA-AGATAAATGTAAGTGCATGATGTGATCATATGGATTWACTTTCATATATCATTAATGGAGGATATGGTT-ATCGCTGCTATGTTT--GCA-CAC-TTGG-CCATTATTTTTATTTAGTTAAA-AATATATATTGGTATAAAATCAAGTG-GT-GTAG-CTGGCGCTAAAGCGAT-TCTATTCTATCTATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||| | | ||| ||  |||||||||||||| | ||| ||||||||| | |||||| ||||||| ||| || |  |||||||  ||||||||||||||||||||||||||||||| |||| ||||   |||||||||||| |||||||||||||||  |||||||||||||||||||||||||||||| || |||||||||||||| | || ||  ||||||||| |  | | |||    |   | ||||||||||||||||||||||||||||||||||  ||||| || ||||||||||||  |||||| || | |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||   |||||||||  |||||||||||||||||||||||||||||||||||||||||||||||||||||| |||  |||| ||||| | |||  | | ||||||||||||||||||||| |||   ||||||||||||||||| ||| |||||||| ||  || || || ||  ||  ||  || | ||||||||||||||||   ||| || | || |||||||||||||||| | || |||| ||| || || |   |  ||| |||| | |||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>2</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|1</Hit_id>
+  <Hit_def>AB462264.1 Culicoides wadai genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Isg18_1</Hit_def>
+  <Hit_accession>1</Hit_accession>
+  <Hit_len>834</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>704.694</Hsp_bit-score>
+      <Hsp_score>381</Hsp_score>
+      <Hsp_evalue>0</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>713</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>761</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>656</Hsp_identity>
+      <Hsp_positive>656</Hsp_positive>
+      <Hsp_gaps>76</Hsp_gaps>
+      <Hsp_align-len>775</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATAT-TAAAAAATATAATGATGTATTCTTATAAAGTGTATGGTTGTTG-----GTTGTT-TTGCAGCGGC-C--C-----T-T-GT--GGCAGCTCRCTATAAAGATGTAGTTTATTATGTCTTAAGCGAGTGCTGTGAAACAAC-A-A-AAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGG-CCCCAGTAAAACTAGTGAT-TTCGTGTCGCTAGTATGCATA------CAT--C-TCT-TTC-G-GGAG-G----G-TATGCATTGATTTTATATCAAGATACTTTGGTGTGATAGTACGAATAGTACATATAAAATAAAAAATATAAG---AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCATGATATTCACGAAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTCATG-CTTGTT-GAAAGACATAGTTTGAGTGCATGATGTGATCATATGAATTTT----TTCATATATCATTAATA--G-AGTATATGGTTTATA-C-TACTTGCTTAC---GCG---GCATGTTTGACCATTATTTTTATTTAACAAAATAACAAATTTTGGTATAAAATCAA</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTA-ATCTAAAACATTCAATGATGTATTCTCA-CAAGTGTATGGTTGTTGTTTCCGTTGTTATTGTAGCAGCTCGTCGTAATTATCGTCGGGCAGCTTGCTATAAAGATGTAGTTTATTATGTCTTAAGCGAGTGCTGCAATACAACAATACAAAATTTCTTAGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCTAAGGCCCCCAGTAAAACTAGTGATCTTTGTGTCACTAGTATGCATATTAATGCATAACATCTCTTCGGAGGTGCGCTTTGATATGCATTGA-TTTATATCAAGATACTTTGGAGTGA--GTAC-ATTCGTACA-ATAAAACAAACAAAAAAAGATCAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTT-TGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGACTCGTTTGAACGTCTCA-TA--AGTGCATGATGTGATCATATGGATTTCGCGATTCATATATCATTAATAAAGGAGAATATGGTTGTTAACGTGCGTG-TTACATTGCGTTTGCA--TTTGACCATTATTTTTATTTAATAAAATAATAAATTTTGGTATAAAATCAA</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||| || ||||| ||  ||||||||||||| |  ||||||||||||||||     |||||| ||| ||| || |  |     | | ||  |||||||  |||||||||||||||||||||||||||||||||||||||  | ||||| | | |||||||||| ||||||||||||||||||||||||||||||||||||| |||| ||||||||||||||||||| || ||||| ||||||||||||      |||  | ||| ||| | || | |    | |||||||||| |||||||||||||||||||| ||||  |||| | | ||||| |||||| ||| || | |||   |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  ||||||||||  |||||||||||||||||||||||||||||||||||||||||||||||||||||| ||| || ||| ||| | |  | |   ||||||||||||||||||||| ||||     |||||||||||||||||  | || ||||||||  || | | | || ||||   |||   |||  |||||||||||||||||||||| ||||||| ||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>3</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|12</Hit_id>
+  <Hit_def>AB462275.1 Culicoides punctatus genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Kag13_1</Hit_def>
+  <Hit_accession>12</Hit_accession>
+  <Hit_len>787</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>645.601</Hsp_bit-score>
+      <Hsp_score>349</Hsp_score>
+      <Hsp_evalue>0</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>776</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>787</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>671</Hsp_identity>
+      <Hsp_positive>671</Hsp_positive>
+      <Hsp_gaps>67</Hsp_gaps>
+      <Hsp_align-len>815</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAATATAATGATGTATTCTTATAAAGTGTATGGTTGTTG-GTTGT-TTTG-CAGCGGCCCTT-G-TGGCAGCTCRCTATAAAGATGTAGTTTATTATGTCTTAAGCGAGTGCTGTG-A-AACAAC-AAAAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCAGTAAAACTAGT----GATTTCG-TGTCGCTAGTATGCATACATCTCTTTCGGGAGGGTATGCATTGATTTTATATC-AAGATAC-TTTG-GTGTG-AT-A--GT-ACG-AATAGTACAT--ATAAAATAAAAAATATAAGAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCATGATATTCACGAAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTCATG-CTTGT--TGAAAGACATAGTTTGAGTGCATGATGTGATCATAT-GA--ATTTT--TTCATATATCATTAATAGAGTATA-TGGTTTATACTACT-TGCTT-ACGCGGCATGTTTGACCATTATTTTTATTTAACAAAATAACAAATTTTGGTATAAAATCAA--GC-GTGTT-GTAGGCTGACGTAGATAAAACTCTTTCTTTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATTATAAAACATATAATGATGT-TCATTCTATAG-GTATGGTTGTTGTGTTGTCATTGTAAGAGTCATTTAGTTGGCAGCTCTCTATAAAGACATAGTTTATTATGTTTTAAGGGAGTACCTTGCAGTGCGACAAAAAAATTACTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCC-GTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGCATATACTTAATT--GTA---TATGCATTGA-TTTATTTCAAAGATACATTGGAGAGAGTATAATTGTAATGAAATTGTACATAAACAAAACAAAAAAAGTAA-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTTCGATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTCTTTCACTGAAAG-CATA-----AGTGCATGATGTGATTATATAGGTGATATCAACTTATATATCATTAATAAAGTGTGGTGGT--A-ACAAATATACTTTAAGCT--ATGTTTGACCATTATTTTTATCTAA-AAAATAATAAATTTTGGTATAAAATCAAATGTAGTGTTTGTTTGTT-AC-TC-ATAACA-TCCA--TTTATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||  ||||| |||||||||||| |  || || || |||||||||||| |||||  |||  || | |  || | ||||||||| |||||||||  ||||||||||||| ||||| |||| |  || |   | || |||||||| |||||||||||||||||||||||||||||||||||||||||||||||||| |||||||||||     ||| ||  || ||||||||||||| |  |  ||  | |   |||||||||| ||||| || ||||||| || | | | | || |  || | | ||| ||||||  | |||| ||||||  ||| |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||   ||||||||| | ||||||||||||||||||||||||||||||||||||||||||||||||||||| ||| |||    |||||| ||||     ||||||||||||||| |||| |   || |    | |||||||||||||| ||| |  ||||  | || | | | ||| | ||   ||||||||||||||||||||| ||| ||||||| ||||||||||||||||||||  |  ||||| ||  | | || |  |||| | ||    |||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>4</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|21</Hit_id>
+  <Hit_def>AB462284.1 Culicoides paraflavescens genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: OKYN05_13</Hit_def>
+  <Hit_accession>21</Hit_accession>
+  <Hit_len>842</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>566.195</Hsp_bit-score>
+      <Hsp_score>306</Hsp_score>
+      <Hsp_evalue>5.03458e-164</Hsp_evalue>
+      <Hsp_query-from>165</Hsp_query-from>
+      <Hsp_query-to>776</Hsp_query-to>
+      <Hsp_hit-from>248</Hsp_hit-from>
+      <Hsp_hit-to>842</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>526</Hsp_identity>
+      <Hsp_positive>526</Hsp_positive>
+      <Hsp_gaps>43</Hsp_gaps>
+      <Hsp_align-len>625</Hsp_align-len>
+      <Hsp_qseq>AAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCAGTAAAACTAGT----GATTTCG-TGTCGCTAGTATGCATACATCTCTTTCGGGAGGGTATGCATTGATTTTATATCAAGATACTTTGGTGTGATAGTACGAATAGTACATAT-A-AAAT-AAAAAA-TATAAGAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCATGATATTCACGAAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTCATGCTTGT-T-GA-A-AGACATAGTTTGAGTGCATGATGTGATCATATGAATTTTTTCATATATCATTAATAGAGTATATGGTTTATACTACTTGCTTACGCGGCATGTTTGACCATTATTTTTATTTAACAAAATAACAAATTTTGGTATAAAATCAAGCGTGTTGTAGGCTGACGTAGATAAAACTCTTTCTTTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>AAAATTTCTTGGGTAGCTTTATTGAAGAGCTTTAAAGACTTATTTGCCCAAGGCCCC-GTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGCATAC--C-CTTT--ATTGGGTATGCATTGATATTTT-TCATGATACTTTGGTGTG--AGTACTTATTGTACATATGATAAATAAAAAAACGATCA-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTTTGATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGCGTCTCTAGCGATAGA-AGCGCTTAAGTGCATGATGTGATTATATAAGTAAAATTATATATCATTAATAAAGGA-ATA----A-A--A-TGG--TATGAATCATATTTAACCATTATTTTTATTTAA-AAAATAACAAATTTTGGTATAAAAT-A-GA-TA-TGTATGATTACCTT-A-AAAATTCTTTA-TTATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||| |||||||||||||||||| ||||||||||||||| |||||||||||     ||| ||  || ||||||||||||||  | ||||     |||||||||||||| || | ||| ||||||||||||||  |||||  || |||||||| | |||| ||||||  || | |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  |||||||||| | ||||||||||||||||||||||||||||||||||||||||||||||||||||| |||| | | | |  | ||| |  | || ||||||||||||||| |||| | |    | |||||||||||||| || | ||     | |  | | |  || |   ||| ||| |||||||||||||||||| ||||||||||||||||||||||||| | |  |  |||| | | || |  | |||| |||||  ||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>134.079</Hsp_bit-score>
+      <Hsp_score>72</Hsp_score>
+      <Hsp_evalue>6.05127e-34</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>144</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>143</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>124</Hsp_identity>
+      <Hsp_positive>124</Hsp_positive>
+      <Hsp_gaps>9</Hsp_gaps>
+      <Hsp_align-len>148</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAATATAATGATGTATTCTTATAAAGTGTATGGTTGTTGGTTGTTT-TGCAGCGGCCCTTG-TG-GC-AGCTCRCTATAAAGATGTAGTTTATTATGTCTTAAG</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAACATATAATGATGT-TTCTT-TAA-G-GTATGGT-GTTTGATATTTGTTGATAGCTATTTGATTAGCAAGCTTACTATAAAGATGTAGTTTATTATGTCTTAAG</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||||||||| |||||||||||| ||||| ||| | ||||||| ||| | | ||| |  |  |    ||| |  || ||||  ||||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>5</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|17</Hit_id>
+  <Hit_def>AB462280.1 Culicoides kibunensis genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: AM05_6</Hit_def>
+  <Hit_accession>17</Hit_accession>
+  <Hit_len>817</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>556.962</Hsp_bit-score>
+      <Hsp_score>301</Hsp_score>
+      <Hsp_evalue>3.03004e-161</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>776</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>817</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>661</Hsp_identity>
+      <Hsp_positive>661</Hsp_positive>
+      <Hsp_gaps>61</Hsp_gaps>
+      <Hsp_align-len>827</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATT-AAAAAATATAATGATGTATTCTTATAAAGTGTATGGTTGTTGGTTGTTTTGCAGCGGCCCTT---GTGGCAGCTCRCTATAAAGATGTAGTTTATTATGTCTTAAGCGAGTGCTGTGAAACAA-CA---A----AAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCAGTAAAACTAGT----GATTTCG-TGTCGCTAGTATGCATACATCTCTTTCGGGAGGGTATGCATTGATTTTATATCAAGATACTTTGGTGTGA---T---AGTACGAA-TAGTAC--ATATAAA-ATAAAAAATATAAGAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCA-TGATATTCACGAAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTCATGC-TT--GTTG---AA-AG-A-CAT-AGTTTGAGTGCATGATGTGATCATATGAATTTTT--T--C--ATATATCATTAATAGAG-TATATGGTTTATACTACTTGCTTACGCGGCATGTTTGACCATTATTTTTATTTAACA-AAATAACAAATTTTGGTATAAAATCAAGC-GTGTTGTAGGCTG-ACG-TAGATAAA-ACT-CTTTCTTTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAAATATAATGATGTATCATTCT-AAG-GTATGGTTGTT--TTGTCTCTCAACAGCTATTAACTTGGCAGCTTACT-CAAAGATGTAGCTTATTATGTTTTAAGTAAGTGTTGTTAGACAATCAGGTATGGTGAAATTWCTTAGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCTAAGGCCCC-GTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGCATATA-CAAGTAAAATTGTATATGCATTGATATTTT-TCATGATACTTTGGTGTGAGTATAAAATTAATAATTTGTACAWAAACAAACAAAAAAAAGATCA-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTCAAACTATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTGTTTTGTTGTCTAACAACAGCAGAAGCATAAGTGCATGATGTGATCATATAAGCTTTTAATYGCYTATATATCATTAATAAAGGTATAAGTATGGTAACAAGTGCTTTTGCA-CATATTTAACCATAATTTTTATTTAATATAAATATATAATTTTGGTATAAAATGAATATGTGTTGYACGTTGTAAGCTATACAAAGAAAACTTTAAAATTGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||||| |||||||||||||||||||  || | ||| |||||||||||  |||| |  || | ||  ||    ||||||||  ||  |||||||||| ||||||||| |||||  |||| ||| | |||| ||   |     ||||| ||| ||||||||||||||||||||||||||||||||||||| |||||||| |||||||||||     ||| ||  || ||||||||||||| | |   |      |  ||||||||||| || | ||| |||||||||||||||   |   | ||  || | ||||  | | ||| | |||||| || | ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  |   |||||||| | ||||||||||||||||||||||||||||||||||||||||||||||||||||| |||  ||  ||||   || |  | ||  ||  | |||||||||||||||||||| |  ||||  |  |  |||||||||||||| || |||| |  |  ||  |  |||||  ||  ||| ||| ||||| |||||||||||| | |||||   |||||||||||||||| ||   |||||| | | || | | || | ||| |   ||||     |||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>6</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|5</Hit_id>
+  <Hit_def>AB462268.1 Culicoides cylindratus genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Kag08, short type</Hit_def>
+  <Hit_accession>5</Hit_accession>
+  <Hit_len>748</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>547.729</Hsp_bit-score>
+      <Hsp_score>296</Hsp_score>
+      <Hsp_evalue>1.82361e-158</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>776</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>748</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>636</Hsp_identity>
+      <Hsp_positive>636</Hsp_positive>
+      <Hsp_gaps>64</Hsp_gaps>
+      <Hsp_align-len>794</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAATATAATGATGTATTCTTATAAAGTGTATGGTTGTTGGTTGTTTTGCAGCGGC-CCTT--GTGGCAGCTCRCTATAAAGATGTAGTTTATTATGTCTTAAGCGAGTGCTGTGAAACAACAAAAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCAGTAAAACTAGTGATTTCGTGTCGCTAGTATGCATACATCTCTTTCGGGAGGGTATGCATTGATTTTATATCAAGATACTTTGG--TGTG-ATAGTAC--GAATAGTACAT---A-TAAA-ATAAAAAATATAAGAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCATGATATTCACGAAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTCATGCTTGTTGAAAGACATAGTTTGAGTGCATGATGTGATCATATGAATTTTTTCATATATCATTAATAGAGTATATGGTTT-A--TACTACTTGCT-TACGCGGCATGTTTGACCATTATTTTTATTTAACAAAATAACAAATTTTGGTATAAAATCAAGCGTGTTGTAGGCT-GACGTAGATAAAACTCTTTCTTTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTA---TAAAATATATAATGATGT--TCAT-TCAA---TAAGGTTGGTGGTTGTATTGTAACAGCTATTTACTTAGCAGCTTGCTATAAAGATGTRGTTTATYATGTCTTAAGYAAGTGTTGYGATACARCAAAAAATTTCTTAGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCTAAGGCCCC-GTAAAACTAGT-AACCCAT-T-GCGAGGTGGC-T--A---GTAT--GCA---TATGCATTGATATTTT-TCATGATACTTTGGAGTGAGTATAATACAAAAATTGTACATAAAACAAAAYAAAAAAAAGATCA-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTATAATATTTT-TGATATTCATAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATAYATTAAACTATCTTATGTGTGTA-AAAG-CATA-----AGTGCATGATGTGATCATAAAAGTCTACTTTTATATCATTAATRAAGG-T--GGTAACAAATA-TACTTGATATAA---GCATATTTGACCATTATTTTTATTTATTTTAATATG-AATTTTGGTTTAAA-TCAAATATGT-GTAT-CTCGTTGTTGTTTATAWA-TAACTTTATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||   ||||| ||||||||||||  || | | ||   || ||||| ||||||| ||| | | ||   ||   | ||||||  |||||||||||| |||||| ||||||||||  |||| || || ||| ||||||||||||| ||||||||||||||||||||||||||||||||||||| |||||||| ||||||||||| |   | | | || ||   || |  |    | |  | |   ||||||||||| || | ||| ||||||||||  || | ||| |||   ||| ||||||   |  ||| | |||||| || | |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||||||||  |||||||||  | |||||||||||||||||||||||||||||||||||||||| |||||||||||| |||  |||  |||| ||||     |||||||||||||||||||  | | |  |  ||||||||||||  ||  |  |||   |  || |||||| | ||    |||| |||||||||||||||||||||    ||||   ||||||||| |||| ||||   ||| |||  || |  || | | | |   |  ||||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>7</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|20</Hit_id>
+  <Hit_def>AB462283.1 Culicoides matsuzawai genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: IS05_6</Hit_def>
+  <Hit_accession>20</Hit_accession>
+  <Hit_len>908</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>542.189</Hsp_bit-score>
+      <Hsp_score>293</Hsp_score>
+      <Hsp_evalue>8.48444e-157</Hsp_evalue>
+      <Hsp_query-from>165</Hsp_query-from>
+      <Hsp_query-to>776</Hsp_query-to>
+      <Hsp_hit-from>299</Hsp_hit-from>
+      <Hsp_hit-to>908</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>527</Hsp_identity>
+      <Hsp_positive>527</Hsp_positive>
+      <Hsp_gaps>44</Hsp_gaps>
+      <Hsp_align-len>633</Hsp_align-len>
+      <Hsp_qseq>AAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCAGTAAAACTAGT----GATTTCG-TGTCGCTAGTATGCATACATCTCTTTCGGGAGGGTATGCATTGATTTTATATCAAGATACTTTGGTGTGATAGTACGAATAGTA-C-ATATAAA-ATAAAAAATATAAGAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCAT-GATATTCACGAAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTCATGCTTGTTGAAAGACATAGTTTGAGTGCATGATGTGATCATA----TG-AATTTTTTCATATATCATTAATAGAGTA-TA---TGGT-TTATACTACTTGCTTACGCGGCATGTTTGACCATTATTTTTATTTAACAAAATAACAAATTTTGGTATAAAATCAAGCGTGTTGTAGGCTG-ACGTAGA-TAAAACTCTTTCTTTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>AAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCC-GTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGCATACA---CTTARTTGA--GTATGCATTGATATTTT-TCATGATACTTTGGTGTGA-AGTACATATTGTACCGATATAAACAAAAAAAAGATCA-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTT-ATCGATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTGTCTTGAAAAAGA-ACATA-AGCGCATGATGTGATTATAAAAGTGTAAAAGCTTT-TATATCACTAATAAAGGAATAAWATGGTGTTTTGCT--TTGCTAA---GGCATATTTAACCATAATTTTTATTTAATATAATATG-AATTTTGGTATAAAATGAATA-TGTC-TAGCTTGGAATTCGCCTAAAAAACCA--TTTATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||||||||||||||||||||| |||||||||||     ||| ||  || |||||||||||||||   |||    ||  |||||||||||| || | ||| ||||||||||||||| |||||  || ||| | ||||||| | |||||| || | ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| || ||||||||| | ||||||||||||||||||||||||||||||||||||||||||||||||||||| |||  | |||||| | | |  |  || |||||||||||| |||    || ||    ||  ||||||| ||||| || | ||   |||| || | ||  ||||| |   ||||| ||| ||||| |||||||||||| | ||||   |||||||||||||||| ||   |||  |||  || |  | |  |||||  |    |||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>150.699</Hsp_bit-score>
+      <Hsp_score>81</Hsp_score>
+      <Hsp_evalue>6.00861e-39</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>163</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>172</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>146</Hsp_identity>
+      <Hsp_positive>146</Hsp_positive>
+      <Hsp_gaps>15</Hsp_gaps>
+      <Hsp_align-len>175</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAA-TATAATGATGTATTCTT-ATA-AA-GTGTATGGTTGTTG-GTTGTTTTG-CAGCGGCCCTT-G-TG-GC-AGCTCRCTATAAAGATGTAGTTTATTAT-GTCTTAAGCGAGTGCTGTGAAA-CAACA</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAAATATAATGATGT-TTCTTTATATAAGGTATATGGTTGTTATGTTGTCTTGTCAACAGCTATTTGATTAGCAAGCTTGCTATAAAGATGTAGTTTATTACGGTCTTAAGTAAGTG-T-TGACAGCAACA</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||||||||||| ||||||||||| ||||| ||| || || ||||||||||  ||||| ||| || | ||  || | |  || ||||  |||||||||||||||||||||  ||||||||  |||| | ||| | |||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>8</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|13</Hit_id>
+  <Hit_def>AB462276.1 Culicoides sumatrae genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: ONYK05_17</Hit_def>
+  <Hit_accession>13</Hit_accession>
+  <Hit_len>784</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>527.415</Hsp_bit-score>
+      <Hsp_score>285</Hsp_score>
+      <Hsp_evalue>2.37574e-152</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>635</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>654</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>551</Hsp_identity>
+      <Hsp_positive>551</Hsp_positive>
+      <Hsp_gaps>53</Hsp_gaps>
+      <Hsp_align-len>671</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTAT-ATT--AAAAAATATAATGATGTATTCTTATAAAGTGTATGGTTGTTGGTTGTTTTGCAGCGGC-CCT--TGTGGCAGC-T----CRCTATAAAGATGTAGTTTATTATGTCTTAAGCGAGTGCT--GTGAAACAACAAAAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCAGTAAAACTAGT----GATTTCG-TGTCGCTAGTATGCATACATCTCTTTCGGGAGGGTATGCATTGATTTTATATCAAGATACTTTGGTGTGATAGTA---CG--AAT-AGTACA--TATA-A-A-AT----AAAAAATA-T-AAGAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATT-TCATGATATTCACGAAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTCATGCTTGTTGAAAGACATAGTTTGAGTGCATGATGTGATCATATGAATTTTTTCATATATCATTAATAGAGTATATG</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATTATTAAAAAAAATATAATGATGT-TTCAT-TCAAG-GTATGGTTGTT-AATCTATTGCAATGGCTATTAATTTAGCAGCTTACACCGCTATAAAGATGTGGTTTATCATATCTTAAGC-ATTCGTAGGTGTTGTGATAGAAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCC-GTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGTATATACTTAATT--GTA---TATGCATTGATATTTT-TCATGATACTTTGGTGTGATAATAAAAAGTAAATCTTTATATTTATATAGAGATAGGAAAAAAAAAGTAAAGAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTATC--GATATTCACGAAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATG-TTATTTAATGGTAACGTAAG-G-GCATGTTGTGATTATATAAGTAAAATTATATATCACTAATAAAGTATATG</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||| |||  ||||||||||||||||| ||| | | ||| |||||||||||   | | |||||  |||   |  | | ||||| |    | |||||||||||| |||||| || |||||||| | |  |  |||     | | ||||||||||||||||||||||||||||||||||||||||||||||||||||||||| |||||||||||     ||| ||  || ||||||||| ||| |  |  ||  | |   ||||||||||| || | ||| ||||||||||||||||| ||    |  |||   || |  |||| | | ||    |||||| | | ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||  ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||| || || || |  |  ||  | | ||||| |||||| |||| | |    | |||||||| ||||| ||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>52.8265</Hsp_bit-score>
+      <Hsp_score>28</Hsp_score>
+      <Hsp_evalue>1.74306e-09</Hsp_evalue>
+      <Hsp_query-from>749</Hsp_query-from>
+      <Hsp_query-to>776</Hsp_query-to>
+      <Hsp_hit-from>757</Hsp_hit-from>
+      <Hsp_hit-to>784</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>28</Hsp_identity>
+      <Hsp_positive>28</Hsp_positive>
+      <Hsp_gaps>0</Hsp_gaps>
+      <Hsp_align-len>28</Hsp_align-len>
+      <Hsp_qseq>TTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>TTATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>9</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|18</Hit_id>
+  <Hit_def>AB462281.1 Culicoides verbosus genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: OKYN05_18</Hit_def>
+  <Hit_accession>18</Hit_accession>
+  <Hit_len>805</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>525.569</Hsp_bit-score>
+      <Hsp_score>284</Hsp_score>
+      <Hsp_evalue>8.54468e-152</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>710</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>732</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>609</Hsp_identity>
+      <Hsp_positive>609</Hsp_positive>
+      <Hsp_gaps>68</Hsp_gaps>
+      <Hsp_align-len>755</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAA-TATAATGATG-T-ATTCTTATAAAGTGTATGGTTGTTGGTTGTTTTGCAGCGGCCCTT---GTGGC-AGCTCRCTATAAAGATGTAGTTTATTATGTCTTAAGCGAGTGCTGTGAAACAACAA------------AAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCAGTAAAACTAGT----GATTTCG-TGTCGCTAGTATGCATACATCTCTTTCGGGAGGGTATGCATTGATTTTATATCAAGATACTTTGG--TGT--G-AT--AGTACGAA-TAGTAC--ATA-TAAAATAAAAAATATAAGAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCATGATATTCACGAAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTCATG-CTTGTTGAAA-GACATAGTTTGAGTGCATGATGTGATCATATGAATTTT-TT-C--ATATATCATTAATAGAG-TATATGGTTTA-TACTACTTGCTTACGCGGCATGTTTGACCATTATTTTTATTTAACA-AAATAACA-AATTTTGGTATAAAAT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAAATATAATGATGTTCATTCATA-AAAG-GTATAACGGTT-GTTGTCTTTCAATGGCTATTCACTTAGCAAGCTTGCTATAAAAATGTAGTTTATTATGTTTTAAGCAAGTGTTGTTAGACAA-AAGGTTGGTTGTTCAAAATTACTTAGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCTAAGGCCCC-GTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGTATATACTTAATT--GTA---TATGCATTGATATTTT-TCATGATACTTTGGAGTGTGAGTATAAAATTAAAATTTGTACAAAAACAAAAACAAAAAAGATCA-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATAAACTAATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTCTT-TAAAATTGAGATA-TA--AGTGCATGATGTGATCATATAAGCTTAATTGCCTATATATCATTAATAAAGGTGGA-GGTATGGTGCTA-TTGTGTA-----CATATTTAACCATCATTTTTATTTAATATAAATAATATAATTTTGGTATAAAAT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||||||||||| |||||||||| | |||| || |||| ||||    ||| ||||| || ||  |||  ||    | || ||||  ||||||| |||||||||||||||| |||||| |||| ||| | |||| ||            |||||| ||| ||||||||||||||||||||||||||||||||||||| |||||||| |||||||||||     ||| ||  || ||||||||| ||| |  |  ||  | |   ||||||||||| || | ||| ||||||||||  |||  | ||  | |   || | ||||  | |  |||| |||||| || | |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||    | |||||||| | ||||||||||||||||||||||||||||||||||||||||||||||||||||| ||| ||| |  ||  || ||| |   |||||||||||||||||||| |  ||  || |  |||||||||||||| || |  | ||| |  | ||| |||  ||     ||| ||| ||||| |||||||||||| | |||||| | ||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>10</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|4</Hit_id>
+  <Hit_def>AB462267.1 Culicoides aterinervis genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: AM05_5</Hit_def>
+  <Hit_accession>4</Hit_accession>
+  <Hit_len>891</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>520.029</Hsp_bit-score>
+      <Hsp_score>281</Hsp_score>
+      <Hsp_evalue>3.97545e-150</Hsp_evalue>
+      <Hsp_query-from>165</Hsp_query-from>
+      <Hsp_query-to>776</Hsp_query-to>
+      <Hsp_hit-from>276</Hsp_hit-from>
+      <Hsp_hit-to>891</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>530</Hsp_identity>
+      <Hsp_positive>530</Hsp_positive>
+      <Hsp_gaps>54</Hsp_gaps>
+      <Hsp_align-len>641</Hsp_align-len>
+      <Hsp_qseq>AAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCAGTAAAACTAGT----GATTTCG-TGTCGCTAGTATGCATACATCTCTTTCGGGAGGGTATGCATTGATTTTATATCAAGATACTTTGG--TGTG-ATAGTAC--GAATAGTACAT--ATAA-AATAAAAAATATA-A-G-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCATGATATTCACGAAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTCATGCTTGTTGAAAGACATAGTTTGAGTGCATGATGTGATCATAT-GA-ATTTT-T-T-C--ATATATCATTAATAGAGTATATGGTTT-A--TACTACTTGCT-TACGCGGCATGTTTGACCATTATTTTTATTTAACAAAATAACAAATTTTGGTATAAAATCAAGCGTGTTGTAGGCT-GACGTAGATAA-AACTCTTTCTTTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>AAAATTTCTTAGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCTAAGGCCCC-GTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGCATACA---C-TT-AGTTGTGTATGCATTGATATTTT-TCATGATACTTTGGAGTGAGTATAATACAAAAATTGTACATAAATAATAATAAAAAAAAAAGATGAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTATAATATTTT-TGATATTCATAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATG-T-GTTTTAC-ACGTA-----AGTGCATGATGTGATCATATAGGTACTTTGTGTACTTATATATCATTAATAAAGG-TGTGGTAACAAATA-TACTTGATATAAGCGT-A--TTTGACCATTATTTTTATTTAATTTAATATG-AATTTTGGTTTAAA-TCAAATATGT-GTAT-CTCGTTGTTGTTTATAACTCTAACATTATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>|||||||||| ||||||||||||||||||||||||||||||||||||| |||||||| |||||||||||     ||| ||  || |||||||||||||||   | ||  |  | |||||||||||| || | ||| ||||||||||  || | ||| |||   ||| ||||||  |||| ||||||||| | | | | |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||||||||  |||||||||  | ||||||||||||||||||||||||||||||||||||||||||||||||||||| ||| | |||  |  || ||     |||||||||||||||||||| |  | ||| | | |  |||||||||||||| ||  | ||||   |  || |||||| | || |||  |  ||||||||||||||||||||||   ||||   ||||||||| |||| ||||   ||| |||  || |  || | | | ||||||  | ||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>132.232</Hsp_bit-score>
+      <Hsp_score>71</Hsp_score>
+      <Hsp_evalue>2.17642e-33</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>160</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>160</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>134</Hsp_identity>
+      <Hsp_positive>134</Hsp_positive>
+      <Hsp_gaps>8</Hsp_gaps>
+      <Hsp_align-len>164</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAATATAATGATGTATTCTTATAAAGTGTATGGTTGTTGGTTGTT-TTGCAGCGGC-CCTT-G-TGGCAGCTCRCTATAAAGATGTAGTTTATTATGTCTTAAGCGAGTGCTGTGAAACA</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATA--AAAATATATAATGATGT-TCATTCTAAGGT-TGTGGATGTATGTTGTTATTGTAACAGCTATTTAGTTAGCAGCTTGCTATAAAGATGTAGTTTATTATGTCTTAAGTAAGTGTTATGATACA</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||||  |||| |||||||||||| |  || ||| || | ||| |||  |||||| ||| | | ||   || | | ||||||  ||||||||||||||||||||||||||||||  |||| | ||| |||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>11</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|9</Hit_id>
+  <Hit_def>AB462272.1 Culicoides nipponensis genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Isg22</Hit_def>
+  <Hit_accession>9</Hit_accession>
+  <Hit_len>794</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>514.489</Hsp_bit-score>
+      <Hsp_score>278</Hsp_score>
+      <Hsp_evalue>1.8496e-148</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>602</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>607</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>524</Hsp_identity>
+      <Hsp_positive>524</Hsp_positive>
+      <Hsp_gaps>57</Hsp_gaps>
+      <Hsp_align-len>633</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAATATAATGATGT--ATTCTTATAAAGTGT-ATGGTTGTTGGTTGTT-TTGCAGCGGC--CCT-TGTGGCAGC-T-CRCTATAAAGATGTAGTTTATTATGTC-T-TA--AGCGAG--TGCTGTGA-AACAACAAA-------AAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCAGTAAAACTAGT----GATTTCG-TGTCGCTAGTATGCATACATCTCTTTCGGGAGGGTATGCATTGATTTTATATCAAGATACTTTGGTGTGATAGTACGAATAGTACATATAAAATAAAAAATATAAGAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATAT-TTCATGATATTCACGAAG-TCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTCATGC-TTGTTGAAAGACATAGTTTGAGTGCATGATGTGATCATAT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATTATAAAAAATATAATGATGTTCATTC-TAT-TAGTGTAATGG-TGTT-ATTATTATTACAATTGCAATATATTTTGCAGCTTACAC-A-AAAGATGTAGTTTATTATATCATATATGTGCAAGTATATTGTAATAATAAAAGAGTTGGTTAAATTTCTTGGGTAGCTTTATTGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCC-GTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGTATATAT-TCATTT---A---TATACATTGATATTTT-TCATGATACTTTGGATTGATA-T--G-ATAAAACAAACAAAA-AAAAAGTGTAAGAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATATTTTTGATATTCAC-AAGATCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTGTGTTTTGTCAAAAGACATA-----AGTGCATGATGTGATTATAT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||  ||||||||||||||||||  |||| |||  ||||| |||| ||||  || || || ||   ||    | | | ||||| | | | | |||||||||||||||||| || | ||   || ||  |  ||| | || || | |       ||||||||||||||||||||| |||||||||||||||||||||||||||||||||| |||||||||||     ||| ||  || ||||||||| ||| || || ||    |   ||| ||||||| || | ||| ||||||||||  ||||| |  | |||  ||| | |||| ||||| | ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||  |||||||||| ||| ||||||||||||||||||||||||||||||||||||||||||||||||||||  ||  ||||  |||||||||     ||||||||||||||| ||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>65.753</Hsp_bit-score>
+      <Hsp_score>35</Hsp_score>
+      <Hsp_evalue>2.23889e-13</Hsp_evalue>
+      <Hsp_query-from>663</Hsp_query-from>
+      <Hsp_query-to>776</Hsp_query-to>
+      <Hsp_hit-from>682</Hsp_hit-from>
+      <Hsp_hit-to>794</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>94</Hsp_identity>
+      <Hsp_positive>94</Hsp_positive>
+      <Hsp_gaps>13</Hsp_gaps>
+      <Hsp_align-len>120</Hsp_align-len>
+      <Hsp_qseq>TTTGACCATTATTTTTATTTAA--CAA-AATAACAAATTTTGGTATAAAATC-AAGCGTGT-TGTAG-GCTGACGTAGATAAAACTCTTTCTTTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>TTTGACCATTATTTTTATTTAAATTAATAATAA-ATATTTTGGT-TTAAATCAAATGGTATATG-AGAGAAAAAGT-G-TTATA-T-TTTTTTTATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||   || ||||| | |||||||| | ||||| ||  || | || || |   | || | | | | | ||| |||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>12</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|19</Hit_id>
+  <Hit_def>AB462282.1 Culicoides humeralis genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Kag15_1</Hit_def>
+  <Hit_accession>19</Hit_accession>
+  <Hit_len>912</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>499.716</Hsp_bit-score>
+      <Hsp_score>270</Hsp_score>
+      <Hsp_evalue>5.17908e-144</Hsp_evalue>
+      <Hsp_query-from>165</Hsp_query-from>
+      <Hsp_query-to>602</Hsp_query-to>
+      <Hsp_hit-from>296</Hsp_hit-from>
+      <Hsp_hit-to>739</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>398</Hsp_identity>
+      <Hsp_positive>398</Hsp_positive>
+      <Hsp_gaps>28</Hsp_gaps>
+      <Hsp_align-len>455</Hsp_align-len>
+      <Hsp_qseq>AAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCAGTAAAACTAGT----GATTTCG-TGTCGCTAGTATGCATACATCTCTTTCGGGAGGGTATGCATTGATTTTATATCAAGATACTTTGGTGTG---ATAGTACGAATAGTACATA--TAA-AATAAAAAA-TATAAGAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCAT-GATATTCACGAAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTCATGCTTGT-T-GAAA--GACATAGTTTGAGTGCATGATGTGATCATAT</Hsp_qseq>
+      <Hsp_hseq>AAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCC-GTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGCATACA---CTTAATTGA--GTATGCATTGATATTTT-TCATGATACTTTGGTGTGAGTATAATTTGTATTGTACATAAACAAGAAAAAAAAACGATCA-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTT-ATCGATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTGTGTCTTGAAAAAGACATCATA--AGTGCATGATGTGATTATAT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||||||||||||||||||||| |||||||||||     ||| ||  || |||||||||||||||   |||    ||  |||||||||||| || | ||| ||||||||||||||   ||| |  | || |||||||   || || ||||||  || | ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| || ||||||||| | ||||||||||||||||||||||||||||||||||||||||||||||||||||| |||  ||| | ||||  |||||  |   ||||||||||||||| ||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>141.466</Hsp_bit-score>
+      <Hsp_score>76</Hsp_score>
+      <Hsp_evalue>3.61625e-36</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>144</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>152</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>130</Hsp_identity>
+      <Hsp_positive>130</Hsp_positive>
+      <Hsp_gaps>14</Hsp_gaps>
+      <Hsp_align-len>155</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAA-TATAATGATGTATTC--T-TATA-AA-GTGTATGGTTGTTGGTTGTTTTG-CAGCGGCCCTT-G--TGGC-AGCTCRCTATAAAGATGTAGTTTATTATGTCTTAAG</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAAATATAATGATGT-TTCTTTATATATAAGGTATATGGTT-AT-GTTGTCTTGTCAAYRGCTATTYGATTAGCAAGCTTGCTATAAAGATGTAGTTTATTATGTCTTAAG</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||||||||||| ||||||||||| |||  | |||| || || |||||||  | ||||| ||| ||   ||  || |  | || ||||  ||||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>3</Hsp_num>
+      <Hsp_bit-score>52.8265</Hsp_bit-score>
+      <Hsp_score>28</Hsp_score>
+      <Hsp_evalue>1.74306e-09</Hsp_evalue>
+      <Hsp_query-from>749</Hsp_query-from>
+      <Hsp_query-to>776</Hsp_query-to>
+      <Hsp_hit-from>885</Hsp_hit-from>
+      <Hsp_hit-to>912</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>28</Hsp_identity>
+      <Hsp_positive>28</Hsp_positive>
+      <Hsp_gaps>0</Hsp_gaps>
+      <Hsp_align-len>28</Hsp_align-len>
+      <Hsp_qseq>TTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>TTATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>13</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|15</Hit_id>
+  <Hit_def>AB462278.1 Culicoides erairai genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: IS05_2</Hit_def>
+  <Hit_accession>15</Hit_accession>
+  <Hit_len>931</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>496.022</Hsp_bit-score>
+      <Hsp_score>268</Hsp_score>
+      <Hsp_evalue>6.69957e-143</Hsp_evalue>
+      <Hsp_query-from>165</Hsp_query-from>
+      <Hsp_query-to>710</Hsp_query-to>
+      <Hsp_hit-from>309</Hsp_hit-from>
+      <Hsp_hit-to>868</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>478</Hsp_identity>
+      <Hsp_positive>478</Hsp_positive>
+      <Hsp_gaps>40</Hsp_gaps>
+      <Hsp_align-len>573</Hsp_align-len>
+      <Hsp_qseq>AAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCAGTAAAACTAGT----GATTTCG-TGTCGCTAGTATGCATACATCTCTT-TCGGGAGGGTATGCATTGATTTTATATCAAGATACTTTGGTGTGATAGTACGAATA-GTAC--ATAT-AAAA--T-AAAAAATATAAGAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCATGATATTCACGAAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTCATGCTTGTT--GA-AAGACATA-GTTTG--AGTGCATGATGTGATCATAT-GA--ATTTTT-TC-ATATATCATTAATAGAGTA-TATGGT-T-TATACTACTTGCTTACGCGGCATGTTTGACCATTATTTTTATTTAACAAAATAACAAATTTTGGTATAAAAT</Hsp_qseq>
+      <Hsp_hseq>AAAATTTCTTAGGTAGCTTTATTGAAGAGCTTTAAAGACTTGTATGCCTAAGGCCCC-GTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGCATATAT-TTTAATC--G-GTGTATGCATTGATATTTT-TCATGATACTTTGGTGTGATATTTTGTATATTTACAAATGTAAAAATGTAAAAAAAGAGATCAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTACT--TATTCACAAAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTGTGATTTTTCTGGTGAAACAGAAGCTTACAAGTGCATGATGTGATCATATAGATGATTTCTGTCTATATATCATTAATAAAGTGGTATGATATGTGTACTAAA-G-TTGTGTTGCATATTTAACCATAATTTTTATTTAATAATATT---AATTTTGGTATAAAAT</Hsp_hseq>
+      <Hsp_midline>|||||||||| ||||||||||| |||||||||||||||||||| |||| |||||||| |||||||||||     ||| ||  || ||||||||||||| || | |  ||  | | |||||||||||| || | ||| ||||||||||||||||| |  | |||  |||  || | ||||  | |||||| | |  |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  |  ||||||| |||||||||||||||||||||||||||||||||||||||||||||||||||||||  || || ||  |   | ||| | | ||   |||||||||||||||||||| ||  |||| | || |||||||||||||| |||  |||| | | | |||||   | ||  |  |||| ||| ||||| |||||||||||| || ||    ||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>154.392</Hsp_bit-score>
+      <Hsp_score>83</Hsp_score>
+      <Hsp_evalue>4.64494e-40</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>169</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>175</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>149</Hsp_identity>
+      <Hsp_positive>149</Hsp_positive>
+      <Hsp_gaps>14</Hsp_gaps>
+      <Hsp_align-len>179</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATAT--TAAAAAATATAATGATGTATTCTTATA-AAGTGTATGGTTGTTGGTTGTTTTG-CAGCG---GCC--CTTGTGGCAGCTCRCTATAAAGATGTAGTTTATTATGTCTTAAGCGAGTGCTG-TGAAACAACAAAAAAT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTATAAAAAATATAATGATGTATCATTCTATAAGTGTATGGTGGTTG-TTGTTTCGACAGCTAAAGTTTACTT-TAGCAGCCTACTATAAAGATGTAGTTTATTATGTCTTAAGT-A-TGGTGTTGATTCAACAAAAAAT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||||  ||||||||||||||||||||  || || ||||||||||| |||| |||||| | ||||    |    ||| | |||||   ||||||||||||||||||||||||||||||  | || || |||  |||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>14</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|3</Hit_id>
+  <Hit_def>AB462266.1 Culicoides japonicus genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Ngs24_1</Hit_def>
+  <Hit_accession>3</Hit_accession>
+  <Hit_len>925</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>492.329</Hsp_bit-score>
+      <Hsp_score>266</Hsp_score>
+      <Hsp_evalue>8.66644e-142</Hsp_evalue>
+      <Hsp_query-from>165</Hsp_query-from>
+      <Hsp_query-to>710</Hsp_query-to>
+      <Hsp_hit-from>316</Hsp_hit-from>
+      <Hsp_hit-to>854</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>471</Hsp_identity>
+      <Hsp_positive>471</Hsp_positive>
+      <Hsp_gaps>41</Hsp_gaps>
+      <Hsp_align-len>563</Hsp_align-len>
+      <Hsp_qseq>AAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCAGTAAAACTAGT----GATTTCG-TGTCGCTAGTATGCATACATCTCTTTCGGGAGGGTATGCATTGATTTTATATCAAGATACTTTGGTGTGAT---AGTACGAATAGTACAT-ATAAAAT-AAAAAA-T-ATAAGAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATAT-TTCATGATATTCACGAAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTCATGCTTGTTGAAAGACATAGTTTGAGTGCATGATGTGATCATATGAATTTT-TT-C--ATATATCATTAATAGAGTATATGGTTTATACTACTTGCTTACGCGGCATGTTTGACCATTATTTTTATTTAACAAAATAACAAATTTTGGTATAAAAT</Hsp_qseq>
+      <Hsp_hseq>AAAATTACTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCC-GTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATG--TATAT-AC-TT-AGTTGTATATGCATTGATATTTT-TCATGATACTTTGGTGTGATTTTTGTA-AAACAAAATATAATAAAATAAAAAAATTGATCA-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATATTACT--TATTCACAAAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTTTGTTG-----CATA-----AGTGCATGATGTGATCATATAAGCTTTATTGCTTATATATCATTAATAAAGG-TGTGATAAATGGTACAAAA-TACTTTGCATATTTAACCATTATTTTTATTTAACATGAAAAT-AATTTTGGTATAAAAT</Hsp_hseq>
+      <Hsp_midline>|||||| |||||||||||||||||||||||||||||||||||||||||||||||||| |||||||||||     ||| ||  || |||||||||  || ||  | ||  |  |  ||||||||||| || | ||| ||||||||||||||||    |||  || |  | || ||||||| |||||| | || | ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||  |  ||||||| ||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||| ||||||     ||||     |||||||||||||||||||| |  ||| || |  |||||||||||||| ||  | || |  ||  |||     |||   |||| ||| ||||||||||||||||||||  | ||  ||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>126.692</Hsp_bit-score>
+      <Hsp_score>68</Hsp_score>
+      <Hsp_evalue>1.01259e-31</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>156</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>170</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>139</Hsp_identity>
+      <Hsp_positive>139</Hsp_positive>
+      <Hsp_gaps>16</Hsp_gaps>
+      <Hsp_align-len>171</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATT-AAAAAATATAATGATGTATT-CTTATA--AAGTGTA-TGGTTGTTGGTTGT-T-TTGCAGCGGCC-CT-TGTG------GCAGCTCRCTATAAAGATGTAGTTTATTATGTCTTAAGCGAGTGCTGTGA</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAAATATAATGATGTATCACTTATATTAAG-GTATTGGTTGTTTATTGTGTGTTGAAGCAGCAGCTATTTTAATATAGCAGCTTACTATAAAAATATAGTTTATTATATTTTAAGTAAGTGCTGTGA</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||||| |||||||||||||||||||  ||||||  ||| ||| ||||||||  |||| | ||| ||| ||  || | |       ||||||  ||||||| || ||||||||||| | |||||  ||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>15</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|16</Hit_id>
+  <Hit_def>AB462279.1 Culicoides oxystoma genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Naha16_1</Hit_def>
+  <Hit_accession>16</Hit_accession>
+  <Hit_len>796</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>468.323</Hsp_bit-score>
+      <Hsp_score>253</Hsp_score>
+      <Hsp_evalue>1.4605e-134</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>557</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>572</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>483</Hsp_identity>
+      <Hsp_positive>483</Hsp_positive>
+      <Hsp_gaps>45</Hsp_gaps>
+      <Hsp_align-len>587</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATT--AAAAA-ATATAATGATGTATTCTTATAAAGTGTATGGTTGTTGGTTGTTTTGCAGCGGC-CCTTGT---GGCAGCTCRCTATAAAGATGTAGTTTATTATGTCTTAAGCGAGTGC-TGTGA-AACAACAAAAAAT-TTCTTGGGTAGCTTT-ATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCAGTAAAACTAGT----GATTTCG-TGTCGCTAGTATGCATA-CATCTCTTTCGGGAGGGTATGCATTGATTTTATATCAAGATACTTTGGTGTGA--TAG--TACGAATAGTACATATAA-AAT-AAAAAA-T-ATAAGAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTG-T-AATATT-TCA-TGAT-ATTCACGAAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTA-ATTAAAAAAACATATAATGATGT-TTC--AT-AAG-GTATGG-TGTTGTTAATATGGTAGTGTCGTCTTGTCACGACAGCTTGTTATAAAGATGTAGTTTATTATGTCTTAAACAAGTCAATATCATATTAACGCAAAATAATCTTAGGTAGCTTTTATGTAAGAGCTTTAAAGACTTTTTTGCCTAAGGCCCC-GTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGTATATAATACCTTGC-GTATTGTATGCATTGATTTT---TCATGATATTAATGTGTGATGTTGTTTATGCAAA--ACAATTAATAATAAAAAAATTGATCA-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCTAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATACGATTAGATTTTGATTAATAATCTCAATGATAATTGACAAAATCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||| |||  ||||| |||||||||||| |||  || ||| |||||| ||||| |  | | | || | |  |||||   | |||||   |||||||||||||||||||||||||||| | |||   | | | |  |||  |||||  |||| ||||||||| ||  ||||||||||||||||| |||||| |||||||| |||||||||||     ||| ||  || ||||||||| |||  ||  ||| | | |  |||||||||||||||   ||| |||| |   ||||||  | |  || | | |  |||  ||| ||| |||||| | || | ||||||||||||||||||||||||||||||||||||||||||||||||||| ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||||||||||||| | |||| | ||| |||| ||| || || ||||||||||||||||||||||||||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>16</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|6</Hit_id>
+  <Hit_def>AB462269.1 Culicoides cylindratus genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Kag08, long type</Hit_def>
+  <Hit_accession>6</Hit_accession>
+  <Hit_len>820</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>457.243</Hsp_bit-score>
+      <Hsp_score>247</Hsp_score>
+      <Hsp_evalue>3.16142e-131</Hsp_evalue>
+      <Hsp_query-from>165</Hsp_query-from>
+      <Hsp_query-to>776</Hsp_query-to>
+      <Hsp_hit-from>234</Hsp_hit-from>
+      <Hsp_hit-to>820</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>505</Hsp_identity>
+      <Hsp_positive>505</Hsp_positive>
+      <Hsp_gaps>49</Hsp_gaps>
+      <Hsp_align-len>624</Hsp_align-len>
+      <Hsp_qseq>AAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCAGTAAAACTAGTGATTTCGTGTCGCTAGTATGCATACATCTCTTTCGGGAGGGTATGCATTGATTTTATATCAAGATACTTTGG--TGTG-ATAGTAC--GAATAGTACAT-ATA-AAATAAAAAATATAAGAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCATGATATTCACGAAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTCATGCTTGTTGAAAGACATAGTTTGAGTGCATGATGTGATCATATGAATTTTTTCATATATCATTAATAGAGTATATGGTTT-A--TACTACTTGCTTACGCGGCATGTTTGACCATTATTTTTATTTAACAAAATAACAAATTTTGGTATAAAATCAAGCGTGTTGTAGGCT-GACGTAGAT-AAAACTCTTTCTTTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>AAAATTTCTTAGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCTAAGGCCCC-GTAAAACTAGT-AACCCAT-T-GCGAGGTGGC-T--A---GTAT--GCA---TATGCATTGATATTTT-TCATGATACTTTGGAGTGAGTATAATACAAAAATTGTACATAAAACAAATAAAAAAGATCA-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTATAATATTTT-TGATATTCATAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATG-T-GTKTWAAWACRTA-----AGTGCATGATGTGATCATAAAAGTCTACTTTTATATCATTAAT-GA--AGGTGGTAACAAATA-TACTTGAT-AYMA-GCGTRTTTGACCATTATTTTTATTTAATTTAATATG-AATTTTGGTTTAAA-TCAAATATGT-GTAT-CTCGTTGTTGTTTATAAATAA--CTTTATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>|||||||||| ||||||||||||||||||||||||||||||||||||| |||||||| ||||||||||| |   | | | || ||   || |  |    | |  | |   ||||||||||| || | ||| ||||||||||  || | ||| |||   ||| |||||| | | |||||||||| || | |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||||||||  |||||||||  | ||||||||||||||||||||||||||||||||||||||||||||||||||||| ||| | ||   || || ||     |||||||||||||||||||  | | |  |  |||||||||||| ||  |  ||||   |  || |||||| | |    || | ||||||||||||||||||||||   ||||   ||||||||| |||| ||||   ||| |||  || |  || | | | || |    ||||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>108.226</Hsp_bit-score>
+      <Hsp_score>58</Hsp_score>
+      <Hsp_evalue>3.66778e-26</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>58</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>58</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>58</Hsp_identity>
+      <Hsp_positive>58</Hsp_positive>
+      <Hsp_gaps>0</Hsp_gaps>
+      <Hsp_align-len>58</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAATATAATGATGT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAATATAATGATGT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>17</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|8</Hit_id>
+  <Hit_def>AB462271.1 Culicoides lungchiensis genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: AM05_8</Hit_def>
+  <Hit_accession>8</Hit_accession>
+  <Hit_len>776</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>449.856</Hsp_bit-score>
+      <Hsp_score>243</Hsp_score>
+      <Hsp_evalue>5.29018e-129</Hsp_evalue>
+      <Hsp_query-from>166</Hsp_query-from>
+      <Hsp_query-to>626</Hsp_query-to>
+      <Hsp_hit-from>182</Hsp_hit-from>
+      <Hsp_hit-to>650</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>408</Hsp_identity>
+      <Hsp_positive>408</Hsp_positive>
+      <Hsp_gaps>34</Hsp_gaps>
+      <Hsp_align-len>482</Hsp_align-len>
+      <Hsp_qseq>AAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCAGTAAAACTAGT----GATTTCG-TGTCGCTAGTATG--CATACATCTCTTTCGGGAGGGTATGCATTGATTTTATATCAAGATACTTTGGTGT---G------ATAGTACGAA-TAGTACATATAAAATAAAAAATATAAGAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCATGATATTCACGAAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTCATGCTTGTTGAAAGACATA-GTT--TGA-GTGCATGATGTGATCATATGAATTTTTTCATATATCATTAATA</Hsp_qseq>
+      <Hsp_hseq>AAATTACTTGGGTAGCTTTATTGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCC-GTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGTATATACATTTATTT--GTA---TATACATTGATATTTTTTCATGATACTTTGGTATAAAGAAAAAAAAAGTACAATTTTGTACATATAAAA-AAAAAAGAT-CTAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTT-TGATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTTCCTTTTA---CATAAGTGCATGATGTG-ATTATATGAAAATATTATATTTTTCATATATCATTAATA</Hsp_hseq>
+      <Hsp_midline>||||| ||||||||||||||| |||||||||||||||||||||||||||||||||| |||||||||||     ||| ||  || |||||||||   |||||| | |||  | |   ||| ||||||| || | ||| ||||||||||| |   |      | ||||| |  | |||||||||||| |||||| ||   |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  |||||||||| | ||||||||||||||||||||||||||||||||||||||||||||||||||||| ||| |  ||  |   |||| ||   ||| ||| || || |||  |||| |  ||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>91.6061</Hsp_bit-score>
+      <Hsp_score>49</Hsp_score>
+      <Hsp_evalue>3.69382e-21</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>82</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>83</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>76</Hsp_identity>
+      <Hsp_positive>76</Hsp_positive>
+      <Hsp_gaps>9</Hsp_gaps>
+      <Hsp_align-len>87</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTAT-ATTAAAAAA-TATAATGATGTATTCT-T-ATAAAGTGT-ATGGTTGTT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATTAAAAAAAAAATATAATGATGT-T-CTATCATAA-GTGTTATGGT-GTT</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||| |  |||||| ||||||||||| | || | |||| |||| ||||| |||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>3</Hsp_num>
+      <Hsp_bit-score>56.5198</Hsp_bit-score>
+      <Hsp_score>30</Hsp_score>
+      <Hsp_evalue>1.34747e-10</Hsp_evalue>
+      <Hsp_query-from>744</Hsp_query-from>
+      <Hsp_query-to>776</Hsp_query-to>
+      <Hsp_hit-from>744</Hsp_hit-from>
+      <Hsp_hit-to>776</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>32</Hsp_identity>
+      <Hsp_positive>32</Hsp_positive>
+      <Hsp_gaps>0</Hsp_gaps>
+      <Hsp_align-len>33</Hsp_align-len>
+      <Hsp_qseq>TTTCTTTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>TTTATTTATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>||| |||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>18</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|2</Hit_id>
+  <Hit_def>AB462265.1 Culicoides arakawae genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Kag02</Hit_def>
+  <Hit_accession>2</Hit_accession>
+  <Hit_len>907</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>444.316</Hsp_bit-score>
+      <Hsp_score>240</Hsp_score>
+      <Hsp_evalue>2.46128e-127</Hsp_evalue>
+      <Hsp_query-from>165</Hsp_query-from>
+      <Hsp_query-to>601</Hsp_query-to>
+      <Hsp_hit-from>303</Hsp_hit-from>
+      <Hsp_hit-to>742</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>385</Hsp_identity>
+      <Hsp_positive>385</Hsp_positive>
+      <Hsp_gaps>25</Hsp_gaps>
+      <Hsp_align-len>451</Hsp_align-len>
+      <Hsp_qseq>AAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCAGTAAAACTAGT----GATTTCG-TGTCGCTAGTATGCATACATCTCTTTCGGGAGGGTATGCATTGATTTTATATCAAGATACTTTGGTGTGATA--GTACGAATAGTAC-A-----TA-TAAAATAAAAAATATAAGAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCATGATATTCACGAAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTCATGCTTGTTGAAAGACATAGTTTGAGTGCATGATGTGATCATA</Hsp_qseq>
+      <Hsp_hseq>AAAATTACTTAGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCTAAGG-CCCTGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGTATATACTTAATT--GTA---TATGCATTGATATTTT-TCATGATACTTTGGTGTGATATAATAAAAAT-GTACAATTTTGTACTAATAAAAAAAAGATCA-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATAA-ATAATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATATTATTTGAAAAAG-TAATATAAGTGCATGATGTGATTATA</Hsp_hseq>
+      <Hsp_midline>|||||| ||| ||||||||||||||||||||||||||||||||||||| |||| ||| |||||||||||     ||| ||  || ||||||||| ||| |  |  ||  | |   ||||||||||| || | ||| |||||||||||||||||   ||  ||| |||| |     || ||| | |||||| || | |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||   || |||||||| | ||||||||||||||||||||||||||||||||||||||||||||||||||||| ||  |  |||||| |  || | | ||||||||||||||| |||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>111.919</Hsp_bit-score>
+      <Hsp_score>60</Hsp_score>
+      <Hsp_evalue>2.83537e-27</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>82</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>81</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>78</Hsp_identity>
+      <Hsp_positive>78</Hsp_positive>
+      <Hsp_gaps>7</Hsp_gaps>
+      <Hsp_align-len>85</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAA-TATAATGATGT--ATTCTTATAAAGTGTATGGTTGTT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAAATATAATGATGTTCATTC--ATAA-G-GTATGGTTGTT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||||||||||| |||||||||||  ||||  |||| | |||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>19</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|11</Hit_id>
+  <Hit_def>AB462274.1 Culicoides peregrinus genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Yng26</Hit_def>
+  <Hit_accession>11</Hit_accession>
+  <Hit_len>794</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>435.083</Hsp_bit-score>
+      <Hsp_score>235</Hsp_score>
+      <Hsp_evalue>1.48131e-124</Hsp_evalue>
+      <Hsp_query-from>167</Hsp_query-from>
+      <Hsp_query-to>634</Hsp_query-to>
+      <Hsp_hit-from>190</Hsp_hit-from>
+      <Hsp_hit-to>675</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>417</Hsp_identity>
+      <Hsp_positive>417</Hsp_positive>
+      <Hsp_gaps>42</Hsp_gaps>
+      <Hsp_align-len>498</Hsp_align-len>
+      <Hsp_qseq>AATTTCTTGGGTAGCTTTA--TAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCAGTAAAACTAGT----GATTTCG-TGTCGCTAGTATGCATACATCTCTTTCGGGAGGGTATGCATTGATTTTA-TATCAAGATACTTTGGTGTGA--T--AG---TACG-A--A--TAGTACATAT-AAAATAAAAAATATAAGAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCATGATATTCACGAAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTCATGCTTGTTGAAAGACATAGTTTGAGTGCATGATGTGATCATATGA---------ATTTTTTCATATATCATTAATAGAGTATAT</Hsp_qseq>
+      <Hsp_hseq>AATTTCTTGGGTAGCTTTAATTTTAAGAGCTTTAAAGACTTTTTTGCCCAAGGCCCC-GTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGTATATACTTAATT--GTA---TATACATTGATATTATTTTCATGATACTTTGGTGTGAAATAAAGTTATAAGTACTATTTTGTACATATAAAAAAAAAAAAGAT-CTAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCMTGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTT-TGATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATATTTTTTTAATAAAATA-TA--AGTGCATGATGTGATTATATGAAAATGTAATATTTTTTCATATATCATTAATAAA-TATAT</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||  |  ||||||||||||||||| ||||||||||||||| |||||||||||     ||| ||  || ||||||||| ||| |  |  ||  | |   ||| ||||||| ||| | ||| |||||||||||||||  |  ||   || | |  |  | |||||||| |||| |||||| ||   |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  |||||||||| | ||||||||||||||||||||||||||||||||||||||||||||||||||||| ||  || || ||  | ||| |   ||||||||||||||| ||||||         |||||||||||||||||||||| | |||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>106.379</Hsp_bit-score>
+      <Hsp_score>57</Hsp_score>
+      <Hsp_evalue>1.31917e-25</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>82</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>87</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>79</Hsp_identity>
+      <Hsp_positive>79</Hsp_positive>
+      <Hsp_gaps>7</Hsp_gaps>
+      <Hsp_align-len>88</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATAT-T-AAAAAATATAATGATGTA-T-TC-TTATAAAGTGT-ATGGTTGTT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATATAAAAAAATATAATGATGTTCTCTCATTAAAAAGTGTTATGGT-GTT</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||||| | |||||||||||||||||  | || ||| ||||||| ||||| |||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>3</Hsp_num>
+      <Hsp_bit-score>58.3664</Hsp_bit-score>
+      <Hsp_score>31</Hsp_score>
+      <Hsp_evalue>3.74646e-11</Hsp_evalue>
+      <Hsp_query-from>660</Hsp_query-from>
+      <Hsp_query-to>776</Hsp_query-to>
+      <Hsp_hit-from>687</Hsp_hit-from>
+      <Hsp_hit-to>794</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>92</Hsp_identity>
+      <Hsp_positive>92</Hsp_positive>
+      <Hsp_gaps>13</Hsp_gaps>
+      <Hsp_align-len>119</Hsp_align-len>
+      <Hsp_qseq>ATGTTTGACCATTATTTTT-ATTTAA-CAAAATAACAAATTTTGGTATAAAATCAAGCGTGTTGTAGGCTGACGTAGATAAAACTCTTTCTTTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>ATATTTGACCATTATTTTTTATTTAATTAAAATAA-TAATATTGGT-TTAAATCAA--AT-ATATA--TTGA-G-AAAT-ATTGT-TTTATTTATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>|| |||||||||||||||| ||||||  |||||||  ||| ||||| | |||||||   |  | ||   ||| | | || |   | ||| |||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>20</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|10</Hit_id>
+  <Hit_def>AB462273.1 Culicoides ohmorii genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Kag05</Hit_def>
+  <Hit_accession>10</Hit_accession>
+  <Hit_len>825</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>429.543</Hsp_bit-score>
+      <Hsp_score>232</Hsp_score>
+      <Hsp_evalue>6.89186e-123</Hsp_evalue>
+      <Hsp_query-from>166</Hsp_query-from>
+      <Hsp_query-to>606</Hsp_query-to>
+      <Hsp_hit-from>202</Hsp_hit-from>
+      <Hsp_hit-to>662</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>396</Hsp_identity>
+      <Hsp_positive>396</Hsp_positive>
+      <Hsp_gaps>36</Hsp_gaps>
+      <Hsp_align-len>469</Hsp_align-len>
+      <Hsp_qseq>AAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCAGTAAAACTAGT----GATTTCG-TGTCGCTAGTATGCATACATCTCTTTCGGGAGGGTATGCATTGATTTTATATCAAGATACTTTGGTGTG--AT-A-GT---------A-C-GAATA-GTACAT--ATA-AAATAAAAAATATAAG-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCATGATATTCACGAAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTCATGCTTGTTG-AAAGACAT--AGTTTGAGTGCATGATGTGATCATATGAAT</Hsp_qseq>
+      <Hsp_hseq>AAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCC-GTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGTATATACTTAATT--GTA---TATGCATTGATATTTT-TCATGATACTTTGGTGTGTGATAATATAAAAAAAAAATCTTTATATTTATATAGAGAGAAAAAAAAAAAATAAGAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTT-TGATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTTATTTGTAAAAAAAAGAAGCATAAGTGCATGATGTGATTATATAAAT</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||||||||||||||||||||| |||||||||||     ||| ||  || ||||||||| ||| |  |  ||  | |   ||||||||||| || | ||| ||||||||||||||  || |  |         | |   |||  || ||  | | ||| |||||| ||||| |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  |||||||||| | ||||||||||||||||||||||||||||||||||||||||||||||||||||| ||| |  ||| ||| | |   ||  | ||||||||||||||| |||| |||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>89.7595</Hsp_bit-score>
+      <Hsp_score>48</Hsp_score>
+      <Hsp_evalue>1.32853e-20</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>67</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>71</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>64</Hsp_identity>
+      <Hsp_positive>64</Hsp_positive>
+      <Hsp_gaps>4</Hsp_gaps>
+      <Hsp_align-len>71</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTAT-ATTA-AAAAATATAATGATGT--ATTCTTATA</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATTAACATAAAAATATAATGATGTTCATTCATATA</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||| |  | ||||||||||||||||  |||| ||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>3</Hsp_num>
+      <Hsp_bit-score>54.6731</Hsp_bit-score>
+      <Hsp_score>29</Hsp_score>
+      <Hsp_evalue>4.84635e-10</Hsp_evalue>
+      <Hsp_query-from>745</Hsp_query-from>
+      <Hsp_query-to>776</Hsp_query-to>
+      <Hsp_hit-from>794</Hsp_hit-from>
+      <Hsp_hit-to>825</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>31</Hsp_identity>
+      <Hsp_positive>31</Hsp_positive>
+      <Hsp_gaps>0</Hsp_gaps>
+      <Hsp_align-len>32</Hsp_align-len>
+      <Hsp_qseq>TTCTTTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>TTATTTATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>|| |||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>21</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|14</Hit_id>
+  <Hit_def>AB462277.1 Culicoides charadraeus genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: KC05_14</Hit_def>
+  <Hit_accession>14</Hit_accession>
+  <Hit_len>913</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>374.144</Hsp_bit-score>
+      <Hsp_score>202</Hsp_score>
+      <Hsp_evalue>3.27525e-106</Hsp_evalue>
+      <Hsp_query-from>166</Hsp_query-from>
+      <Hsp_query-to>557</Hsp_query-to>
+      <Hsp_hit-from>296</Hsp_hit-from>
+      <Hsp_hit-to>661</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>335</Hsp_identity>
+      <Hsp_positive>335</Hsp_positive>
+      <Hsp_gaps>30</Hsp_gaps>
+      <Hsp_align-len>394</Hsp_align-len>
+      <Hsp_qseq>AAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCAGTAAAACTAGTGATTTCGTGTCGCTAGTATGCATACATCTCTTTCGGGAGGGTATGCATTGATTTTATATCAAGATACTTTGGTGTGATAGTACGAATAGTACATATAAAATAAAAAATATAAGAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAAT--ATTTCATGATATTCACGAAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCT</Hsp_qseq>
+      <Hsp_hseq>AAATTTCTTAGGTAGCTTTATCGAAGAGCTTTAAAGACTTGTTTGCCTAAGGCCCC-GTAAAACTAGT-AACCCAT-T-GCGAGGTGGC-T--A---GTAT--GCA-TTTGTGCATTGATATTTT-TCATGATACTTTGGTGTGTTTGT--G--TAATA-AAAAAAAAT-AAAAA-AT--CAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATTGATATT-TGTTAT--A--AAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCT</Hsp_hseq>
+      <Hsp_midline>||||||||| ||||||||||| ||||||||||||||||||||||||| |||||||| ||||||||||| |   | | | || ||   || |  |    | |  | |   | ||||||||| || | ||| |||||||||||||| | ||  |  || || | | ||||| ||||| ||   |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  || |  || |||  |  |||||||||||||||||||||||||||||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>87.9128</Hsp_bit-score>
+      <Hsp_score>47</Hsp_score>
+      <Hsp_evalue>4.77826e-20</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>63</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>68</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>62</Hsp_identity>
+      <Hsp_positive>62</Hsp_positive>
+      <Hsp_gaps>5</Hsp_gaps>
+      <Hsp_align-len>68</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTA-TATTAAA-AAA---TATAATGATGTATTCT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTAATATAAAACAAAAATTATAATGATGTATTCT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||| ||| ||| |||   ||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>22</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|7</Hit_id>
+  <Hit_def>AB462270.1 Culicoides dubius genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Isg23</Hit_def>
+  <Hit_accession>7</Hit_accession>
+  <Hit_len>1096</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>366.757</Hsp_bit-score>
+      <Hsp_score>198</Hsp_score>
+      <Hsp_evalue>5.48065e-104</Hsp_evalue>
+      <Hsp_query-from>328</Hsp_query-from>
+      <Hsp_query-to>557</Hsp_query-to>
+      <Hsp_hit-from>597</Hsp_hit-from>
+      <Hsp_hit-to>828</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>222</Hsp_identity>
+      <Hsp_positive>222</Hsp_positive>
+      <Hsp_gaps>4</Hsp_gaps>
+      <Hsp_align-len>233</Hsp_align-len>
+      <Hsp_qseq>ATAAAATAAAAAATATAAGAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCA-T-GATATTCAC-GAAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCT</Hsp_qseq>
+      <Hsp_hseq>ATAAAAAAAAAAATTAAATAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATCTTAGTTGTTATTCACAGAA-TCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCT</Hsp_hseq>
+      <Hsp_midline>|||||| |||||||  || ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| | | | | ||||||| ||| ||||||||||||||||||||||||||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>122.999</Hsp_bit-score>
+      <Hsp_score>66</Hsp_score>
+      <Hsp_evalue>1.30987e-30</Hsp_evalue>
+      <Hsp_query-from>164</Hsp_query-from>
+      <Hsp_query-to>233</Hsp_query-to>
+      <Hsp_hit-from>393</Hsp_hit-from>
+      <Hsp_hit-to>461</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>69</Hsp_identity>
+      <Hsp_positive>69</Hsp_positive>
+      <Hsp_gaps>1</Hsp_gaps>
+      <Hsp_align-len>70</Hsp_align-len>
+      <Hsp_qseq>AAAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCAGTAAAACTAGT</Hsp_qseq>
+      <Hsp_hseq>AAAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCC-GTAAAACTAGT</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||||||||||||||||||||||| |||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>3</Hsp_num>
+      <Hsp_bit-score>76.8329</Hsp_bit-score>
+      <Hsp_score>41</Hsp_score>
+      <Hsp_evalue>1.03431e-16</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>51</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>49</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>48</Hsp_identity>
+      <Hsp_positive>48</Hsp_positive>
+      <Hsp_gaps>2</Hsp_gaps>
+      <Hsp_align-len>51</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAAAAAATATA</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATA--AAAATATATA</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||||  |||| |||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+</Iteration_hits>
+  <Iteration_stat>
+    <Statistics>
+      <Statistics_db-num>22</Statistics_db-num>
+      <Statistics_db-len>18669</Statistics_db-len>
+      <Statistics_hsp-len>16</Statistics_hsp-len>
+      <Statistics_eff-space>13920920</Statistics_eff-space>
+      <Statistics_kappa>0.46</Statistics_kappa>
+      <Statistics_lambda>1.28</Statistics_lambda>
+      <Statistics_entropy>0.85</Statistics_entropy>
+    </Statistics>
+  </Iteration_stat>
+</Iteration>
+<Iteration>
+  <Iteration_iter-num>2</Iteration_iter-num>
+  <Iteration_query-ID>Query_2</Iteration_query-ID>
+  <Iteration_query-def>AB462260.1 Culicoides brevipalpis genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Isg21</Iteration_query-def>
+  <Iteration_query-len>780</Iteration_query-len>
+<Iteration_hits>
+<Hit>
+  <Hit_num>1</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|0</Hit_id>
+  <Hit_def>AB462263.1 Culicoides maculatus genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Kag12_1</Hit_def>
+  <Hit_accession>0</Hit_accession>
+  <Hit_len>764</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>673.301</Hsp_bit-score>
+      <Hsp_score>364</Hsp_score>
+      <Hsp_evalue>0</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>780</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>764</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>664</Hsp_identity>
+      <Hsp_positive>664</Hsp_positive>
+      <Hsp_gaps>56</Hsp_gaps>
+      <Hsp_align-len>800</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTATAAAAAAATATAATGATGTATTCT--AGTGTATGGTTGTTTCGTTGGCATTGCAACTGCTCGCTCGAGGGCAGCTCACTATAAAGATGTAGTTTATTATGTCTTAAGTGAGTGTTGTGATACAAC-AAAAATTACTTGGGTAGCTTTATCGAAGAGCTTTAAAGATTTGTATGCCCAAGG--CCCGTAAAACTAGTGA-CTTCGTGTCACTAGTATGCATGT-TCTCTCGCAGAGCATGCATTGATTTT-TATCAAGATACTTTGGAGTGATAGTACGAATGTACGCATAACAAACAAACAAAAAAAGATC-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCT-GATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGT-T-GTTTCACAGCATCA---TAAGTGCATGATGTGATTATATGGGCCGCGCTCTCACGAGCAACGCTCATATATCATTAATAGATG-TGTGGTTTAGTGCAGC-A-GTGTGCATGTTTGACCATTATTTTTATTTAATGCAAATAACAAATTTTGGTATAAAATCAAGCG-TGCCTCTG-CGACAAAACTGTAACATTTAAATTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTA-A--CT--AAACATTCAATGATGTATTCTTTAAGGTATGGTTG--TCGTTGTTATTGCAGCAGC-CTCTCGCGGGCAGCTTGCTATAAAGATGTAGTTTATTATGTCTTAAGCAAGTGTTGTGGTTCAACAAAAAATTACTTGGGTAGCTTTATTTAAGAGCTTTAAAGACTTGTTTGCCCAAGGCTCCCGTAAAACTAGTGATCTT-GTTTCATTAGTATGCAATTATAT-TTATATA-TTTGCATTGATTTTATATCAAGATACTTTGGTGTGA--GTACGTATGTA--CAT---ATA-AAACAAAAAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTTCGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTATTGTCTGAAAAGATAAATGTAAGTGCATGATGTGATCATATGGA------T-TWACTT-------TCATATATCATTAATGGAGGATATGGTT-ATCGCTGCTATGTTTGCACACTTGGCCATTATTTTTATTTAGTT-AAA-AATATATATTGGTATAAAATCAAGTGGTGTAGCTGGCGCTAAAGCGATTCTATTCTATCTATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||| |   |  ||| ||  |||||||||||||  |  |||||||||  ||||||  |||||| | || | |||| ||||||||  ||||||||||||||||||||||||||||||  ||||||||| | |||| |||||||||||||||||||||||  |||||||||||||| |||| |||||||||  |||||||||||||||| ||| || ||| |||||||||  | | | |   | |   |||||||||||| |||||||||||||||| ||||  ||||| |||||  |||   | | ||||||||||||||| ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| | |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| | || | | |  || |   ||||||||||||||||| ||||||       | | ||         ||||||||||||||| || | | ||||| |  || || | || ||||   ||| |||||||||||||||| |  ||| || | || |||||||||||||||| | ||   ||| ||  ||| |  |   |||  |  |||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>2</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|12</Hit_id>
+  <Hit_def>AB462275.1 Culicoides punctatus genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Kag13_1</Hit_def>
+  <Hit_accession>12</Hit_accession>
+  <Hit_len>787</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>632.674</Hsp_bit-score>
+      <Hsp_score>342</Hsp_score>
+      <Hsp_evalue>0</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>780</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>787</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>665</Hsp_identity>
+      <Hsp_positive>665</Hsp_positive>
+      <Hsp_gaps>57</Hsp_gaps>
+      <Hsp_align-len>812</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTATAAAAAAATATAATGATGT--ATTC--TAGTGTATGGTTGTTTCGTTGGCATTGCAACTGCTCGCTCGAG--GGCAGCTCACTATAAAGATGTAGTTTATTATGTCTTAAGTGAGT--GTT---GTGATACAACAAAAATTACTTGGGTAGCTTTATCGAAGAGCTTTAAAGATTTGTATGCCCAAGG-CCCGTAAAACTAGTGAC---TT-CG-TGTCACTAGTATGCATGTTCTCTCGCAGAGCATGCATTGATTTTTATC-AAGATACTTTGGAGTGA-TAGTA-CG-AATGTACGCATA-ACAAAC-AAACAAAAAAAGATCAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCT-GATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTTGTTTCACAGCAT-CATAAGTGCATGATGTGATTATATGGGCCGCGCTCTCACGAGCAACGCTCATATATCATTAATAGATGTGTGGTT-TAGTGCAGC-AGTGT--GC-ATGTTTGACCATTATTTTTATTTAATGCAAATAACAAATTTTGGTATAAAATCAAGCGT-GCCTCTGCGACAAAACTG-TAACATTTAAATTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTAT--TAT-AAAACATATAATGATGTTCATTCTATAG-GTATGGTTGTTGTGTTGTCATTGTAAGAG-TC-ATTTAGTTGGCAGCTCTCTATAAAGACATAGTTTATTATGTTTTAAGGGAGTACCTTGCAGTGCGACAA-AAAAATTACTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGCATATACT-TAATTGTATATGCATTGATTTATTTCAAAGATACATTGGAGAGAGTATAATTGTAATGAAATTGTACATAAACAAAACAAAAAAAGTAAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTTCGATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTC-TTTCACTGAAAGCATAAGTGCATGATGTGATTATATAGGT-GA--TATCA--A-CT----T-ATATATCATTAATAAA-GTGTGGTGGTAACAAATATACTTTAAGCTATGTTTGACCATTATTTTTATCTAAA--AAATAATAAATTTTGGTATAAAATCAAATGTAGTGTTTGTTTGTTA-CTCATAACATCCAT-TTATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||  ||| |||| ||||||||||||  ||||  ||| |||||||||||  |||| ||||| ||  | ||  |  ||  |||||||| |||||||||  ||||||||||||| ||||| ||||   ||   |||  |||| ||||||||||||||||||||||| ||||||||||||||| |||| ||||||||| |||||||||||||| ||   || ||  ||  ||||||||||| | || |    |   |||||||||||| | || ||||||| |||||| || ||  |  | |||| |    || | |||| ||||||||||||   ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| | ||||||||||  ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  |||||| | |  |||||||||||||||||||||||| ||  |   | |||  | |     | |||||||||||||| | |||||||  ||    |   | | |  || ||||||||||||||||||||| |||   |||||| ||||||||||||||||||||  || |  | ||      | ||  ||||||  |  ||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>3</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|1</Hit_id>
+  <Hit_def>AB462264.1 Culicoides wadai genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Isg18_1</Hit_def>
+  <Hit_accession>1</Hit_accession>
+  <Hit_len>834</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>627.135</Hsp_bit-score>
+      <Hsp_score>339</Hsp_score>
+      <Hsp_evalue>0</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>780</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>834</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>696</Hsp_identity>
+      <Hsp_positive>696</Hsp_positive>
+      <Hsp_gaps>90</Hsp_gaps>
+      <Hsp_align-len>852</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTATAAAAAAATATAATGATGTATTCT----AGTGTAT-G--GTTGTTT-CGTTGGCATTGCAACTGCTCG-C-------TCG-AGGGCAGCTCACTATAAAGATGTAGTTTATTATGTCTTAAGTGAGTGTTGTGATACAACA----AAAATTACTTGGGTAGCTTTATCGAAGAGCTTTAAAGATTTGTATGCCCAAGGCCC---GTAAAACTAGTGA-CTTCGTGTCACTAGTATGCAT------G--T----TCTC-TCGCA---GAGC------ATGCATTGATTTTTATCAAGATACTTTGGAGTGATAGTACGAAT-GTACGCATAACAAACAAACAAAAAAAGATCAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCTGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGT-T-GTTTCACAGCATCATAAGTGCATGATGTGATTATATGGGC--CGCGCTCTCACGAGCAACGCTCATATATCATTAATAGATGTGTGGTTTA-GTGCA-G---CAGTGTGCATG--TTTGACCATTATTTTTATTTAATGCAAATAACAAATTTTGGTATAAAATCAAGCGT-GC-C--TCTG-CGACAAA--ACTG-TAACA-TT-T-AA--ATTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTA-A-TCT-AAAACATTCAATGATGTATTCTCACAAGTGTATGGTTGTTGTTTCCGTTGTTATTGTAGCAGCTCGTCGTAATTATCGTCGGGCAGCTTGCTATAAAGATGTAGTTTATTATGTCTTAAGCGAGTGCTGCAATACAACAATACAAAATTTCTTAGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCTAAGGCCCCCAGTAAAACTAGTGATCTTTGTGTCACTAGTATGCATATTAATGCATAACATCTCTTCGGAGGTGCGCTTTGATATGCATTGATTTATATCAAGATACTTTGGAGTGA--GTAC-ATTCGTAC-AAT-A-AAACAAACAAAAAAAGATCAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTTGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGACTCGTTTGAACGTCTCATAAGTGCATGATGTGATCATATGGATTTCGCGAT-TCAT-AT-ATCATTAATAAAGGAG-AATA--TG-GTTGTTAACGTGCGTGTTACATTGCGTTTGCATTTGACCATTATTTTTATTTAATA-AAATAATAAATTTTGGTATAAAATCAAATGTAGCGCAGTATATCG-CATACTACTACTACCACTTCTTAACCACTATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||| | | | |||| ||  |||||||||||||    ||||||| |  ||||||| |||||  |||| | | ||||| |       |||  ||||||||  |||||||||||||||||||||||||||||| ||||| ||  ||||||||    |||||| ||| ||||||||||| ||||||||||||||| |||| |||| |||||||   ||||||||||||| ||| |||||||||||||||||      |  |    |||| ||| |   | ||      |||||||||||| |||||||||||||||||||||  |||| | | ||||  || | |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  | |||| |  |  |||||||||||||||||||| ||||||    |||| | |||  |  | |  | ||| |  |  ||||  || || ||| | ||||  |   || || |  ||  |||||||||||||||||||||||  |||||| ||||||||||||||||||||  || || |  | |  || || |  |||  || || || | ||  | |||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>4</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|5</Hit_id>
+  <Hit_def>AB462268.1 Culicoides cylindratus genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Kag08, short type</Hit_def>
+  <Hit_accession>5</Hit_accession>
+  <Hit_len>748</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>549.575</Hsp_bit-score>
+      <Hsp_score>297</Hsp_score>
+      <Hsp_evalue>5.09701e-159</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>596</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>580</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>508</Hsp_identity>
+      <Hsp_positive>508</Hsp_positive>
+      <Hsp_gaps>38</Hsp_gaps>
+      <Hsp_align-len>607</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTATAAAAAAATATAATGATGT--ATTCTAGTGTATGGTTGTTTCGTTGGCATTGCAACTGCTCGCTCGAGGGCAGCTCACTATAAAGATGTAGTTTATTATGTCTTAAGTGAGTGTTGTGATACAAC-AAAAATTACTTGGGTAGCTTTATCGAAGAGCTTTAAAGATTTGTATGCCCAAGG-CCCGTAAAACTAGTGACTTCGTGTCACTAGTATGCATGTTCTCTCGCAGAGCATGCATTGATTTTTATCAAGATACTTTGGAGTGA---TAGTAC--GAA-TGTACGCATAACAAACAAACAAAAAAAGATC-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCTGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTTGTTTCACAGCATCATAAGTGCATGATGTGATTATA</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTAT------AAAATATATAATGATGTTCATTC-A--ATAAGGTTG-GTGGTT-GTATTGTAACAGCTATTTACTTAGCAGCTTGCTATAAAGATGTRGTTTATYATGTCTTAAGYAAGTGTTGYGATACARCAAAAAATTTCTTAGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCTAAGGCCCCGTAAAACTAGTAAC-CCAT-T-GCGAGGTGGC---TAGTAT-GC--A-TATGCATTGATATTTTTCATGATACTTTGGAGTGAGTATAATACAAAAATTGTACATAAAACAAA-AYA-AAAAAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTATAATATTTTTGATATTCATAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATAYATTAAACTATCTTATG-TGTGTAAAAG---CATAAGTGCATGATGTGATCATA</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||      |||| ||||||||||||  |||| |   || |||||  | ||| | |||| ||| |||   |     ||||||  |||||||||||| |||||| ||||||||||  ||||||| |||||| | ||||||| ||| ||||||||||| ||||||||||||||| |||| |||| |||| |||||||||||||| ||  | | |  | ||   ||   |  | | ||  |  |||||||||| ||| ||| |||||||||||||||   || |||   || |||||  | |||||| | | ||||||||||| |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| |||||||| ||||||||| |  |||||||||||||||||||||||||||||||||||||||| |||||||||||||||| ||| | | ||   ||||||||||||||||||| |||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>52.8265</Hsp_bit-score>
+      <Hsp_score>28</Hsp_score>
+      <Hsp_evalue>1.75223e-09</Hsp_evalue>
+      <Hsp_query-from>753</Hsp_query-from>
+      <Hsp_query-to>780</Hsp_query-to>
+      <Hsp_hit-from>721</Hsp_hit-from>
+      <Hsp_hit-to>748</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>28</Hsp_identity>
+      <Hsp_positive>28</Hsp_positive>
+      <Hsp_gaps>0</Hsp_gaps>
+      <Hsp_align-len>28</Hsp_align-len>
+      <Hsp_qseq>TTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>TTATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>5</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|17</Hit_id>
+  <Hit_def>AB462280.1 Culicoides kibunensis genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: AM05_6</Hit_def>
+  <Hit_accession>17</Hit_accession>
+  <Hit_len>817</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>527.415</Hsp_bit-score>
+      <Hsp_score>285</Hsp_score>
+      <Hsp_evalue>2.38824e-152</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>565</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>585</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>498</Hsp_identity>
+      <Hsp_positive>498</Hsp_positive>
+      <Hsp_gaps>40</Hsp_gaps>
+      <Hsp_align-len>595</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTATAAAAAAATATAATGATGTAT---TCTAGTGTATGGTTGTTTCGTTGGCATTGCAACTGCTCGCTCGAGGGCAGCTCACTATAAAGATGTAGTTTATTATGTCTTAAGTGAGTGTTGTGATACAA-CA---A-----AAATTACTTGGGTAGCTTTATCGAAGAGCTTTAAAGATTTGTATGCCCAAGG-CCCGTAAAACTAGTGAC---TT-CG-TGTCACTAGTATGCATGTTC-TCTCGCA--GAGCATGCATTGATTTTTATCAAGATACTTTGGAGTGA-TAGTACGAAT-GT-ACGCATA-ACAAACAAAC-AAAAAAAGATC-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTT---CTGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTTGTTT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATAT--TAAAAAAATATAATGATGTATCATTCTAAGGTATGGTTG-TT--TTGTCTCT-CAACAGCTATTAACTTGGCAGCTTACT-CAAAGATGTAGCTTATTATGTTTTAAGTAAGTGTTGTTAGACAATCAGGTATGGTGAAATTWCTTAGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCTAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGCATATACAAGTAAAATTGTATATGCATTGATATTTTTCATGATACTTTGGTGTGAGTA-TAAAATTAATAATTTGTACAWAAACAAACAAAAAAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTCAAACT-ATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGT-GTTT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||||  |||||||||||||||||||||   ||||  ||||||||| ||  ||| |  | |||| |||        ||||||| |||  |||||||||| ||||||||| |||||| |||||||| | |||| ||   |     ||||| ||| ||||||||||| ||||||||||||||| |||| |||| |||| |||||||||||||| ||   || ||  ||  ||||||||||| | |   |   |  |   |||||||||| ||| ||| |||||||||| |||| || ||  | |  | |    || | |||||||| ||||||||||| ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||    || |||||||||  |||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>6</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|18</Hit_id>
+  <Hit_def>AB462281.1 Culicoides verbosus genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: OKYN05_18</Hit_def>
+  <Hit_accession>18</Hit_accession>
+  <Hit_len>805</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>523.722</Hsp_bit-score>
+      <Hsp_score>283</Hsp_score>
+      <Hsp_evalue>3.08939e-151</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>716</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>732</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>609</Hsp_identity>
+      <Hsp_positive>609</Hsp_positive>
+      <Hsp_gaps>64</Hsp_gaps>
+      <Hsp_align-len>756</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTATAAAAAAATATAATGATGT--ATTC-T---A-GTGT-ATGGTTGTT-TCGTTGGCATTGCAACTGCTCGCTCGAGGGCAGCTCACTATAAAGATGTAGTTTATTATGTCTTAAGTGAGTGTTGTGATACAACA------------AAAATTACTTGGGTAGCTTTATCGAAGAGCTTTAAAGATTTGTATGCCCAAGG-CCCGTAAAACTAGTGAC---TT-CG-TGTCACTAGTATGCATGTTCTCTCGCAGAGCATGCATTGATTTTTATCAAGATACTTTGGAGTGATAGTA-CGAA-T---GTACGCATAACAAACAAACA-AAAAAAGATC-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTT-CTGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTTGTTTCACA--GC-ATCATAAGTGCATGATGTGATTATATGGGCCGCGCTCTCACGAGCAACGCTCATATATCATTAATAGATGTGT-GGTTTAGTGCAGCAGTGTGCATGTTTGACCATTATTTTTATTTAATGCAAATAACA-AATTTTGGTATAAAAT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATAT--TAAAAAAATATAATGATGTTCATTCATAAAAGGTATAACGGTTGTTGTC-TTTCAATGGCTA-T--TCACT-TA-GCAAGCTTGCTATAAAAATGTAGTTTATTATGTTTTAAGCAAGTGTTGTTAGACAAAAGGTTGGTTGTTCAAAATTACTTAGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCTAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGTATATACT-TAATTGTATATGCATTGATATTTTTCATGATACTTTGGAGTGTGAGTATAAAATTAAAATTTGTACAA-AAACAAAAACAAAAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATAAACTAATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTC-TTTAAAATTGAGAT-ATAAGTGCATGATGTGATCATATAAGC-----T-TAATT-GC--C--T-ATATATCATTAATAAAGGTGGAGGTATGGTGCTATTGTGTACATATTTAACCATCATTTTTATTTAATATAAATAATATAATTTTGGTATAAAAT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||||  |||||||||||||||||||  |||| |   | || | | ||||||| || ||   || || | |  || ||  | |  ||||  ||||||| |||||||||||||||| |||||  |||||||| | |||| |            |||||||||| ||||||||||| ||||||||||||||| |||| |||| |||| |||||||||||||| ||   || ||  ||  |||||||| || | || |    |   |||||||||| ||| ||| ||||||||||||||  ||||   || |    |  | | || ||||||| | |||||||||| |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||   || |||||||||  ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  ||| | |  |  || |||||||||||||||||| ||||  ||     | | |   ||  |  | |||||||||||||| | |||  ||| | ||||    |||| ||| ||| ||||| |||||||||||||  |||||| | ||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>7</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|20</Hit_id>
+  <Hit_def>AB462283.1 Culicoides matsuzawai genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: IS05_6</Hit_def>
+  <Hit_accession>20</Hit_accession>
+  <Hit_len>908</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>512.642</Hsp_bit-score>
+      <Hsp_score>277</Hsp_score>
+      <Hsp_evalue>6.68735e-148</Hsp_evalue>
+      <Hsp_query-from>167</Hsp_query-from>
+      <Hsp_query-to>596</Hsp_query-to>
+      <Hsp_hit-from>299</Hsp_hit-from>
+      <Hsp_hit-to>732</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>389</Hsp_identity>
+      <Hsp_positive>389</Hsp_positive>
+      <Hsp_gaps>18</Hsp_gaps>
+      <Hsp_align-len>441</Hsp_align-len>
+      <Hsp_qseq>AAAATTACTTGGGTAGCTTTATCGAAGAGCTTTAAAGATTTGTATGCCCAAGG-CCCGTAAAACTAGTGAC---TT-CG-TGTCACTAGTATGCATGTTCTCTCGCAGAGCATGCATTGATTTTTATCAAGATACTTTGGAGTGATAGTACGAA-TGTACGCATAACAAACAAACAAAAAAAGATC-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCT-GATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTTGT-TTCACA-GCATCATAAGTGCATGATGTGATTATA</Hsp_qseq>
+      <Hsp_hseq>AAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGCATACACT-TARTTGAGTATGCATTGATATTTTTCATGATACTTTGGTGTGA-AGTACATATTGTACCGAT-ATAAAC--A-AAAAAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTATCGATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGT-GTCTTGAAAAAGAACATAAGCGCATGATGTGATTATA</Hsp_hseq>
+      <Hsp_midline>|||||| ||||||||||||||| ||||||||||||||| |||| ||||||||| |||||||||||||| ||   || ||  ||  |||||||||||   || |    ||| |||||||||| ||| ||| |||||||||| |||| |||||  | |||||  || | ||||  | ||||||||||| ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| | ||||||||||  |||||||||||||||||||||||||||||||||||||||||||||||||||||||||| || || | |   | |||||| ||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>122.999</Hsp_bit-score>
+      <Hsp_score>66</Hsp_score>
+      <Hsp_evalue>1.31676e-30</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>156</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>163</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>137</Hsp_identity>
+      <Hsp_positive>137</Hsp_positive>
+      <Hsp_gaps>17</Hsp_gaps>
+      <Hsp_align-len>168</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTATAAAAAAATATAATGATGTATTCT--AG-T--G-TAT--GGTTGTTTCGTTGGCATTG-CAACTGCTCGCTCGAGG-GC-AGCTCACTATAAAGATGTAGTTTATTAT-GTCTTAAGTGAGTGTTG</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTA-AAAAAA-TATAATGATGT-TTCTTTATATAAGGTATATGGTTGTTATGTTGTC-TTGTCAACAGCTATTT-GATTAGCAAGCTTGCTATAAAGATGTAGTTTATTACGGTCTTAAGTAAGTGTTG</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||||||| |||||| ||||||||||| ||||  |  |  | |||  |||||||  |||| | ||| |||| |||   | ||   || ||||  |||||||||||||||||||||  ||||||||| |||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>3</Hsp_num>
+      <Hsp_bit-score>52.8265</Hsp_bit-score>
+      <Hsp_score>28</Hsp_score>
+      <Hsp_evalue>1.75223e-09</Hsp_evalue>
+      <Hsp_query-from>753</Hsp_query-from>
+      <Hsp_query-to>780</Hsp_query-to>
+      <Hsp_hit-from>881</Hsp_hit-from>
+      <Hsp_hit-to>908</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>28</Hsp_identity>
+      <Hsp_positive>28</Hsp_positive>
+      <Hsp_gaps>0</Hsp_gaps>
+      <Hsp_align-len>28</Hsp_align-len>
+      <Hsp_qseq>TTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>TTATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>8</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|13</Hit_id>
+  <Hit_def>AB462276.1 Culicoides sumatrae genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: ONYK05_17</Hit_def>
+  <Hit_accession>13</Hit_accession>
+  <Hit_len>784</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>510.796</Hsp_bit-score>
+      <Hsp_score>276</Hsp_score>
+      <Hsp_evalue>2.4052e-147</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>597</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>621</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>524</Hsp_identity>
+      <Hsp_positive>524</Hsp_positive>
+      <Hsp_gaps>52</Hsp_gaps>
+      <Hsp_align-len>635</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTAT-ATTATAAAAAAATATAATGATGT---ATTCTAGTGTATGGTTGTTTCGTTGGCATTGCAACTGC--TCGCTCGAGGGCAGC-T-CA---CTATAAAGATGTAGTTTATTATGTCTTAAG---T-G-A-GTGTTGTGATACAACAAAAATTACTTGGGTAGCTTTATCGAAGAGCTTTAAAGATTTGTATGCCCAAGG-CCCGTAAAACTAGTGAC---TT-CG-TGTCACTAGTATGCATGTTCTCTCGCAGAGCATGCATTGATTTTTATCAAGATACTTTGGAGTGATAGTACGAATGT--A-C-GCATA---ACA-A-ACA-A--ACAAAAAAAG--ATCAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATT-TCTGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTTGTTTCACAGCATCATAAGTGCATGATGTGATTATAT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATTATTA-AAAAAAATATAATGATGTTTCATTCAAG-GTATGGTTG-TT-AAT-CTATTGCAATGGCTATTAATTTA--GCAGCTTACACCGCTATAAAGATGTGGTTTATCATATCTTAAGCATTCGTAGGTGTTGTGAT---A-GAAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGTATATACT-TAATTGTATATGCATTGATATTTTTCATGATACTTTGGTGTGATAATA-AAAAGTAAATCTTTATATTTATATAGAGATAGGAAAAAAAAAGTAAAGAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTATC-GATATTCACGAAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTTATTTAATGGTAACGTAAGGGCATGTTGTGATTATAT</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||| |||| ||||||||||||||||||   |||| || ||||||||| ||   |   |||||||  ||  |   |  |  ||||| | ||   |||||||||||| |||||| || |||||||   | | | ||||||||||   |  |||||| ||||||||||||||| ||||||||||||||| |||| ||||||||| |||||||||||||| ||   || ||  ||  |||||||| || | || |    |   |||||||||| ||| ||| |||||||||| |||||| ||  || ||  | |   |||   | | | | | |  | ||||||||  |  |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| || |||||||||  |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||| |  | | | |||| ||||| |||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>54.6731</Hsp_bit-score>
+      <Hsp_score>29</Hsp_score>
+      <Hsp_evalue>4.87186e-10</Hsp_evalue>
+      <Hsp_query-from>752</Hsp_query-from>
+      <Hsp_query-to>780</Hsp_query-to>
+      <Hsp_hit-from>756</Hsp_hit-from>
+      <Hsp_hit-to>784</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>29</Hsp_identity>
+      <Hsp_positive>29</Hsp_positive>
+      <Hsp_gaps>0</Hsp_gaps>
+      <Hsp_align-len>29</Hsp_align-len>
+      <Hsp_qseq>ATTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>ATTATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>9</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|19</Hit_id>
+  <Hit_def>AB462282.1 Culicoides humeralis genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Kag15_1</Hit_def>
+  <Hit_accession>19</Hit_accession>
+  <Hit_len>912</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>508.949</Hsp_bit-score>
+      <Hsp_score>275</Hsp_score>
+      <Hsp_evalue>8.65063e-147</Hsp_evalue>
+      <Hsp_query-from>167</Hsp_query-from>
+      <Hsp_query-to>597</Hsp_query-to>
+      <Hsp_hit-from>296</Hsp_hit-from>
+      <Hsp_hit-to>739</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>394</Hsp_identity>
+      <Hsp_positive>394</Hsp_positive>
+      <Hsp_gaps>21</Hsp_gaps>
+      <Hsp_align-len>448</Hsp_align-len>
+      <Hsp_qseq>AAAATTACTTGGGTAGCTTTATCGAAGAGCTTTAAAGATTTGTATGCCCAAGG-CCCGTAAAACTAGTGAC---TT-CG-TGTCACTAGTATGCATGTTCTCTCGCAGAGCATGCATTGATTTTTATCAAGATACTTTGGAGTGA---TAGTACG-AATGTACGCATAACAAACAAACAAAAAAAGATC-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCT-GATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGT-TGT-TTCACA--G-CATCATAAGTGCATGATGTGATTATAT</Hsp_qseq>
+      <Hsp_hseq>AAAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGCATACACT-TAATTGAGTATGCATTGATATTTTTCATGATACTTTGGTGTGAGTATAATTTGTATTGTA--CATAAACAAGAAA-AAAAAACGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTATCGATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTGTGTCTTGAAAAAGACATCATAAGTGCATGATGTGATTATAT</Hsp_hseq>
+      <Hsp_midline>|||||| ||||||||||||||| ||||||||||||||| |||| ||||||||| |||||||||||||| ||   || ||  ||  |||||||||||   || |    ||| |||||||||| ||| ||| |||||||||| ||||   || |  | | ||||  |||||  || ||| |||||| |||| ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| | ||||||||||  |||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||| || | |  | |||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>124.846</Hsp_bit-score>
+      <Hsp_score>67</Hsp_score>
+      <Hsp_evalue>3.66109e-31</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>156</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>161</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>135</Hsp_identity>
+      <Hsp_positive>135</Hsp_positive>
+      <Hsp_gaps>15</Hsp_gaps>
+      <Hsp_align-len>166</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTATAAAAAAATATAATGATGTATTCT-AGTGTAT--GGT-T--G-TTTCGTTGGCATTG-CAACTGCTCGCTCGAGG-GC-AGCTCACTATAAAGATGTAGTTTATTATGTCTTAAGTGAGTGTTG</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTA-AAAAAA-TATAATGATGT-TTCTTTATATATAAGGTATATGGTTATGTTGTC-TTGTCAAYRGCTAT-TYGATTAGCAAGCTTGCTATAAAGATGTAGTTTATTATGTCTTAAGTAAGTGTTG</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||||||| |||||| ||||||||||| ||||   | |||  ||| |  | ||  |||| | ||| |||  |||   | ||   || ||||  ||||||||||||||||||||||||||||||| |||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>3</Hsp_num>
+      <Hsp_bit-score>54.6731</Hsp_bit-score>
+      <Hsp_score>29</Hsp_score>
+      <Hsp_evalue>4.87186e-10</Hsp_evalue>
+      <Hsp_query-from>752</Hsp_query-from>
+      <Hsp_query-to>780</Hsp_query-to>
+      <Hsp_hit-from>884</Hsp_hit-from>
+      <Hsp_hit-to>912</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>29</Hsp_identity>
+      <Hsp_positive>29</Hsp_positive>
+      <Hsp_gaps>0</Hsp_gaps>
+      <Hsp_align-len>29</Hsp_align-len>
+      <Hsp_qseq>ATTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>ATTATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>10</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|9</Hit_id>
+  <Hit_def>AB462272.1 Culicoides nipponensis genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Isg22</Hit_def>
+  <Hit_accession>9</Hit_accession>
+  <Hit_len>794</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>503.409</Hsp_bit-score>
+      <Hsp_score>272</Hsp_score>
+      <Hsp_evalue>4.02475e-145</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>597</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>607</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>520</Hsp_identity>
+      <Hsp_positive>520</Hsp_positive>
+      <Hsp_gaps>56</Hsp_gaps>
+      <Hsp_align-len>630</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTATAAAAAAATATAATGATGT--ATTC---TAGTGT-ATGGTTGTTTCGTTGGCATTGCAACTGCTCGCTCGAGGGCAGCT--CACTATAAAGATGTAGTTTATTATGTC-T-TAAGTG--AG--TGTTGTGAT-ACAACA-A-------AAATTACTTGGGTAGCTTTATCGAAGAGCTTTAAAGATTTGTATGCCCAAGG-CCCGTAAAACTAGTGAC---TT-CG-TGTCACTAGTATGCATGTTCTCTCGCAGAGCATGCATTGATTTTTATCAAGATACTTTGGAGTGATAGTACGAATGTACGCATAACAAACAAACAAAAAAAG-ATCAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATAT-TTCT-GATATTCACA-GAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTTGTTTCACAGCATCATAAGTGCATGATGTGATTATAT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTAT--TAT-AAAAAATATAATGATGTTCATTCTATTAGTGTAATGG-TG-TT-ATTATTATTACAATTGCAATATATTTTGCAGCTTACAC-A-AAAGATGTAGTTTATTATATCATATATGTGCAAGTATATTGTAATAATAAAAGAGTTGGTTAAATTTCTTGGGTAGCTTTATTGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGTAT-ATAT-TCATTTA-TATACATTGATATTTTTCATGATACTTTGGATTGATA-T--G-A--TA---A-AACAAACAAAAAAAAAGTGTAAGAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATATTTTTGATATTCACAAGA-TCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTGTGTTTTGTCAAAAGA-CATAAGTGCATGATGTGATTATAT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||  ||| |||||||||||||||||  ||||   |||||| |||| || ||  ||   ||| ||| |||    |     ||||||  ||| | |||||||||||||||||| || | || |||  ||  | |||| || | || | |       ||||| ||||||||||||||| ||||||||||||||| |||| ||||||||| |||||||||||||| ||   || ||  ||  |||||||| ||  | | ||    |  || ||||||| ||| ||| ||||||||||| ||||| |  | |  ||   | |||||||||| |||||  | |  ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| || | |||||||||| || ||||||||||||||||||||||||||||||||||||||||||||||||||||| |||| | ||| |  | ||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>82.3729</Hsp_bit-score>
+      <Hsp_score>44</Hsp_score>
+      <Hsp_evalue>2.23481e-18</Hsp_evalue>
+      <Hsp_query-from>668</Hsp_query-from>
+      <Hsp_query-to>780</Hsp_query-to>
+      <Hsp_hit-from>682</Hsp_hit-from>
+      <Hsp_hit-to>794</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>93</Hsp_identity>
+      <Hsp_positive>93</Hsp_positive>
+      <Hsp_gaps>6</Hsp_gaps>
+      <Hsp_align-len>116</Hsp_align-len>
+      <Hsp_qseq>TTTGACCATTATTTTTATTTAA-TGCA-AATAACAAATTTTGGTATAAAATCAAGCGTGCCTCTGCGACAAAAC-TGTAACATTTAAATTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>TTTGACCATTATTTTTATTTAAATTAATAATAA-ATATTTTGGTTTAAA-TCAAATG-GTATATGAGAGAAAAAGTGTTATATTTTTTTTATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||| |  | ||||| | |||||||| |||| ||||  | |  | || || ||||  ||| | ||||   ||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>11</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|8</Hit_id>
+  <Hit_def>AB462271.1 Culicoides lungchiensis genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: AM05_8</Hit_def>
+  <Hit_accession>8</Hit_accession>
+  <Hit_len>776</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>475.709</Hsp_bit-score>
+      <Hsp_score>257</Hsp_score>
+      <Hsp_evalue>8.7739e-137</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>598</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>619</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>516</Hsp_identity>
+      <Hsp_positive>516</Hsp_positive>
+      <Hsp_gaps>49</Hsp_gaps>
+      <Hsp_align-len>633</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTATAAAAAAATATAATGATGT-AT-TC-T-AGTG-TATGGTTGTTTCGT-TGGCATTGCAACTGCTCGCTCGAGGGCAGCTCACTATAAAGATGTAGTTTATTA--TGTC-T-TAAGTGAGTGTTGT--GATA---CAA---CA--AAAATTACTTGGGTAGCTTTATCGAAGAGCTTTAAAGATTTGTATGCCCAAGG-CCCGTAAAACTAGTGAC---TT-CG-TGTCACTAGTATGCATGTTC-TCTCGCAGAGCATGCATTGAT-TTTTATCAAGATACTTTGGAGTGATAG--TACGAATGTACGCA--T-AACAAACAAACAAAAAAAGATC-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCTGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTTG-TTTCACAGCATCATAAGTGCATGATGTGATTATATG</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTAT-TAAAAAAAAAATATAATGATGTTCTATCATAAGTGTTATGG-TGTTATATATTACAAT--AACTATTTAAT-TA-GTAAGCTTATTATAAAGATGTGGTTTATCACTTATCTTATAAATAAGTATTGTAATATATTTTAAGTGTATGGAAATTACTTGGGTAGCTTTATTGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGTATATACATTTATTTGTATATACATTGATATTTTTTCATGATACTTTGGTAT-AAAGAAAAAAAAAGTACAATTTTGTACATATAAA-AAAAAAAGATCTAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTTGATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTTCCTTTTA------CATAAGTGCATGATGTGATTATATG</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||| | | ||||||||||||||||||  | || | |||| ||||| ||||   | |  || |  ||||  |   |  | |  |||| | ||||||||||| |||||| |  | || | ||| | ||| ||||   |||    ||    |   ||||||||||||||||||||| ||||||||||||||| |||| ||||||||| |||||||||||||| ||   || ||  ||  |||||||| || | | | |    |   || ||||||| |||| ||| ||||||||||  | | ||   |  || ||||     |  ||| | ||| ||||||||||| ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| |||||||||||  |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  ||| |      |||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>52.8265</Hsp_bit-score>
+      <Hsp_score>28</Hsp_score>
+      <Hsp_evalue>1.75223e-09</Hsp_evalue>
+      <Hsp_query-from>746</Hsp_query-from>
+      <Hsp_query-to>780</Hsp_query-to>
+      <Hsp_hit-from>743</Hsp_hit-from>
+      <Hsp_hit-to>776</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>33</Hsp_identity>
+      <Hsp_positive>33</Hsp_positive>
+      <Hsp_gaps>1</Hsp_gaps>
+      <Hsp_align-len>35</Hsp_align-len>
+      <Hsp_qseq>ATTTAAATTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>ATTT-ATTTATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>|||| | ||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>12</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|4</Hit_id>
+  <Hit_def>AB462267.1 Culicoides aterinervis genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: AM05_5</Hit_def>
+  <Hit_accession>4</Hit_accession>
+  <Hit_len>891</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>475.709</Hsp_bit-score>
+      <Hsp_score>257</Hsp_score>
+      <Hsp_evalue>8.7739e-137</Hsp_evalue>
+      <Hsp_query-from>167</Hsp_query-from>
+      <Hsp_query-to>597</Hsp_query-to>
+      <Hsp_hit-from>276</Hsp_hit-from>
+      <Hsp_hit-to>713</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>388</Hsp_identity>
+      <Hsp_positive>388</Hsp_positive>
+      <Hsp_gaps>25</Hsp_gaps>
+      <Hsp_align-len>447</Hsp_align-len>
+      <Hsp_qseq>AAAATTACTTGGGTAGCTTTATCGAAGAGCTTTAAAGATTTGTATGCCCAAGG-CCCGTAAAACTAGTGAC---TT-CG-TGTCACTAGTATGCATGTTCTCTCGCAGAGCATGCATTGATTTTTATCAAGATACTTTGGAGTGA---TAGTAC--GAA-TGTACGCAT-AA-CA-AACAAACAAAAAAAGAT-CAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCTGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTTGTTTCACAGCATCATAAGTGCATGATGTGATTATAT</Hsp_qseq>
+      <Hsp_hseq>AAAATTTCTTAGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCTAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGCATACACT-TAGTTGTGTATGCATTGATATTTTTCATGATACTTTGGAGTGAGTATAATACAAAAATTGTA--CATAAATAATAATAAA-AAAAAAAGATGAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTATAATATTTTTGATATTCATAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGT-GTTTTACA-CG---TAAGTGCATGATGTGATCATAT</Hsp_hseq>
+      <Hsp_midline>|||||| ||| ||||||||||| ||||||||||||||| |||| |||| |||| |||||||||||||| ||   || ||  ||  |||||||||||   || | |  | | |||||||||| ||| ||| |||||||||||||||   || |||   || ||||  ||| ||  | || ||| ||||||||||  |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| |||||||| ||||||||| |  |||||||||||||||||||||||||||||||||||||||||||||||||||||||||| |||| ||| |    ||||||||||||||||| ||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>132.232</Hsp_bit-score>
+      <Hsp_score>71</Hsp_score>
+      <Hsp_evalue>2.18788e-33</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>163</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>160</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>136</Hsp_identity>
+      <Hsp_positive>136</Hsp_positive>
+      <Hsp_gaps>9</Hsp_gaps>
+      <Hsp_align-len>166</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTATAAAAAAATATAATGATGT--ATTCTAGTGTA-TGGTTGTTTCGTTGGCATTGCAACTGCTCGCTCGAGGGCAGCTCACTATAAAGATGTAGTTTATTATGTCTTAAGTGAGTGTTGTGATACA</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATA--A-AAATA--TATAATGATGTTCATTCTAAGGTTGTGGATGTAT-GTTGTTATTGTAACAGCTATTTAGTTAGCAGCTTGCTATAAAGATGTAGTTTATTATGTCTTAAGTAAGTGTTATGATACA</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||||  | ||| |  |||||||||||  ||||||  ||  ||| ||| | ||||  |||| ||| |||   | |   ||||||  ||||||||||||||||||||||||||||||| |||||| |||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>3</Hsp_num>
+      <Hsp_bit-score>58.3664</Hsp_bit-score>
+      <Hsp_score>31</Hsp_score>
+      <Hsp_evalue>3.76617e-11</Hsp_evalue>
+      <Hsp_query-from>668</Hsp_query-from>
+      <Hsp_query-to>780</Hsp_query-to>
+      <Hsp_hit-from>780</Hsp_hit-from>
+      <Hsp_hit-to>891</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>90</Hsp_identity>
+      <Hsp_positive>90</Hsp_positive>
+      <Hsp_gaps>9</Hsp_gaps>
+      <Hsp_align-len>117</Hsp_align-len>
+      <Hsp_qseq>TTTGACCATTATTTTTATTTAATGCAAATAACAAATTTTGGTATAAAATC-AA-GCGTGCCTCTGCG-ACAAAACTGTAACATTTAA-ATTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>TTTGACCATTATTTTTATTTAAT-TTAAT-ATGAATTTTGGT-TTAAATCAAATATGTGTATCT-CGTTGTTGTTTATAAC-TCTAACATTATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||   ||| |  ||||||||| | ||||| ||   |||  ||| ||        | |||| | ||| |||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>13</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|2</Hit_id>
+  <Hit_def>AB462265.1 Culicoides arakawae genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Kag02</Hit_def>
+  <Hit_accession>2</Hit_accession>
+  <Hit_len>907</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>472.016</Hsp_bit-score>
+      <Hsp_score>255</Hsp_score>
+      <Hsp_evalue>1.13498e-135</Hsp_evalue>
+      <Hsp_query-from>167</Hsp_query-from>
+      <Hsp_query-to>780</Hsp_query-to>
+      <Hsp_hit-from>303</Hsp_hit-from>
+      <Hsp_hit-to>907</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>512</Hsp_identity>
+      <Hsp_positive>512</Hsp_positive>
+      <Hsp_gaps>41</Hsp_gaps>
+      <Hsp_align-len>630</Hsp_align-len>
+      <Hsp_qseq>AAAATTACTTGGGTAGCTTTATCGAAGAGCTTTAAAGATTTGTATGCCCAAGGCCC-GTAAAACTAGTGAC---TT-CG-TGTCACTAGTATGCATGTTCTCTCGCAGAGCATGCATTGATTTTTATCAAGATACTTTGGAGTG--ATAGTACGAATGTACGCATAACAAAC-AAACAAAAAAAGATC-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCTGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTTGTTTCACA--GCATCATAAGTGCATGATGTGATTATATGGGCCGCGCTCTCACGAGCAACGCTCATATATCATTAATAGATGTGTGGTTTAGTGCAGCAGTGTGCATGTTTGACCATTATTTTTATTTAATGCAAATAACAAA-T-T-TTGGTATAAAATCAAGC-GTGCCTCTGCGACAAAACTGTAACATTTAAATTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>AAAATTACTTAGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCTAAGGCCCTGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGTATATACT-TAATTGTATATGCATTGATATTTTTCATGATACTTTGGTGTGATATAATAAAAATGTAC-AATTTTGTACTAATAAAAAAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATAAATAATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATATTATTTGAAAAAGTAATATAAGTGCATGATGTGATTATACAAG--GCT-T-TAACAGGCAT-G----TATATCATTAATAAAGGATAGATATGGTA-A--A-TGAGCATATTTAACCATTATTTTTATTTAA---AA-TAATAAAGTATATTGGTATAAAATAAATATGTGACT-TGCCTTATTACT-TA-C-TTTAA-TT-TGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>|||||||||| ||||||||||| ||||||||||||||| |||| |||| ||||||| ||||||||||| ||   || ||  ||  |||||||| || | || |    |   |||||||||| ||| ||| |||||||||| |||  ||| ||  |||||||  ||     || ||  ||||||||||| |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||   | |||||||||  |||||||||||||||||||||||||||||||||||||||||||||||||||||||| || ||| | |  | |  ||||||||||||||||||||||   |  ||  | | ||  |||  |    ||||||||||||| | |   | | | ||  |  | || |||| ||| ||||||||||||||||||   || ||| ||| | | |||||||||||| ||   ||| || |||   |  ||| || | ||||| || |||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>111.919</Hsp_bit-score>
+      <Hsp_score>60</Hsp_score>
+      <Hsp_evalue>2.85029e-27</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>81</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>82</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>77</Hsp_identity>
+      <Hsp_positive>77</Hsp_positive>
+      <Hsp_gaps>5</Hsp_gaps>
+      <Hsp_align-len>84</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTATAAAAAAATATAATGATGT--ATTC-TAGTGTATGGTTGTTT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTA-AAAAAA-TATAATGATGTTCATTCATAAGGTATGGTTGTTT</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||||||| |||||| |||||||||||  |||| ||  ||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>14</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|21</Hit_id>
+  <Hit_def>AB462284.1 Culicoides paraflavescens genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: OKYN05_13</Hit_def>
+  <Hit_accession>21</Hit_accession>
+  <Hit_len>842</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>466.476</Hsp_bit-score>
+      <Hsp_score>252</Hsp_score>
+      <Hsp_evalue>5.28053e-134</Hsp_evalue>
+      <Hsp_query-from>167</Hsp_query-from>
+      <Hsp_query-to>597</Hsp_query-to>
+      <Hsp_hit-from>248</Hsp_hit-from>
+      <Hsp_hit-to>687</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>387</Hsp_identity>
+      <Hsp_positive>387</Hsp_positive>
+      <Hsp_gaps>25</Hsp_gaps>
+      <Hsp_align-len>448</Hsp_align-len>
+      <Hsp_qseq>AAAATTACTTGGGTAGCTTTATCGAAGAGCTTTAAAGATTTGTATGCCCAAGG-CCCGTAAAACTAGTGAC---TT-CG-TGTCACTAGTATGCATGTTCTCTCGCAGAGCATGCATTGATTTTTATCAAGATACTTTGGAGTGATAGTAC-GAATGTACGCATAACAAACAAACAAAAAAA-GATC-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCT-GATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTTGTTTC-A-C-A--GCATCA--TAAGTGCATGATGTGATTATAT</Hsp_qseq>
+      <Hsp_hseq>AAAATTTCTTGGGTAGCTTTATTGAAGAGCTTTAAAGACTTATTTGCCCAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGCATACCCT-TTATTGGGTATGCATTGATATTTTTCATGATACTTTGGTGTGA--GTACTTATTGTA--CAT-A-TGATAAATAAAAAAACGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTTTGATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGC-GTCTCTAGCGATAGAAGCGCTTAAGTGCATGATGTGATTATAT</Hsp_hseq>
+      <Hsp_midline>|||||| ||||||||||||||| ||||||||||||||| || | ||||||||| |||||||||||||| ||   || ||  ||  |||||||||||   || |    | | |||||||||| ||| ||| |||||||||| ||||  ||||  | ||||  ||| |   | ||| ||||||| |||| ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| | ||||||||||  |||||||||||||||||||||||||||||||||||||||||||||||||||||||||  || || | | |  | | |   ||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>108.226</Hsp_bit-score>
+      <Hsp_score>58</Hsp_score>
+      <Hsp_evalue>3.68709e-26</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>156</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>152</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>131</Hsp_identity>
+      <Hsp_positive>131</Hsp_positive>
+      <Hsp_gaps>18</Hsp_gaps>
+      <Hsp_align-len>163</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTATAAAAAAATATAATGATGTATTCT--AGTGTATGGT-T--G-T-TTCGTTGGCATTGCAACTGCTCGCTCGAGGGCAGCTCACTATAAAGATGTAGTTTATTATGTCTTAAGTGAGTGTTG</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTA-AAACA--TATAATGATGT-TTCTTTAAGGTATGGTGTTTGATATTTGTTG--ATAGCTATT--T-GATT-AG-CAAGCTTACTATAAAGATGTAGTTTATTATGTCTTAAGTAAGTATTG</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||||||| ||| |  ||||||||||| ||||  |  ||||||| |  | | || ||||  || || | |  | | |  ||   |||| |||||||||||||||||||||||||||||||| ||| |||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>3</Hsp_num>
+      <Hsp_bit-score>71.293</Hsp_bit-score>
+      <Hsp_score>38</Hsp_score>
+      <Hsp_evalue>4.83751e-15</Hsp_evalue>
+      <Hsp_query-from>664</Hsp_query-from>
+      <Hsp_query-to>780</Hsp_query-to>
+      <Hsp_hit-from>733</Hsp_hit-from>
+      <Hsp_hit-to>842</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>93</Hsp_identity>
+      <Hsp_positive>93</Hsp_positive>
+      <Hsp_gaps>9</Hsp_gaps>
+      <Hsp_align-len>118</Hsp_align-len>
+      <Hsp_qseq>CATGTTTGACCATTATTTTTATTTAATGCAAATAACAAATTTTGGTATAAAATCAAGCGTGCCTCTGCGACAAAACTGTAACATT-TAAATTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>CATATTTAACCATTATTTTTATTTAA--AAAATAACAAATTTTGGTATAAAAT--AG-AT--ATGTATGA-TTACCTTAAAAATTCTTTATTATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>||| ||| ||||||||||||||||||   ||||||||||||||||||||||||  ||  |   | |  ||   | ||  || ||| |  |||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>15</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|15</Hit_id>
+  <Hit_def>AB462278.1 Culicoides erairai genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: IS05_2</Hit_def>
+  <Hit_accession>15</Hit_accession>
+  <Hit_len>931</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>459.089</Hsp_bit-score>
+      <Hsp_score>248</Hsp_score>
+      <Hsp_evalue>8.83619e-132</Hsp_evalue>
+      <Hsp_query-from>167</Hsp_query-from>
+      <Hsp_query-to>566</Hsp_query-to>
+      <Hsp_hit-from>309</Hsp_hit-from>
+      <Hsp_hit-to>717</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>362</Hsp_identity>
+      <Hsp_positive>362</Hsp_positive>
+      <Hsp_gaps>19</Hsp_gaps>
+      <Hsp_align-len>414</Hsp_align-len>
+      <Hsp_qseq>AAAATTACTTGGGTAGCTTTATCGAAGAGCTTTAAAGATTTGTATGCCCAAGG-CCCGTAAAACTAGTGAC---TT-CG-TGTCACTAGTATGCAT--GTTCT-CTCGCAGAGCATGCATTGATTTTTATCAAGATACTTTGGAGTGATAGTACG-A-ATGTACGCA--TAACAAACAAACAAAAAAAGATCAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTT-CTGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTTGTTTC</Hsp_qseq>
+      <Hsp_hseq>AAAATTTCTTAGGTAGCTTTATTGAAGAGCTTTAAAGACTTGTATGCCTAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGCATATATTTTAATCG--GTGTATGCATTGATATTTTTCATGATACTTTGGTGTGATATTTTGTATATTTACAAATGTAAAAATGTAA-AAAAAGAGATCAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTACT--TATTCACAAAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTGTGATTTTTC</Hsp_hseq>
+      <Hsp_midline>|||||| ||| ||||||||||| ||||||||||||||| ||||||||| |||| |||||||||||||| ||   || ||  ||  |||||||||||   || |  |||  | | |||||||||| ||| ||| |||||||||| |||||| |  | | || |||  |  ||| ||   || ||||| |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||  |||||||| ||||||||||||||||||||||||||||||||||||||||||||||||||||||| || | ||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>139.619</Hsp_bit-score>
+      <Hsp_score>75</Hsp_score>
+      <Hsp_evalue>1.30748e-35</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>170</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>173</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>148</Hsp_identity>
+      <Hsp_positive>148</Hsp_positive>
+      <Hsp_gaps>17</Hsp_gaps>
+      <Hsp_align-len>180</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTATAAAAAAATATAATGATGTAT--T-CT---AGTGTATGGTTGTT-TCGTTG-G-CATTGCAACTGCTCGCTCGAGGGCAGCTCACTATAAAGATGTAGTTTATTATGTCTTAAGTGAGTGTTG-TGATACAACAAAAA</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTAT-AAAAAATATAATGATGTATCATTCTATAAGTGTATGGTGGTTGTTGTTTCGACA--GCTAAAGTTTACTTTAG--CAGCCTACTATAAAGATGTAGTTTATTATGTCTTAAGT-A-TGGTGTTGATTCAACAAAAA</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||||||| |||||||||||||||||||  | ||   |||||||||| ||| | |||  | ||  || |  | |  ||  ||  ||||  |||||||||||||||||||||||||||||||| | || || |||| |||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>16</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|3</Hit_id>
+  <Hit_def>AB462266.1 Culicoides japonicus genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Ngs24_1</Hit_def>
+  <Hit_accession>3</Hit_accession>
+  <Hit_len>925</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>457.243</Hsp_bit-score>
+      <Hsp_score>247</Hsp_score>
+      <Hsp_evalue>3.17806e-131</Hsp_evalue>
+      <Hsp_query-from>167</Hsp_query-from>
+      <Hsp_query-to>597</Hsp_query-to>
+      <Hsp_hit-from>316</Hsp_hit-from>
+      <Hsp_hit-to>745</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>380</Hsp_identity>
+      <Hsp_positive>380</Hsp_positive>
+      <Hsp_gaps>21</Hsp_gaps>
+      <Hsp_align-len>441</Hsp_align-len>
+      <Hsp_qseq>AAAATTACTTGGGTAGCTTTATCGAAGAGCTTTAAAGATTTGTATGCCCAAGG-CCCGTAAAACTAGTGAC---TT-CG-TGTCACTAGTATGCATGTTCTCTCGCAGAGCATGCATTGATTTTTATCAAGATACTTTGGAGTGAT-AGTACGAATGTACGCATAACAAACAAACAAAAAAAGATC-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATAT-TT-CTGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTTGTTTCACAGCATCATAAGTGCATGATGTGATTATAT</Hsp_qseq>
+      <Hsp_hseq>AAAATTACTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGTATATACT-TAGTTGTATATGCATTGATATTTTTCATGATACTTTGGTGTGATTTTTGTAAAACAAAATATAATAAAATAA-AAAAATTGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATATTACT--TATTCACAAAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTTTGTT----G---CATAAGTGCATGATGTGATCATAT</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||| ||||||||||||||| |||| ||||||||| |||||||||||||| ||   || ||  ||  |||||||| || | || | |  |   |||||||||| ||| ||| |||||||||| |||||   |   ||   |   |||| |||  || |||||  |||| ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| || ||  |||||||| ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  ||    |   ||||||||||||||||||| ||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>104.533</Hsp_bit-score>
+      <Hsp_score>56</Hsp_score>
+      <Hsp_evalue>4.76955e-25</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>63</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>61</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>61</Hsp_identity>
+      <Hsp_positive>61</Hsp_positive>
+      <Hsp_gaps>2</Hsp_gaps>
+      <Hsp_align-len>63</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTATAAAAAAATATAATGATGTAT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATAT--TAAAAAAATATAATGATGTAT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||||  |||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>17</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|6</Hit_id>
+  <Hit_def>AB462269.1 Culicoides cylindratus genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Kag08, long type</Hit_def>
+  <Hit_accession>6</Hit_accession>
+  <Hit_len>820</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>449.856</Hsp_bit-score>
+      <Hsp_score>243</Hsp_score>
+      <Hsp_evalue>5.31802e-129</Hsp_evalue>
+      <Hsp_query-from>167</Hsp_query-from>
+      <Hsp_query-to>596</Hsp_query-to>
+      <Hsp_hit-from>234</Hsp_hit-from>
+      <Hsp_hit-to>652</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>377</Hsp_identity>
+      <Hsp_positive>377</Hsp_positive>
+      <Hsp_gaps>27</Hsp_gaps>
+      <Hsp_align-len>438</Hsp_align-len>
+      <Hsp_qseq>AAAATTACTTGGGTAGCTTTATCGAAGAGCTTTAAAGATTTGTATGCCCAAGG-CCCGTAAAACTAGTGACTTCGTGTCACTAGTATGCATGTTCTCTCGCAGAGCATGCATTGATTTTTATCAAGATACTTTGGAGTGA---TAGTAC--GAA-TGTACGCATAACAAACAAACAAAAAAAGATC-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCTGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTTGTTTCACAGCATCATAAGTGCATGATGTGATTATA</Hsp_qseq>
+      <Hsp_hseq>AAAATTTCTTAGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCTAAGGCCCCGTAAAACTAGTAAC-CCAT-T-GCGAGGTGGC---TAGTAT-GC--A-TATGCATTGATATTTTTCATGATACTTTGGAGTGAGTATAATACAAAAATTGTA--CAT-A-AAACAAA-TAAAAAAGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTATAATATTTTTGATATTCATAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGT-GTKTWA-AW-A-CRTAAGTGCATGATGTGATCATA</Hsp_hseq>
+      <Hsp_midline>|||||| ||| ||||||||||| ||||||||||||||| |||| |||| |||| |||||||||||||| ||  | | |  | ||   ||   |  | | ||  |  |||||||||| ||| ||| |||||||||||||||   || |||   || ||||  ||| | |||||||  |||||||||| |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| |||||||| ||||||||| |  |||||||||||||||||||||||||||||||||||||||||||||||||||||||||| || | | |  | | ||||||||||||||||| |||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>93.4528</Hsp_bit-score>
+      <Hsp_score>50</Hsp_score>
+      <Hsp_evalue>1.03243e-21</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>61</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>58</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>58</Hsp_identity>
+      <Hsp_positive>58</Hsp_positive>
+      <Hsp_gaps>3</Hsp_gaps>
+      <Hsp_align-len>61</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTATAAAAAAATATAATGATGT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTA-AAAAA--TATAATGATGT</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||||||| |||||  |||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>3</Hsp_num>
+      <Hsp_bit-score>52.8265</Hsp_bit-score>
+      <Hsp_score>28</Hsp_score>
+      <Hsp_evalue>1.75223e-09</Hsp_evalue>
+      <Hsp_query-from>753</Hsp_query-from>
+      <Hsp_query-to>780</Hsp_query-to>
+      <Hsp_hit-from>793</Hsp_hit-from>
+      <Hsp_hit-to>820</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>28</Hsp_identity>
+      <Hsp_positive>28</Hsp_positive>
+      <Hsp_gaps>0</Hsp_gaps>
+      <Hsp_align-len>28</Hsp_align-len>
+      <Hsp_qseq>TTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>TTATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>18</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|16</Hit_id>
+  <Hit_def>AB462279.1 Culicoides oxystoma genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Naha16_1</Hit_def>
+  <Hit_accession>16</Hit_accession>
+  <Hit_len>796</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>448.01</Hsp_bit-score>
+      <Hsp_score>242</Hsp_score>
+      <Hsp_evalue>1.9127e-128</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>555</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>572</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>479</Hsp_identity>
+      <Hsp_positive>479</Hsp_positive>
+      <Hsp_gaps>45</Hsp_gaps>
+      <Hsp_align-len>586</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTATAAAAAAATATAATGATGTATTC-TAGTGTATGGTTGTTTCGTTGGCAT-TGCAACTGCTCG-CTCG--AGGGCAGCTCACTATAAAGATGTAGTTTATTATGTCTTAAGTGAGT-GTTGTGATA-CAAC-AAAAATTA-CTTGGGTAGC-TTTATCGAAGAGCTTTAAAGATTTGTATGCCCAAGG-CCCGTAAAACTAGTGAC---TT-CG-TGTCACTAGTATGCATGT--T-CTCT-CGCAGAGCATGCATTGATTTTTATCAAGATACTTTGGAGTGATAGTACGAATGTACGCATAACAA-ACA-AACAAAAAAA--GATC-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTG-T-AATATT-TC--TGAT-ATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTA-ATTAAAAAAACATATAATGATGT-TTCATAAGGTATGG-TG-TT-GTT--AATATGGTAGTG-TCGTCTTGTCACGACAGCTTGTTATAAAGATGTAGTTTATTATGTCTTAAACAAGTCAATATCATATTAACGCAAAATAATCTTAGGTAGCTTTTATGTAAGAGCTTTAAAGACTTTTTTGCCTAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGTATATAATACCTTGCGTATTGTATGCATTGATTTTT--CATGATATTAATGTGTGAT-GT-TG--TTTATGCAAAACAATTAATAATAAAAAAATTGATCAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCTAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATACGATTAGATTTTGATTAATAATCTCAATGATAATTGACAAAATCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||| |||| ||||| |||||||||||| ||| ||  |||||| || || |||   || ||  | || ||| || |  | | |||||   ||||||||||||||||||||||||||||   |||   | | |||  |||  ||||| | ||| |||||| |||||  |||||||||||||| || | |||| |||| |||||||||||||| ||   || ||  ||  |||||||| || |  | |  | || |  | ||||||||||||||  || |||| |   | ||||| ||  |  | || ||| |||||   | || |||||||  |||| ||||||||||||||||||||||||||||||||||||||||||||||||||| ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||||||||||||| | |||| | ||  |||| ||| ||| | ||||||||||||||||||||||||||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>19</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|11</Hit_id>
+  <Hit_def>AB462274.1 Culicoides peregrinus genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Yng26</Hit_def>
+  <Hit_accession>11</Hit_accession>
+  <Hit_len>794</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>440.623</Hsp_bit-score>
+      <Hsp_score>238</Hsp_score>
+      <Hsp_evalue>3.20062e-126</Hsp_evalue>
+      <Hsp_query-from>169</Hsp_query-from>
+      <Hsp_query-to>598</Hsp_query-to>
+      <Hsp_hit-from>190</Hsp_hit-from>
+      <Hsp_hit-to>636</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>383</Hsp_identity>
+      <Hsp_positive>383</Hsp_positive>
+      <Hsp_gaps>23</Hsp_gaps>
+      <Hsp_align-len>450</Hsp_align-len>
+      <Hsp_qseq>AATTACTTGGGTAGCTTTA--TCGAAGAGCTTTAAAGATTTGTATGCCCAAGG-CCCGTAAAACTAGTGAC---TT-CG-TGTCACTAGTATGCATGTTCTCTCGCAGAGCATGCATTGAT-TT-TTATCAAGATACTTTGGAGTGA--T--AGTACGAATGTACGCA--T-AACA-AACAAACAAAAAAAGATC-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCTGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTTGTTTCAC-AGCATCATAAGTGCATGATGTGATTATATG</Hsp_qseq>
+      <Hsp_hseq>AATTTCTTGGGTAGCTTTAATTTTAAGAGCTTTAAAGACTTTTTTGCCCAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGTATATACT-TAATTGTATATACATTGATATTATTTTCATGATACTTTGGTGTGAAATAAAGTTATAA-GTACTATTTTGTACATATAAAAAAAAAAAAGATCTAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCMTGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTTGATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATATTTTTTTAATAAAAT-ATAAGTGCATGATGTGATTATATG</Hsp_hseq>
+      <Hsp_midline>|||| ||||||||||||||  |  |||||||||||||| || | ||||||||| |||||||||||||| ||   || ||  ||  |||||||| || | || |    |   || ||||||| || || ||| |||||||||| ||||  |  |||   || ||||     |  ||| |  ||| ||||||||||| |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| |||||||||||  |||||||||||||||||||||||||||||||||||||||||||||||||||||||| || ||| |  |  || ||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>106.379</Hsp_bit-score>
+      <Hsp_score>57</Hsp_score>
+      <Hsp_evalue>1.32611e-25</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>61</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>60</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>60</Hsp_identity>
+      <Hsp_positive>60</Hsp_positive>
+      <Hsp_gaps>1</Hsp_gaps>
+      <Hsp_align-len>61</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTATAAAAAAATATAATGATGT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATA-TATAAAAAAATATAATGATGT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||||| |||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>3</Hsp_num>
+      <Hsp_bit-score>63.9064</Hsp_bit-score>
+      <Hsp_score>34</Hsp_score>
+      <Hsp_evalue>8.09487e-13</Hsp_evalue>
+      <Hsp_query-from>665</Hsp_query-from>
+      <Hsp_query-to>780</Hsp_query-to>
+      <Hsp_hit-from>687</Hsp_hit-from>
+      <Hsp_hit-to>794</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>91</Hsp_identity>
+      <Hsp_positive>91</Hsp_positive>
+      <Hsp_gaps>10</Hsp_gaps>
+      <Hsp_align-len>117</Hsp_align-len>
+      <Hsp_qseq>ATGTTTGACCATTA-TTTTTATTTAATGCAAATAACAAATTTTGGTATAAAATCAAGCGTGCCTCTGCGACAAAACTGTAACATTTAAATTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>ATATTTGACCATTATTTTTTATTTAATTAAAATAA-TAATATTGGT-TTAAATCAAATATATAT-TGAGA-AATATTGT----TTT-ATTTATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>|| ||||||||||| ||||||||||||  ||||||  ||| ||||| | |||||||   |   | || || || | |||    ||| | ||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>20</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|10</Hit_id>
+  <Hit_def>AB462273.1 Culicoides ohmorii genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Kag05</Hit_def>
+  <Hit_accession>10</Hit_accession>
+  <Hit_len>825</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>420.31</Hsp_bit-score>
+      <Hsp_score>227</Hsp_score>
+      <Hsp_evalue>4.16966e-120</Hsp_evalue>
+      <Hsp_query-from>168</Hsp_query-from>
+      <Hsp_query-to>597</Hsp_query-to>
+      <Hsp_hit-from>202</Hsp_hit-from>
+      <Hsp_hit-to>658</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>386</Hsp_identity>
+      <Hsp_positive>386</Hsp_positive>
+      <Hsp_gaps>29</Hsp_gaps>
+      <Hsp_align-len>458</Hsp_align-len>
+      <Hsp_qseq>AAATTACTTGGGTAGCTTTATCGAAGAGCTTTAAAGATTTGTATGCCCAAGG-CCCGTAAAACTAGTGAC---TT-CG-TGTCACTAGTATGCATGTTCTCTCGCAGAGCATGCATTGATTTTTATCAAGATACTTTGG--AGTGAT-A-GT-ACGAATGTA-C-GCATA---ACA-A-ACA-AACAAAAAAAGAT---CAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTCTGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTTGTTTC-AC-----AGCATCATAAGTGCATGATGTGATTATAT</Hsp_qseq>
+      <Hsp_hseq>AAATTTCTTGGGTAGCTTTATAGAAGAGCTTTAAAGACTTGTTTGCCCAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGTATATACT-TAATTGTATATGCATTGATATTTTTCATGATACTTTGGTGTGTGATAATATAAAAAAAAAATCTTTATATTTATATAGAGAGAAAAAAAAAAAATAAGAAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATTTTTGATATTCACAAGGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTTATTTGTAAAAAAAAGAAGCATAAGTGCATGATGTGATTATAT</Hsp_hseq>
+      <Hsp_midline>||||| ||||||||||||||| ||||||||||||||| |||| ||||||||| |||||||||||||| ||   || ||  ||  |||||||| || | || |    |   |||||||||| ||| ||| ||||||||||   ||||| |  | |  ||   | |   |||   | | | | | || ||||||| ||    ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| |||||||||||  ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| |||  |      || | ||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>89.7595</Hsp_bit-score>
+      <Hsp_score>48</Hsp_score>
+      <Hsp_evalue>1.33553e-20</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>61</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>60</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>57</Hsp_identity>
+      <Hsp_positive>57</Hsp_positive>
+      <Hsp_gaps>1</Hsp_gaps>
+      <Hsp_align-len>61</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATATTATAAAAAAATATAATGATGT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTAT-TAACATAAAAATATAATGATGT</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||| | | | ||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>3</Hsp_num>
+      <Hsp_bit-score>52.8265</Hsp_bit-score>
+      <Hsp_score>28</Hsp_score>
+      <Hsp_evalue>1.75223e-09</Hsp_evalue>
+      <Hsp_query-from>753</Hsp_query-from>
+      <Hsp_query-to>780</Hsp_query-to>
+      <Hsp_hit-from>798</Hsp_hit-from>
+      <Hsp_hit-to>825</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>28</Hsp_identity>
+      <Hsp_positive>28</Hsp_positive>
+      <Hsp_gaps>0</Hsp_gaps>
+      <Hsp_align-len>28</Hsp_align-len>
+      <Hsp_qseq>TTATGACGACCTCAACTCATGTGTGACT</Hsp_qseq>
+      <Hsp_hseq>TTATGACGACCTCAACTCATGTGTGACT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>21</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|14</Hit_id>
+  <Hit_def>AB462277.1 Culicoides charadraeus genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: KC05_14</Hit_def>
+  <Hit_accession>14</Hit_accession>
+  <Hit_len>913</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>414.77</Hsp_bit-score>
+      <Hsp_score>224</Hsp_score>
+      <Hsp_evalue>1.93996e-118</Hsp_evalue>
+      <Hsp_query-from>168</Hsp_query-from>
+      <Hsp_query-to>600</Hsp_query-to>
+      <Hsp_hit-from>296</Hsp_hit-from>
+      <Hsp_hit-to>700</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>376</Hsp_identity>
+      <Hsp_positive>376</Hsp_positive>
+      <Hsp_gaps>44</Hsp_gaps>
+      <Hsp_align-len>441</Hsp_align-len>
+      <Hsp_qseq>AAATTACTTGGGTAGCTTTATCGAAGAGCTTTAAAGATTTGTATGCCCAAGG-CCCGTAAAACTAGTGAC---TT-CG-TGTCACTAGTATGCATGTTCTCTCGCAGAGCATGCATTGATTTTTATCAAGATACTTTGGAGTGATAGTACGAATGTACGCATAACAAACAAACAAAAAAAGATCAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAAT--ATTTCTGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATGTTGTTTCACAGCATCATAAGTGCATGATGTGATTATATGGG</Hsp_qseq>
+      <Hsp_hseq>AAATTTCTTAGGTAGCTTTATCGAAGAGCTTTAAAGACTTGTTTGCCTAAGGCCCCGTAAAACTAGTAACCCATTGCGAGGTGGCTAGTATGCAT----T-T------G--TGCATTGATATTTTTCATGATACTTTGG--TG-T-GTTTG--TGTA---ATAA-AAA-AAA-ATAAAAA-ATCAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATTGATATTTGTTAT--A-A-AGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTATAT-GTAT-AT-G--T-ATAAGTGCATGATGTGATTATATGGG</Hsp_hseq>
+      <Hsp_midline>||||| ||| ||||||||||||||||||||||||||| |||| |||| |||| |||||||||||||| ||   || ||  ||  |||||||||||    | |      |  ||||||||| ||| ||| ||||||||||  || | ||  |  ||||   |||| ||| ||| | ||||| ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||  || | || |||  | | ||||||||||||||||||||||||||||||||||||||||||||||||||||||||| | || | |  |  | ||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>100.839</Hsp_bit-score>
+      <Hsp_score>54</Hsp_score>
+      <Hsp_evalue>6.1698e-24</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>80</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>83</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>74</Hsp_identity>
+      <Hsp_positive>74</Hsp_positive>
+      <Hsp_gaps>3</Hsp_gaps>
+      <Hsp_align-len>83</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTA-TATTATAAAAAAA-TATAATGATGTATTCT-AGTGTATGGTTGTT</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTAATATAAAACAAAAATTATAATGATGTATTCTCATTGGTTGGTTGTT</Hsp_hseq>
+      <Hsp_midline>||||||||||||||||||||||||||||||||||||| ||| | | ||||| |||||||||||||||| | ||  ||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+<Hit>
+  <Hit_num>22</Hit_num>
+  <Hit_id>gnl|BL_ORD_ID|7</Hit_id>
+  <Hit_def>AB462270.1 Culicoides dubius genes for 18S rRNA, ITS1, 5.8S rRNA, ITS2a, 2S rRNA, ITS2, 28S rRNA, partial and complete sequence, clone: Isg23</Hit_def>
+  <Hit_accession>7</Hit_accession>
+  <Hit_len>1096</Hit_len>
+  <Hit_hsps>
+    <Hsp>
+      <Hsp_num>1</Hsp_num>
+      <Hsp_bit-score>364.91</Hsp_bit-score>
+      <Hsp_score>197</Hsp_score>
+      <Hsp_evalue>1.98157e-103</Hsp_evalue>
+      <Hsp_query-from>322</Hsp_query-from>
+      <Hsp_query-to>558</Hsp_query-to>
+      <Hsp_hit-from>597</Hsp_hit-from>
+      <Hsp_hit-to>831</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>227</Hsp_identity>
+      <Hsp_positive>227</Hsp_positive>
+      <Hsp_gaps>8</Hsp_gaps>
+      <Hsp_align-len>240</Hsp_align-len>
+      <Hsp_qseq>ATAACAAACAAACAAAAAAAGATCAAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATAT-TTC--TGATATTCACAGAGTCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTAT</Hsp_qseq>
+      <Hsp_hseq>ATAA-AAA-AAA-AAATTAA-AT-AAAACCTTAAACGGGGGATCACTTGGCTCATGGGTCGATGAAGACCGCAGCAAACTGCGTGTCACCATGTGAACTGCAGGACACACGATCATTGACATGTTGAACGCATATTGCACCCCATGCGATTAGATTTTGTAATATCTTAGTTGTTATTCACAGAATCTGTGTGGGGTACACATGGTTGAGTGTCGTTATTTATATATTAAACTATCTTAT</Hsp_hseq>
+      <Hsp_midline>|||| ||| ||| |||  || || ||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||| ||   || |||||||||| |||||||||||||||||||||||||||||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+    <Hsp>
+      <Hsp_num>2</Hsp_num>
+      <Hsp_bit-score>73.1396</Hsp_bit-score>
+      <Hsp_score>39</Hsp_score>
+      <Hsp_evalue>1.34501e-15</Hsp_evalue>
+      <Hsp_query-from>1</Hsp_query-from>
+      <Hsp_query-to>39</Hsp_query-to>
+      <Hsp_hit-from>1</Hsp_hit-from>
+      <Hsp_hit-to>39</Hsp_hit-to>
+      <Hsp_query-frame>1</Hsp_query-frame>
+      <Hsp_hit-frame>1</Hsp_hit-frame>
+      <Hsp_identity>39</Hsp_identity>
+      <Hsp_positive>39</Hsp_positive>
+      <Hsp_gaps>0</Hsp_gaps>
+      <Hsp_align-len>39</Hsp_align-len>
+      <Hsp_qseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATA</Hsp_qseq>
+      <Hsp_hseq>TTTCCGTAGGTGAACCTGCGGAAGGATCATTATTGTATA</Hsp_hseq>
+      <Hsp_midline>|||||||||||||||||||||||||||||||||||||||</Hsp_midline>
+    </Hsp>
+  </Hit_hsps>
+</Hit>
+</Iteration_hits>
+  <Iteration_stat>
+    <Statistics>
+      <Statistics_db-num>22</Statistics_db-num>
+      <Statistics_db-len>18669</Statistics_db-len>
+      <Statistics_hsp-len>16</Statistics_hsp-len>
+      <Statistics_eff-space>13994188</Statistics_eff-space>
+      <Statistics_kappa>0.46</Statistics_kappa>
+      <Statistics_lambda>1.28</Statistics_lambda>
+      <Statistics_entropy>0.85</Statistics_entropy>
+    </Statistics>
+  </Iteration_stat>
+</Iteration>
+</BlastOutput_iterations>
+</BlastOutput>
+


### PR DESCRIPTION
As discussed on galaxyproject/tools-iuc#1893 this turns the merge code from the Galaxy BLAST XML datatype into a tool that can merge a list of datasets (or multiple individual datasets) into a single BLAST XML dataset.