### PR TITLE
Add bio.tools for Blast2GO

### DIFF
--- a/tools/blast2go/blast2go.xml
+++ b/tools/blast2go/blast2go.xml
@@ -1,5 +1,8 @@
 <tool id="blast2go" name="Blast2GO" version="0.0.11" profile="16.10">
     <description>Maps BLAST results to GO annotation terms</description>
+    <xrefs>
+        <xref type="bio.tools">Blast2GO</xref>
+    </xrefs>
     <requirements>
         <requirement type="package" version="2.5">b2g4pipe</requirement>
         <requirement type="package" version="3.9">python</requirement>


### PR DESCRIPTION
Hi,

This PR links the tools to its bio.tools entry: https://bio.tools/Blast2GO
It will be useful to get EDAM ontology annotations

Have a good day!
