### PR TITLE
get_species_taxids: fix sed

### DIFF
--- a/tools/ncbi_blast_plus/get_species_taxids.xml
+++ b/tools/ncbi_blast_plus/get_species_taxids.xml
@@ -7,17 +7,17 @@
     <command detect_errors="aggressive"><![CDATA[
 #if $type_cond.type_sel == 'names'
     #for name in $type_cond.names.split(',')
-        taxid=\$(get_species_taxids.sh -n '$name' | grep Taxid | sed 's/Taxid://') &&
-        if [ -z \$taxid ]; then
+        taxid=\$(get_species_taxids.sh -n '$name' | grep Taxid | sed 's/Taxid\s*:\s*//') &&
+        if [ -z "\$taxid" ]; then
             >&2 echo "could not find taxid for $name" && exit 1;
         else
             echo " $name -> \$taxid";
         fi &&
-        get_species_taxids.sh -t \$taxid >> species_ids.txt &&
+        get_species_taxids.sh -t "\$taxid" >> species_ids.txt &&
     #end for
 #else
     #for taxid in $type_cond.ids.split(',')
-       get_species_taxids.sh -t $taxid >> species_ids.txt &&
+       get_species_taxids.sh -t "$taxid" >> species_ids.txt &&
     #end for
 #end if
 sort -n -u  species_ids.txt > '$output'

--- a/tools/ncbi_blast_plus/ncbi_macros.xml
+++ b/tools/ncbi_blast_plus/ncbi_macros.xml
@@ -1,6 +1,6 @@
 <macros>
     <token name="@TOOL_VERSION@">2.14.1</token>
-    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@VERSION_SUFFIX@">1</token>
     <token name="@PROFILE@">16.10</token>
     <xml name="parallelism">
         <!-- If job splitting is enabled, break up the query file into parts -->


### PR DESCRIPTION
there seem to be now spaces around `:`

also add some quotes