### PR TITLE
Disable slashcommand and flake requirements

### DIFF
--- a/.flake8_requirements
+++ b/.flake8_requirements
@@ -1,0 +1,2 @@
+flake8
+flake8-import-order

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -147,7 +147,7 @@ jobs:
         path: ~/.cache/pip
         key: pip_cache_py_${{ matrix.python-version }}_gxy_${{ needs.setup.outputs.galaxy-head-sha }}
     - name: Install flake8
-      run: pip install flake8 flake8-import-order
+      run: pip install -r .flake8_requirements 
     - name: Flake8
       run: echo '${{ needs.setup.outputs.repository-list }}' | xargs -d '\n' flake8 --output-file pylint_report.txt --tee
     - uses: actions/upload-artifact@v3

--- a/.github/workflows/slash.yaml
+++ b/.github/workflows/slash.yaml
@@ -7,7 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Slash Command Dispatch
-        if: github.repository_owner == 'peterjc'
+        # workaround for checking availablity of secret https://github.com/actions/runner/issues/520
+        env:
+          PAT: ${{ secrets.PAT }}
+        if: github.repository_owner == 'peterjc' and env.PAT != ''
         uses: peter-evans/slash-command-dispatch@v3
         with:
           token: ${{ secrets.PAT }}


### PR DESCRIPTION
Currently the slash workflow (which reacts on all comments and looks for `/run-all-tool-tests`) always fails because the PAT is not defined. Guess it would be cool to run this only if PAT is defined (not sure if it will work the way I implemented it). 

Also introduces .flake8_requirement file as discussed. If useful and working then we can add it to IUC.

