### PR TITLE
Ignore flake8 B902 blind except Exception: statement

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -5,3 +5,7 @@ max-line-length = 88
 extend-ignore =
     # See https://github.com/PyCQA/pycodestyle/issues/373
     E203,
+    # B902 blind except Exception: statement
+    # For now willing to ignore this as testing assorted
+    # operating systems for the right exception is hard:
+    B902,


### PR DESCRIPTION
For now willing to ignore this as testing assorted operating systems for the right exception is hard.