### PR TITLE
Add bio.tools for Blast_rbh

### DIFF
--- a/tools/blast_rbh/blast_rbh.xml
+++ b/tools/blast_rbh/blast_rbh.xml
@@ -4,6 +4,9 @@
         <requirement type="package" version="1.77">biopython</requirement>
         <requirement type="package" version="2.9.0">blast</requirement>
     </requirements>
+    <xrefs>
+        <xref type="bio.tools">blast_rbh</xref>
+    </xrefs>
     <version_command>
 python $__tool_directory__/blast_rbh.py --version
     </version_command>


### PR DESCRIPTION
Hi,

This PR links the tools to its bio.tools entry: https://bio.tools/blast_rbh
It will be useful to get EDAM ontology annotations

Have a good day!
