### PR TITLE
Add biotools blastxml to top descr

### DIFF
--- a/tools/blastxml_to_top_descr/blastxml_to_top_descr.xml
+++ b/tools/blastxml_to_top_descr/blastxml_to_top_descr.xml
@@ -3,6 +3,9 @@
     <requirements>
         <requirement type="package" version="3.9">python</requirement>
     </requirements>
+    <xrefs>
+        <xref type="bio.tools">blastxml_to_top_descr</xref>
+    </xrefs>
     <version_command>
 python $__tool_directory__/blastxml_to_top_descr.py --version
     </version_command>

--- a/tools/blastxml_to_top_descr/blastxml_to_top_descr.xml
+++ b/tools/blastxml_to_top_descr/blastxml_to_top_descr.xml
@@ -1,11 +1,11 @@
 <tool id="blastxml_to_top_descr" name="BLAST top hit descriptions" version="0.1.2" profile="16.10">
     <description>Make a table from BLAST output</description>
-    <requirements>
-        <requirement type="package" version="3.9">python</requirement>
-    </requirements>
     <xrefs>
         <xref type="bio.tools">blastxml_to_top_descr</xref>
     </xrefs>
+    <requirements>
+        <requirement type="package" version="3.9">python</requirement>
+    </requirements>
     <version_command>
 python $__tool_directory__/blastxml_to_top_descr.py --version
     </version_command>


### PR DESCRIPTION
Hi,

This PR links the tools to its bio.tools entry: https://bio.tools/blastxml_to_top_descr
It will be useful to get EDAM ontology annotations

Have a good day!
