### PR TITLE
fix make_nr if no dups exist

### DIFF
--- a/tools/make_nr/.shed.yml
+++ b/tools/make_nr/.shed.yml
@@ -24,3 +24,4 @@ include:
   - ../../test-data/more_duplicates.fasta
   - ../../test-data/deduplicate.nosortids.fasta
   - ../../test-data/deduplicate.sortids.fasta
+  - ../../test-data/empty.fasta

--- a/tools/make_nr/make_nr.py
+++ b/tools/make_nr/make_nr.py
@@ -141,7 +141,7 @@ def make_nr(input_fasta, output_fasta, sep=";", sort_ids=False):
         )
     elif len(input_fasta) == 1:
         # Single file, no need to make a copy or edit titles
-        os.symlink(os.path.abspath(input_fasta), output_fasta)
+        os.symlink(os.path.abspath(input_fasta[0]), output_fasta)
         sys.stderr.write("No perfect duplicates in file, %i unique entries\n" % unique)
     else:
         with open(output_fasta, "w") as handle:

--- a/tools/make_nr/make_nr.py
+++ b/tools/make_nr/make_nr.py
@@ -18,7 +18,7 @@ from optparse import OptionParser
 
 
 if "-v" in sys.argv or "--version" in sys.argv:
-    print("v0.0.1")
+    print("v0.0.2")
     sys.exit(0)
 
 
@@ -134,14 +134,17 @@ def make_nr(input_fasta, output_fasta, sep=";", sort_ids=False):
                             continue
                         # TODO - line wrapping
                         handle.write(">%s\n%s\n" % (title, seq))
-        sys.stderr.write(
-            "%i unique entries; removed %i duplicates "
-            "leaving %i representative records\n"
-            % (unique, len(duplicates), len(representatives))
-        )
     else:
-        os.symlink(os.path.abspath(input_fasta), output_fasta)
-        sys.stderr.write("No perfect duplicates in file, %i unique entries\n" % unique)
+        with open(output_fasta, "w") as handle:
+            for f in input_fasta:
+                with gzip_open(f) as in_handle:
+                    for title, seq in SimpleFastaParser(in_handle):
+                        handle.write(">%s\n%s\n" % (title, seq))
+    sys.stderr.write(
+        "%i unique entries; removed %i duplicates "
+        "leaving %i representative records\n"
+        % (unique, len(duplicates), len(representatives))
+    )
 
 
 make_nr(args, options.output, options.sep, options.alphasort)

--- a/tools/make_nr/make_nr.py
+++ b/tools/make_nr/make_nr.py
@@ -12,6 +12,7 @@ from __future__ import print_function
 
 import gzip
 import os
+import shutil
 import sys
 
 from optparse import OptionParser
@@ -141,7 +142,7 @@ def make_nr(input_fasta, output_fasta, sep=";", sort_ids=False):
         )
     elif len(input_fasta) == 1:
         # Single file, no need to make a copy or edit titles
-        os.symlink(os.path.abspath(input_fasta[0]), output_fasta)
+        shutil.copy(os.path.abspath(input_fasta[0]), output_fasta)
         sys.stderr.write("No perfect duplicates in file, %i unique entries\n" % unique)
     else:
         with open(output_fasta, "w") as handle:

--- a/tools/make_nr/make_nr.xml
+++ b/tools/make_nr/make_nr.xml
@@ -51,6 +51,14 @@ python $__tool_directory__/make_nr.py $alphasort -s '$separator' -o '$output'
             <param name="alphasort" value="-a"/>
             <output name="output" file="deduplicate.sortids.fasta" ftype="fasta"/>
         </test>
+        <test>
+            <param name="input" value="empty.fasta" ftype="fasta"/>
+            <output name="output" file="empty.fasta" ftype="fasta"/>
+        </test>
+        <test>
+            <param name="input" value="empty.fasta,empty.fasta" ftype="fasta"/>
+            <output name="output" file="empty.fasta" ftype="fasta"/>
+        </test>
     </tests>
     <help>
 **What it does**

--- a/tools/make_nr/make_nr.xml
+++ b/tools/make_nr/make_nr.xml
@@ -1,4 +1,4 @@
-<tool id="make_nr" name="Make FASTA non-redundant" version="0.0.1">
+<tool id="make_nr" name="Make FASTA non-redundant" version="0.0.2">
     <description>by combining duplicated sequences</description>
     <requirements>
         <requirement type="package" version="1.67">biopython</requirement>

--- a/tools/ncbi_blast_plus/README.rst
+++ b/tools/ncbi_blast_plus/README.rst
@@ -136,6 +136,7 @@ a galaxy specific suffix which gets reset to zero with each new BLAST version:
 ============== ===============================================================
 Version        Changes
 -------------- ---------------------------------------------------------------
+2.10.1+galaxy1 - Make locally installed database selector non-optional.
 2.10.1+galaxy0 - Updated for NCBI BLAST+ 2.10.1 release.
                - Supports locally installed v4 or v5 format BLAST databases
                  (listed in the ``blastdb*.loc`` files).

--- a/tools/ncbi_blast_plus/ncbi_macros.xml
+++ b/tools/ncbi_blast_plus/ncbi_macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">2.10.1</token>
-    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@VERSION_SUFFIX@">1</token>
     <token name="@PROFILE@">16.10</token>
     <xml name="parallelism">
         <!-- If job splitting is enabled, break up the query file into parts -->
@@ -353,7 +353,7 @@
               <option value="file">FASTA file from your history (see warning note below)</option>
             </param>
             <when value="db">
-                <param name="database" type="select" multiple="true" label="Nucleotide BLAST database">
+                <param name="database" type="select" multiple="true" optional="false" label="Nucleotide BLAST database">
                     <options from_data_table="blastdb" />
                 </param>
                 <param name="histdb" type="hidden" value="" />
@@ -381,7 +381,7 @@
               <option value="file">FASTA file from your history (see warning note below)</option>
             </param>
             <when value="db">
-                <param name="database" type="select" multiple="true" label="Protein BLAST database">
+                <param name="database" type="select" multiple="true" optional="false" label="Protein BLAST database">
                     <options from_data_table="blastdb_p" />
                 </param>
                 <param name="histdb" type="hidden" value="" />
@@ -452,7 +452,7 @@
                           <option value="histdb">BLAST database from your history</option>
                       </param>
                       <when value="db">
-                          <param name="database" argument="-db" type="select" multiple="true" label="Protein BLAST database">
+                          <param name="database" argument="-db" type="select" multiple="true" optional="false" label="Protein BLAST database">
                             <options from_data_table="blastdb_p" />
                         </param>
                         <param name="histdb" type="hidden" value="" />


### PR DESCRIPTION
the branch for the case that no duplicates exist
fails because is assumes that the input is a
single file:

```
Traceback (most recent call last):
  File "/gpfs1/data/galaxy_server/galaxy/shed_tools/toolshed.g2.bx.psu.edu/repos/peterjc/make_nr/c84f12187af9/make_nr/tools/make_nr/make_nr.py", line 133, in <module>
    make_nr(args, options.output, options.sep, options.alphasort)
  File "/gpfs1/data/galaxy_server/galaxy/shed_tools/toolshed.g2.bx.psu.edu/repos/peterjc/make_nr/c84f12187af9/make_nr/tools/make_nr/make_nr.py", line 128, in make_nr
    os.symlink(os.path.abspath(input_fasta), output_fasta)
  File "/gpfs1/data/galaxy_server/galaxy/database/dependencies/_conda/envs/__biopython@1.67/lib/python3.6/posixpath.py", line 378, in abspath
    path = os.fspath(path)
TypeError: expected str, bytes or os.PathLike object, not list
```