### PR TITLE
TaxID Changes to Allow higher-level IDs

### DIFF
--- a/tool-data/taxid_nodes.loc.sample
+++ b/tool-data/taxid_nodes.loc.sample
@@ -1,0 +1,7 @@
+# A sample of the TaxID location file, functionally identical to the blastloc files
+# One probably would not need to store more than just the copy ofnodes.dmp from NCBI,
+# but this method does allow it if so desired. 
+#
+#<unique_id>	<database_caption>	<base_name_path>
+#
+ncbi_nodes	NCBI nodes.dmp 06.29.2022	/opt/blast/nodes.dmp

--- a/tool-data/tool_data_table_conf.xml.sample
+++ b/tool-data/tool_data_table_conf.xml.sample
@@ -11,4 +11,8 @@
         <columns>value, name, path</columns>
         <file path="tool-data/blastdb_d.loc" />
     </table>
+    <table name="taxid_nodes" comment_char="#" allow_duplicate_entries="False">
+        <columns>value, name, path</columns>
+        <file path="tool-data/taxid_nodes.loc" />
+    </table>
 </tables>

--- a/tools/ncbi_blast_plus/ncbi_blastn_wrapper.xml
+++ b/tools/ncbi_blast_plus/ncbi_blastn_wrapper.xml
@@ -5,11 +5,14 @@
         <import>ncbi_macros.xml</import>
     </macros>
     <expand macro="parallelism" />
-    <expand macro="preamble" />
+    <expand macro="preamble">
+      <requirement type="package" version="3.9">python</requirement>
+    </expand>
     <command detect_errors="aggressive">
 <![CDATA[
 ## The command is a Cheetah template which allows some Python based syntax.
 ## Lines starting hash hash are comments. Galaxy will turn newlines into spaces
+@TAXID_FILE_GEN@
 blastn
 @QUERY@
 @BLAST_DB_SUBJECT@

--- a/tools/ncbi_blast_plus/ncbi_blastp_wrapper.xml
+++ b/tools/ncbi_blast_plus/ncbi_blastp_wrapper.xml
@@ -5,10 +5,13 @@
         <import>ncbi_macros.xml</import>
     </macros>
     <expand macro="parallelism" />
-    <expand macro="preamble" />
+    <expand macro="preamble">
+      <requirement type="package" version="3.9">python</requirement>
+    </expand>
     <command detect_errors="aggressive">
 ## The command is a Cheetah template which allows some Python based syntax.
 ## Lines starting hash hash are comments. Galaxy will turn newlines into spaces
+@TAXID_FILE_GEN@
 blastp
 @QUERY@
 @BLAST_DB_SUBJECT@

--- a/tools/ncbi_blast_plus/ncbi_blastx_wrapper.xml
+++ b/tools/ncbi_blast_plus/ncbi_blastx_wrapper.xml
@@ -5,10 +5,13 @@
         <import>ncbi_macros.xml</import>
     </macros>
     <expand macro="parallelism" />
-    <expand macro="preamble" />
+    <expand macro="preamble">
+      <requirement type="package" version="3.9">python</requirement>
+    </expand>
     <command detect_errors="aggressive">
 ## The command is a Cheetah template which allows some Python based syntax.
 ## Lines starting hash hash are comments. Galaxy will turn newlines into spaces
+@TAXID_FILE_GEN@
 blastx
 @QUERY@
 @BLAST_DB_SUBJECT@

--- a/tools/ncbi_blast_plus/ncbi_macros.xml
+++ b/tools/ncbi_blast_plus/ncbi_macros.xml
@@ -1,6 +1,6 @@
 <macros>
-    <token name="@TOOL_VERSION@">2.10.1</token>
-    <token name="@VERSION_SUFFIX@">2</token>
+    <token name="@TOOL_VERSION@">2.12.0</token>
+    <token name="@VERSION_SUFFIX@">1</token>
     <token name="@PROFILE@">16.10</token>
     <xml name="parallelism">
         <!-- If job splitting is enabled, break up the query file into parts -->
@@ -576,12 +576,64 @@
                        help="This option is only available for database searches."/>
             </when>
             <when value="taxidlist">
-                <param argument="-taxidlist" type="data" format="txt" label="Restrict search of database to list of TaxId's"
-                       help="This option is only available for database searches."/>
+              <conditional name="taxon_filtering">
+                <param type="select" label="Filter results by TaxID" name="taxon_selection">
+                  <option value="file_filter">Use TaxIDs from text file</option>
+                  <option value="text_filter">Manually enter TaxIDs</option>
+                </param>
+                <when value="file_filter">
+                  <param name="filter_item" type="data" format="txt" label="TaxID List from History (New-line separated, .txt format)"/>
+                </when>
+                <when value="text_filter">
+                  <conditional name="master_taxon_list">
+                    <param type="select" label="TaxID master list (For deriving sub-IDs)" name="master_selection">
+                      <option value="installed" selected="true">Use installed nodes.dmp file to derive sub-IDs</option>
+                      <option value="uploaded">Use history item to derive sub-IDs (Must match NCBI nodes.dmp format)</option>
+                      <option value="no_master">Do not derive sub-IDs</option>
+                    </param>
+                    <when value="installed">
+                      <param name="database" type="select" multiple="false" label="Select masterlist of TaxIDs (nodes.dmp file)">
+                        <options from_data_table="taxid_nodes" />
+                      </param>
+                    </when>
+                    <when value="uploaded">
+                      <param name="database" type="data" format="txt,dmp" multiple="false" label="Select masterlist of TaxIDs (nodes.dmp file)"/>
+                    </when>
+                  </conditional>
+                  <param label="Filter by these TaxIDs (Can be multiple, comma-separated)" name="taxids" type="text" value="" optional="true"/>
+                </when>
+              </conditional>
             </when>
             <when value="negative_taxidlist">
-                <param argument="-negative_taxidlist" type="data" format="txt" label="Restrict search of database to list of TaxId's"
-                       help="This option is only available for database searches."/>
+                <conditional name="taxon_filtering">
+                <param type="select" label="Filter results by TaxID" name="taxon_selection">
+                  <option value="file_filter">Use TaxIDs from text file</option>
+                  <option value="text_filter">Manually enter TaxIDs</option>
+                </param>
+                <when value="file_filter">
+                  <param name="filter_item" type="data" format="txt" label="TaxID List from History (New-line separated, .txt format)"/>
+                </when>
+                <when value="text_filter">
+                  <conditional name="master_taxon_list">
+                    <param type="select" label="TaxID master list (For deriving sub-IDs)" name="master_selection">
+                      <option value="installed" selected="true">Use installed nodes.dmp file to derive sub-IDs</option>
+                      <option value="uploaded">Use history item to derive sub-IDs (First two columns must match NCBI nodes.dmp format)</option>
+                      <option value="no_master">Do not derive sub-IDs (Can only use species and strain level IDs)</option>
+                    </param>
+                    <when value="installed">
+                      <param name="database" type="select" multiple="false" label="Select masterlist of TaxIDs (nodes.dmp file)">
+                        <options from_data_table="taxid_nodes" />
+                      </param>
+                    </when>
+                    <when value="uploaded">
+                      <param name="database" type="data" format="txt,dmp" multiple="false" label="Select masterlist of TaxIDs (nodes.dmp file)"/>
+                    </when>
+                    <when value="no_master">
+                    </when>
+                  </conditional>
+                  <param label="Filter by these TaxIDs (Can be multiple, comma-separated)" name="taxids" type="text" value="" optional="true"/>
+                </when>
+              </conditional>
             </when>
         </conditional>
     </xml>
@@ -600,6 +652,25 @@
 #end if
     ]]></token>
 
+    <token name="@TAXID_FILE_GEN@"><![CDATA[
+#if $adv_opts.adv_optional_id_files_opts.adv_optional_id_files_opts_selector == 'taxidlist' or $adv_opts.adv_optional_id_files_opts.adv_optional_id_files_opts_selector == 'negative_taxidlist':
+  #if $adv_opts.adv_optional_id_files_opts.taxon_filtering.taxon_selection == 'text_filter':
+    #if $adv_opts.adv_optional_id_files_opts.taxon_filtering.master_taxon_list.master_selection == 'no_master':
+      $__tool_directory__/taxSubIDs.py
+      '${adv_opts.adv_optional_id_files_opts.taxon_filtering.taxids}' >> ./taxFile.txt;
+    #elif $adv_opts.adv_optional_id_files_opts.taxon_filtering.master_taxon_list.master_selection == 'uploaded':
+      $__tool_directory__/taxSubIDs.py
+      '${adv_opts.adv_optional_id_files_opts.taxon_filtering.master_taxon_list.database}' '${adv_opts.adv_optional_id_files_opts.taxon_filtering.taxids}' >> ./taxFile.txt;
+    #else
+      $__tool_directory__/taxSubIDs.py
+      '${adv_opts.adv_optional_id_files_opts.taxon_filtering.master_taxon_list.database.fields.path}' '${adv_opts.adv_optional_id_files_opts.taxon_filtering.taxids}' >> ./taxFile.txt;
+    #end if
+  #elif $adv_opts.adv_optional_id_files_opts.taxon_filtering.taxon_selection == 'file_filter':
+    ln -s '${adv_opts.adv_optional_id_files_opts.taxon_filtering.filter_item}' ./taxFile.txt
+  #end if
+#end if
+    ]]></token>
+
     <token name="@ADV_ID_LIST_FILTER@"><![CDATA[
 #if $adv_opts.adv_optional_id_files_opts.adv_optional_id_files_opts_selector == 'negative_gilist':
     -negative_gilist '${adv_opts.adv_optional_id_files_opts.negative_gilist}'
@@ -608,9 +679,9 @@
 #elif $adv_opts.adv_optional_id_files_opts.adv_optional_id_files_opts_selector == 'seqidlist':
     -seqidlist '${adv_opts.adv_optional_id_files_opts.seqidlist}'
 #elif $adv_opts.adv_optional_id_files_opts.adv_optional_id_files_opts_selector == 'taxidlist':
-    -taxidlist '${adv_opts.adv_optional_id_files_opts.taxidlist}'
+    -taxidlist taxFile.txt
 #elif $adv_opts.adv_optional_id_files_opts.adv_optional_id_files_opts_selector == 'negative_taxidlist':
-    -negative_taxidlist '${adv_opts.adv_optional_id_files_opts.negative_taxidlist}'
+    -negative_taxidlist taxFile.txt
 #end if
     ]]></token>
 
@@ -630,7 +701,7 @@
 #if $db_opts.db_origin.db_origin_selector=="db":
   -db "${db_opts.db_origin.database.fields.path.replace(',',' ')}"
 #else if $db_opts.db_origin.db_origin_selector=="histdb":
-  -db '${os.path.join($db_opts.db_origin.histdb.extra_files_path, "blastdb")}'
+-db ${os.path.join($db_opts.db_origin.histdb.extra_files_path, "blastdb")}
 #end if
     ]]></token>
 

--- a/tools/ncbi_blast_plus/ncbi_macros.xml
+++ b/tools/ncbi_blast_plus/ncbi_macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">2.10.1</token>
-    <token name="@VERSION_SUFFIX@">1</token>
+    <token name="@VERSION_SUFFIX@">2</token>
     <token name="@PROFILE@">16.10</token>
     <xml name="parallelism">
         <!-- If job splitting is enabled, break up the query file into parts -->

--- a/tools/ncbi_blast_plus/ncbi_macros.xml
+++ b/tools/ncbi_blast_plus/ncbi_macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">2.12.0</token>
+    <token name="@TOOL_VERSION@">2.10.1</token>
     <token name="@VERSION_SUFFIX@">1</token>
     <token name="@PROFILE@">16.10</token>
     <xml name="parallelism">

--- a/tools/ncbi_blast_plus/ncbi_tblastn_wrapper.xml
+++ b/tools/ncbi_blast_plus/ncbi_tblastn_wrapper.xml
@@ -5,10 +5,13 @@
         <import>ncbi_macros.xml</import>
     </macros>
     <expand macro="parallelism" />
-    <expand macro="preamble" />
+    <expand macro="preamble">
+      <requirement type="package" version="3.9">python</requirement>
+    </expand>
     <command detect_errors="aggressive">
 ## The command is a Cheetah template which allows some Python based syntax.
 ## Lines starting hash hash are comments. Galaxy will turn newlines into spaces
+@TAXID_FILE_GEN@
 tblastn
 @QUERY@
 @BLAST_DB_SUBJECT@

--- a/tools/ncbi_blast_plus/ncbi_tblastx_wrapper.xml
+++ b/tools/ncbi_blast_plus/ncbi_tblastx_wrapper.xml
@@ -5,10 +5,13 @@
         <import>ncbi_macros.xml</import>
     </macros>
     <expand macro="parallelism" />
-    <expand macro="preamble" />
+    <expand macro="preamble">
+      <requirement type="package" version="3.9">python</requirement>
+    </expand>
     <command detect_errors="aggressive">
 ## The command is a Cheetah template which allows some Python based syntax.
 ## Lines starting hash hash are comments. Galaxy will turn newlines into spaces
+@TAXID_FILE_GEN@
 tblastx
 @QUERY@
 @BLAST_DB_SUBJECT@

--- a/tools/ncbi_blast_plus/taxSubIDs.py
+++ b/tools/ncbi_blast_plus/taxSubIDs.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+import sys
+procDict = {}
+
+def findChildren(idIn):
+  return procDict.get(idIn, [])
+
+if __name__ == "__main__":
+  if len(sys.argv) == 2:
+    outList = sys.argv[1].split(",")
+    for i in outList:
+      print(i.strip())
+    exit(0)
+  searchSpace = sys.argv[2].split(",")
+  diffSpace = []
+  for i in range(0, len(searchSpace)):
+    searchSpace[i] = int(searchSpace[i].strip())
+    diffSpace.append(searchSpace[i])
+  taxFile = open(sys.argv[1])
+  for line in taxFile.readlines():
+    segments = line.split("\t|\t")
+    thisID = int(segments[0].strip())
+    thisParent = int(segments[1].strip())
+    if thisParent in procDict.keys():
+      procDict[thisParent].append(thisID)
+    else:
+      procDict[thisParent] = [thisID]
+  while len(diffSpace) != 0:
+    processes = []
+    thisRun = []
+    for exID in diffSpace:
+        res = findChildren(exID)
+        for i in res:
+          for j in searchSpace:
+            if j == i:
+              break
+          else:
+            thisRun.append(i)
+            searchSpace.append(i)
+    diffSpace = thisRun
+  
+  for i in searchSpace:
+    print(i)
+


### PR DESCRIPTION
We've been running a version of this wrapper with TaxIDs for a bit, and we've found our users like to input higher order TaxIDs at the BLAST step (rather than chaining through to having another file as input). This is a version that integrates our approach to the problem with the wrapper styling of the main project. 

An live example of the BLASTn wrapper can also be found at  https://cpt.tamu.edu/galaxy/root?tool_id=ncbi_blastn_wrapper