### PR TITLE
Clarify max hits option help text

### DIFF
--- a/tools/ncbi_blast_plus/README.rst
+++ b/tools/ncbi_blast_plus/README.rst
@@ -259,6 +259,10 @@ v0.3.0  - Updated for NCBI BLAST+ 2.7.1,
         - Document the BLAST+ 2.6.0 change in the standard 12 column output
           from ``qacc,sacc,...`` to ``qaccver,saccver,...`` instead.
         - Accept gzipped FASTA inputs (contribution from Anton Nekrutenko).
+v0.3.1  - Clarify help text for max hits option, confusing as depending on the
+          output format it must be mapped to different command line arguments.
+          Except for text and HTML outputs, must use ``-max_target_seqs``
+          which does not just apply as an output limit.
 ======= ======================================================================
 
 

--- a/tools/ncbi_blast_plus/ncbi_macros.xml
+++ b/tools/ncbi_blast_plus/ncbi_macros.xml
@@ -623,7 +623,7 @@
         -max_target_seqs '${adv_opts.max_hits}'
     #else
         ## Text and HTML output formats 0-4 currently need this instead:
-        -num_descriptions '${adv_opts.max_hits}' -num_alignments '${adv_opts.max_hits}#
+        -num_descriptions '${adv_opts.max_hits}' -num_alignments '${adv_opts.max_hits}'
     #end if
 #end if
 #if str($adv_opts.max_hsps)

--- a/tools/ncbi_blast_plus/ncbi_macros.xml
+++ b/tools/ncbi_blast_plus/ncbi_macros.xml
@@ -443,7 +443,7 @@
     </xml>
 
     <xml name="input_max_hits">
-        <param name="max_hits" type="integer" min="0" value="0" label="Maximum hits to consider/show" help="Use zero for default limits. For HTML and plain text output this value is passed -num_descriptions and -num_alignments and used as a final output limit. For XML and tabular etc, this is used with -max_target_seqs which is also used as an internal limit during the search, which can in some cases exclude matches would otherwise become the best hit." />
+        <param name="max_hits" type="integer" min="0" value="0" label="Maximum hits to consider/show" help="Use zero for default limits. For HTML and plain text output this value is passed -num_descriptions and -num_alignments and used as a final output limit. For XML and tabular etc, this is used with -max_target_seqs which is also used as an internal limit during the search, which can in some cases exclude matches which would otherwise become the best hit." />
         <param argument="-max_hsps" type="integer" min="1" optional="true" value="" label="Maximum number of HSPs (alignments) to keep for any single query-subject pair" help="The HSPs shown will be the best as judged by expect value. If this option is not set, BLAST shows all HSPs meeting the expect value criteria" />
     </xml>
 

--- a/tools/ncbi_blast_plus/ncbi_macros.xml
+++ b/tools/ncbi_blast_plus/ncbi_macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@WRAPPER_VERSION@">0.3.0</token>
+    <token name="@WRAPPER_VERSION@">0.3.1</token>
     <xml name="parallelism">
         <!-- If job splitting is enabled, break up the query file into parts -->
         <parallelism method="multi" split_inputs="query" split_mode="to_size" split_size="1000" merge_outputs="output1" />
@@ -443,7 +443,7 @@
     </xml>
 
     <xml name="input_max_hits">
-        <param name="max_hits" type="integer" min="0" value="0" label="Maximum hits to show" help="Use zero for default limits" />
+        <param name="max_hits" type="integer" min="0" value="0" label="Maximum hits to consider/show" help="Use zero for default limits. For HTML and plain text output this value is passed -num_descriptions and -num_alignments and used as a final output limit. For XML and tabular etc, this is used with -max_target_seqs which is also used as an internal limit during the search, which can in some cases exclude matches would otherwise become the best hit." />
         <param argument="-max_hsps" type="integer" min="1" optional="true" value="" label="Maximum number of HSPs (alignments) to keep for any single query-subject pair" help="The HSPs shown will be the best as judged by expect value. If this option is not set, BLAST shows all HSPs meeting the expect value criteria" />
     </xml>
 
@@ -589,15 +589,41 @@
     <token name="@ADV_FILTER_QUERY@">$adv_opts.filter_query</token>
     <token name="@ADV_MAX_HITS@"><![CDATA[
 ## Need int(str(...)) because $adv_opts.max_hits is an InputValueWrapper object not a string
-## Note -max_target_seqs used to simply override -num_descriptions and -num_alignments
-## but this was changed in BLAST+ 2.2.27 onwards to force their use (raised with NCBI)
+##
+## Quoting BLAST 2.7.1+ output from "blastp --help" or "blastn --help":
+##
+##  *** Formatting options
+##   -num_descriptions <Integer, >=0>
+##    Number of database sequences to show one-line descriptions for
+##    Not applicable for outfmt > 4
+##    Default = `500'
+##     * Incompatible with:  max_target_seqs
+##  -num_alignments <Integer, >=0>
+##    Number of database sequences to show alignments for
+##    Default = `250'
+##     * Incompatible with:  max_target_seqs
+##
+##  *** Restrict search or results
+##
+##  -max_target_seqs <Integer, >=1>
+##   Maximum number of aligned sequences to keep
+##   Not applicable for outfmt <= 4
+##   Default = `500'
+##    * Incompatible with:  num_descriptions, num_alignments
+##
+## So, taken at face value we do still need to treat the Text and HTML output
+## differently from the Tabular and XML, yet the treatment of these limits is
+## different (during search or after the search when writing the output):
+## https://blastedbio.blogspot.com/2015/12/blast-max-target-sequences-bug.html
+##
+## See also our user-facing help text.
 #if (str($adv_opts.max_hits) and int(str($adv_opts.max_hits)) > 0):
     #if str($output.out_format) in ["6", "ext", "cols", "5"]:
         ## Most output formats use this, including tabular and XML:
         -max_target_seqs '${adv_opts.max_hits}'
     #else
         ## Text and HTML output formats 0-4 currently need this instead:
-        -num_descriptions $adv_opts.max_hits -num_alignments $adv_opts.max_hits
+        -num_descriptions '${adv_opts.max_hits}' -num_alignments '${adv_opts.max_hits}#
     #end if
 #end if
 #if str($adv_opts.max_hsps)


### PR DESCRIPTION
Clarify help text for max hits option, confusing as depending on the output format it must be mapped to different command line arguments. Except for text and HTML outputs, must use ``-max_target_seqs`` which does not _just_ apply as an output limit.

I have quoted parts of the command line help in the XML, also https://www.ncbi.nlm.nih.gov/books/NBK279682/ says:
    
>"The max_target_seqs option should be used with any tabular output to control the number of matches reported."

See my 2015 blog post for details & the apparent NCBI BLAST+ bug Sujai Kumar found https://blastedbio.blogspot.com/2015/12/blast-max-target-sequences-bug.html and new paper Shah et al (2018) which also flags the sometimes unexpected side effects of this confusingly documented BLAST+ "feature" https://doi.org/10.1093/bioinformatics/bty833