### PR TITLE
Skip query hits above user-defined threshold

### DIFF
--- a/tools/ncbi_blast_plus/blastxml_to_tabular.py
+++ b/tools/ncbi_blast_plus/blastxml_to_tabular.py
@@ -137,7 +137,7 @@ parser.add_option(
     dest="hits",
     type=int,
     default=float("inf"),
-    help="number of query hits to display (default to displaying all hits)"
+    help="number of query hits to display (defaults to all query hits)"
 )
 (options, args) = parser.parse_args()
 

--- a/tools/ncbi_blast_plus/blastxml_to_tabular.py
+++ b/tools/ncbi_blast_plus/blastxml_to_tabular.py
@@ -132,6 +132,13 @@ parser.add_option(
     help="[std|ext|col1,col2,...] standard 12 columns, "
     "extended 25 columns, or list of column names",
 )
+parser.add_option(
+    "--hits",
+    dest="hits",
+    type=int,
+    default=float("inf"),
+    help="number of query hits to display (default to displaying all hits)"
+)
 (options, args) = parser.parse_args()
 
 colnames = (
@@ -242,6 +249,11 @@ def convert(blastxml_filename, output_handle):
                 # <Hit_def>chrIII gi|240255695|ref|NC_003074.8| Arabidopsis
                 # thaliana chromosome 3, complete sequence</Hit_def>
                 # <Hit_accession>2</Hit_accession>
+
+                # Skip query hits above user-defined threshold
+                if int(hit.findtext("Hit_num")) > options.hits:
+                  continue
+
                 sseqid = hit.findtext("Hit_id").split(None, 1)[0]
                 hit_def = sseqid + " " + hit.findtext("Hit_def")
                 if re_default_subject_id.match(sseqid) and sseqid == hit.findtext(


### PR DESCRIPTION
Hello, thanks for writing [blastxml_to_tabular.py](https://github.com/peterjc/galaxy_blast/blob/master/tools/ncbi_blast_plus/blastxml_to_tabular.py)!

It does almost everything I need. However, as I only care about the top hits, I added an option to filter the number of hits returned based on `Hit_num` from the XML input file (by default, nothing is filtered).

I opened this PR in case you find that these changes may be helpful to other users.

Best regards,
Nuno