### PR TITLE
Add bio.tools for ncbi_blast_plus

### DIFF
--- a/tools/ncbi_blast_plus/ncbi_macros.xml
+++ b/tools/ncbi_blast_plus/ncbi_macros.xml
@@ -7,6 +7,10 @@
         <parallelism method="multi" split_inputs="query" split_mode="to_size" split_size="1000" merge_outputs="output1" />
     </xml>
 
+    <xrefs>
+        <xref type="bio.tools">ncbi_blast_plus</xref>
+    </xrefs>
+
     <xml name="preamble">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">blast</requirement>


### PR DESCRIPTION


Hi,

This PR links the tools to its bio.tools entry: https://bio.tools/ncbi_blast_plus
It will be useful to get EDAM ontology annotations

Have a good day!
