### PR TITLE
Remove deprecated ``sudo: false`` from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,6 @@
 # for background,
 # http://blastedbio.blogspot.com/2013/09/using-travis-ci-for-testing-galaxy-tools.html
 
-# We don't need sudo so can avoid slower legacy TravisCI infrastructure
-sudo: false
-
 # Galaxy currently only supports Python 2.7
 language: python
 cache: pip


### PR DESCRIPTION
See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration