### PR TITLE
Restore the tool test skip entries from TravisCI era

### DIFF
--- a/.tt_skip
+++ b/.tt_skip
@@ -1,3 +1,6 @@
+tools/ncbi_blast_plus/ncbi_psiblast_wrapper.xml
+tools/ncbi_blast_plus/ncbi_deltablast_wrapper.xml
+tools/reciprocal_best_hits/reciprocal_best_hits.xml
 tools/blast2go/
 datatypes/
 workflows/


### PR DESCRIPTION
e.g. We can't test ``ncbi_deltablast_wrapper.xml`` without downloading a large protein domain database.

This partly reverts the exclusion list changes made in #149 to move from TravisCI to GitHub Actions