### PR TITLE
make blast dbs non-optional

### DIFF
--- a/tools/ncbi_blast_plus/README.rst
+++ b/tools/ncbi_blast_plus/README.rst
@@ -136,7 +136,7 @@ a galaxy specific suffix which gets reset to zero with each new BLAST version:
 ============== ===============================================================
 Version        Changes
 -------------- ---------------------------------------------------------------
-2.10.1+galaxy1 - Make cached reference data selector non-optional
+2.10.1+galaxy1 - Make locally installed database selector non-optional.
 2.10.1+galaxy0 - Updated for NCBI BLAST+ 2.10.1 release.
                - Supports locally installed v4 or v5 format BLAST databases
                  (listed in the ``blastdb*.loc`` files).

--- a/tools/ncbi_blast_plus/README.rst
+++ b/tools/ncbi_blast_plus/README.rst
@@ -136,6 +136,7 @@ a galaxy specific suffix which gets reset to zero with each new BLAST version:
 ============== ===============================================================
 Version        Changes
 -------------- ---------------------------------------------------------------
+2.10.1+galaxy1 - Make cached reference data selector non-optional
 2.10.1+galaxy0 - Updated for NCBI BLAST+ 2.10.1 release.
                - Supports locally installed v4 or v5 format BLAST databases
                  (listed in the ``blastdb*.loc`` files).

--- a/tools/ncbi_blast_plus/ncbi_macros.xml
+++ b/tools/ncbi_blast_plus/ncbi_macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">2.10.1</token>
-    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@VERSION_SUFFIX@">1</token>
     <token name="@PROFILE@">16.10</token>
     <xml name="parallelism">
         <!-- If job splitting is enabled, break up the query file into parts -->
@@ -353,7 +353,7 @@
               <option value="file">FASTA file from your history (see warning note below)</option>
             </param>
             <when value="db">
-                <param name="database" type="select" multiple="true" label="Nucleotide BLAST database">
+                <param name="database" type="select" multiple="true" optional="false" label="Nucleotide BLAST database">
                     <options from_data_table="blastdb" />
                 </param>
                 <param name="histdb" type="hidden" value="" />
@@ -381,7 +381,7 @@
               <option value="file">FASTA file from your history (see warning note below)</option>
             </param>
             <when value="db">
-                <param name="database" type="select" multiple="true" label="Protein BLAST database">
+                <param name="database" type="select" multiple="true" optional="false" label="Protein BLAST database">
                     <options from_data_table="blastdb_p" />
                 </param>
                 <param name="histdb" type="hidden" value="" />
@@ -452,7 +452,7 @@
                           <option value="histdb">BLAST database from your history</option>
                       </param>
                       <when value="db">
-                          <param name="database" argument="-db" type="select" multiple="true" label="Protein BLAST database">
+                          <param name="database" argument="-db" type="select" multiple="true" optional="false" label="Protein BLAST database">
                             <options from_data_table="blastdb_p" />
                         </param>
                         <param name="histdb" type="hidden" value="" />


### PR DESCRIPTION
since multiple="true" selects are optional by default the tools
can be submitted without selecting a DB which leads to a tool
error.